### PR TITLE
Settings → Add settings tab with R2 and custom providers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,15 @@ jobs:
           node-version-file: ".nvmrc"
           cache: "npm"
       - run: npm audit
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+      - run: npm ci
+      - run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: "npm"
-      - run: npm audit
+      - run: npm run audit
 
   test:
     name: Test

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ main.js
 
 # Dev vault (created by `make create-dev-vault`)
 /dev-vault/
+/data.json
+/.s3rver-data/
 
 # Node
 /node_modules/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,8 @@ programmer would do.
 - Guard clauses and early returns; flat beats nested; no `else` after a `return`
 - No ternary expressions; Go doesn't have one and neither do we, write the `if` (file local
   helpers like `stringOr(v, fallback)` cover the defaulting cases)
+- Braces on every `if`, even a one line body; Go's formatter won't let you drop them and neither
+  do we
 - Every exported symbol gets a one sentence `//` doc comment above it, Go style
   ("normalizeSettings returns..."); no JSDoc `/** */` blocks
 - Table driven tests with `node:test` and `node:assert/strict`; no test framework dependencies
@@ -86,6 +88,9 @@ programmer would do.
   when a concern outgrows single files
 - Framework code stays thin glue; logic lives in pure modules that never import `obsidian`
 - No clever generics, no decorators, no magic
+- A small, focused dependency beats hand rolling something fiddly to get right (request signing,
+  a mock server); it loses to hand rolling the moment it drags in a framework or an SDK we don't
+  need
 
 ## Priorities
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,36 @@ Risk is out of 5. Activity last checked 2026-07.
 
 - Line length is set to 100 characters for all project files
 
+## Code Style
+
+Write TypeScript as if it were Go: simple, explicit, boring. When unsure, ask what the dullest Go
+programmer would do.
+
+- The formatter is law; Biome decides and nobody debates the output
+- Pure functions first; classes only where the Obsidian API demands them (`Plugin`,
+  `PluginSettingTab`), and those classes are shells: methods delegate immediately to module level
+  functions, no logic lives on the class
+- Named exports only, except the plugin class Obsidian requires as a default export
+- String literal unions over enums; `erasableSyntaxOnly` in tsconfig enforces strippable syntax
+- `type` over `interface`: data shapes are structs, not contracts, and `type` can't be reopened
+  by declaration merging; `interface` only if implementing a framework contract demands it
+- Errors are values: domain logic returns results rather than throwing; exceptions stay at the
+  framework boundary
+- Explicit zero values: every type has a complete default (see `DEFAULT_SETTINGS`), never
+  undefined shaped holes
+- Guard clauses and early returns; flat beats nested; no `else` after a `return`
+- No ternary expressions; Go doesn't have one and neither do we, write the `if` (file local
+  helpers like `stringOr(v, fallback)` cover the defaulting cases)
+- Every exported symbol gets a one sentence `//` doc comment above it, Go style
+  ("normalizeSettings returns..."); no JSDoc `/** */` blocks
+- Table driven tests with `node:test` and `node:assert/strict`; no test framework dependencies
+- Small files with one concern; no barrel files, no `utils.ts` dumping ground
+- File names are kebab-case (`settings-tab.ts`); tests sit beside the code they test as
+  `name.test.ts`, Go's `_test.go` pattern; graduate to package folders (`settings/tab.ts`) only
+  when a concern outgrows single files
+- Framework code stays thin glue; logic lives in pure modules that never import `obsidian`
+- No clever generics, no decorators, no magic
+
 ## Priorities
 
 - When stuck, the blocker is usually priorities, not missing information → Decide and move

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,13 +12,19 @@ npm install
 npm run dev
 ```
 
-`npm run dev` watches `src/main.ts` and rebuilds `main.js` on every save.
+`npm run dev` runs two things side by side, via `concurrently`: an esbuild watcher that rebuilds
+`main.js` on every save to `src/`, and a local mock S3 server (`s3rver`) on `localhost:4568` for
+testing storage settings without touching a real bucket. Run `npm run dev:s3` on its own if you
+only need the mock server.
 
 ## CI
 
-Every push and PR runs three checks: `npm run lint` (Biome), `npm run build` (type-check + bundle),
-and `npm run check-versions` (`package.json` and `manifest.json` versions must match). Run all
-three locally before pushing, they're fast. `npm run format` applies Biome's auto-fixes.
+Every push and PR runs: `npm run lint` (Biome), `npm run build` (type-check + bundle), `npm test`
+(`node:test`), `npm run check-versions` (`package.json` and `manifest.json` versions must match),
+and `npm run audit` (production dependencies only; dev tooling like the mock S3 server never
+ships, so its advisories don't gate CI). Run these locally before pushing, they're fast. Plain
+`npm audit` also works but includes that dev-only noise; `npm run audit` is the one that matches
+CI. `npm run format` applies Biome's auto-fixes.
 
 ## Testing locally
 
@@ -30,10 +36,15 @@ With `npm run dev` running:
 
 1. Open `dev-vault/` as a vault in Obsidian (Open another vault → Open folder as vault).
 2. Settings → Community plugins → turn off Restricted mode, then enable Geode.
-3. Open the developer console (Cmd-Option-I on macOS) to watch the `geode: ...` log lines from
-   `onload`, `active-leaf-change`, `file-open`, and `layout-ready`.
-4. After changing `src/main.ts`, reload Obsidian to pick up the new `main.js` (Cmd-P → "Reload app
+3. Settings → Geode, set Provider to Custom and fill in the mock server: Endpoint
+   `http://localhost:4568`, Region `us-east-1`, Bucket `geode-dev`, Access key ID `S3RVER`, and
+   add a secret with value `S3RVER` (s3rver's fixed dev credentials). Click Test Connection.
+4. After changing source files, reload Obsidian to pick up the new `main.js` (Cmd-P → "Reload app
    without saving"). Installing the community Hot-Reload plugin removes the need for this step.
+
+The mock server's data directory (`.s3rver-data/`) and Obsidian's plugin data file (`data.json`,
+which lands at the repo root because the dev vault symlinks the whole repo in as the plugin
+folder) are both gitignored; neither should ever be committed.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 **[Obsidian](https://obsidian.md) plugin** for remote sync, MCP, and an API for your vault.
 
 [![GitHub Branch Check Runs](https://img.shields.io/github/check-runs/8thpark/geode/main?style=flat-square&label=ci)](https://github.com/8thpark/geode/actions/workflows/ci.yml?query=branch%3Amain)
-[![OSSF Scorecard Score](https://img.shields.io/ossf-scorecard/github.com/8thpark/geode?style=flat-square&label=OSSF)](https://scorecard.dev/viewer/?uri=github.com/8thpark/geode)
+[![OSSF Scorecard Score](https://img.shields.io/ossf-scorecard/github.com/8thpark/geode?style=flat-square&label=OSSF)](https://scorecard.dev/viewer/?uri=github.com/8thpark/geode&sort_by=check-score&sort_direction=desc)
 ![Plugin Version](https://img.shields.io/github/package-json/version/8thpark/geode?style=flat-square)
 ![GitHub Repo stars](https://img.shields.io/github/stars/8thpark/geode?style=social)
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "id": "geode",
   "name": "Geode",
   "version": "0.0.1",
-  "minAppVersion": "1.5.0",
+  "minAppVersion": "1.11.4",
   "description": "Remote sync, MCP, and an API for your Obsidian vault.",
   "author": "8thpark",
   "isDesktopOnly": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,16 @@
       "name": "geode",
       "version": "0.0.1",
       "license": "Elastic-2.0",
+      "dependencies": {
+        "aws4fetch": "1.x.x"
+      },
       "devDependencies": {
         "@biomejs/biome": "2.5.3",
         "@types/node": "24.x.x",
+        "concurrently": "10.x.x",
         "esbuild": "0.x.x",
         "obsidian": "1.x.x",
+        "s3rver": "3.x.x",
         "typescript": "7.x.x"
       }
     },
@@ -202,6 +207,28 @@
         "crelt": "^1.0.6",
         "style-mod": "^4.1.0",
         "w3c-keyname": "^2.2.4"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz",
+      "integrity": "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@so-ric/colorspace": "^1.1.6",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -646,6 +673,24 @@
         "node": ">=18"
       }
     },
+    "node_modules/@koa/router": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@koa/router/-/router-9.4.0.tgz",
+      "integrity": "sha512-dOOXgzqaDoHu5qqMEPLKEgLz5CeIA7q8+1W62mCvFVCOqeC71UoTGJ4u1xUSOpIl2J1x2pqrNULkFteUeZW3/A==",
+      "deprecated": "**IMPORTANT 10x+ PERFORMANCE UPGRADE**: Please upgrade to v12.0.1+ as we have fixed an issue with debuglog causing 10x slower router benchmark performance, see https://github.com/koajs/router/pull/173",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "http-errors": "^1.7.3",
+        "koa-compose": "^4.1.0",
+        "methods": "^1.1.2",
+        "path-to-regexp": "^6.1.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/@marijn/find-cluster-break": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.3.tgz",
@@ -653,6 +698,17 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/@so-ric/colorspace": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
+      "integrity": "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color": "^5.0.2",
+        "text-hex": "1.0.x"
+      }
     },
     "node_modules/@types/codemirror": {
       "version": "5.60.8",
@@ -690,6 +746,13 @@
       "dependencies": {
         "@types/estree": "*"
       }
+    },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript/typescript-aix-ppc64": {
       "version": "7.0.2",
@@ -1031,6 +1094,297 @@
         "node": ">=16.20.0"
       }
     },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/aws4fetch": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/aws4fetch/-/aws4fetch-1.0.20.tgz",
+      "integrity": "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==",
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.3.1.tgz",
+      "integrity": "sha512-y7tTxhGKXcyBxRKAni+awqx8uqaJKrSFSNFSeRG5CsWNdmy2BIK+6VGWEW7TZnIO/533mtMEA4rOevQV815YJw==",
+      "dev": true,
+      "dependencies": {
+        "dicer": "0.3.0"
+      },
+      "engines": {
+        "node": ">=4.5.0"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cache-content-type": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-content-type/-/cache-content-type-1.0.1.tgz",
+      "integrity": "sha512-IKufZ1o4Ut42YUrZSo8+qnMTrFuKkvyoLXUywKz9GJ5BrhOFGhLdkx9sG4KAnVvbY6kEcSFjLQul+DVmBm2bgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^2.1.18",
+        "ylru": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/color": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
+      "integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^3.1.3",
+        "color-string": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
+      "integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/concurrently": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-10.0.3.tgz",
+      "integrity": "sha512-hc3LH4UaKWd/bbyDK/IGVa4RB6PtQ3CUYwtrkzqHn+wIG3Hr5fhpRlk0L/gCa8ZE1L/Ufj50Zho69cI5w8SQBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "rxjs": "7.8.2",
+        "shell-quote": "1.8.4",
+        "supports-color": "10.2.2",
+        "tree-kill": "1.2.2",
+        "yargs": "18.0.0"
+      },
+      "bin": {
+        "conc": "dist/bin/index.js",
+        "concurrently": "dist/bin/index.js"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookies": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.9.1.tgz",
+      "integrity": "sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "keygrip": "~1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cookies/node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/crelt": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.7.tgz",
@@ -1038,6 +1392,150 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dicer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.0.tgz",
+      "integrity": "sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==",
+      "dev": true,
+      "dependencies": {
+        "streamsearch": "0.1.2"
+      },
+      "engines": {
+        "node": ">=4.5.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.28.1",
@@ -1081,6 +1579,617 @@
         "@esbuild/win32-x64": "0.28.1"
       }
     },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "3.21.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.21.1.tgz",
+      "integrity": "sha512-FTFVjYoBOZTJekiUsawGsSYV9QL0A+zDYCRj7y34IO6Jg+2IMYEtQa+bbictpdpV8dHxXywqU7C0gRDEOFtBFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^1.0.4"
+      },
+      "bin": {
+        "xml2js": "cli.js"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/naturalintelligence"
+      }
+    },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/http-assert": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.5.0.tgz",
+      "integrity": "sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-equal": "~1.0.1",
+        "http-errors": "~1.8.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-errors/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/humanize-number": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/humanize-number/-/humanize-number-0.0.2.tgz",
+      "integrity": "sha512-un3ZAcNQGI7RzaWGZzQDH47HETM4Wrj6z6E4TId8Yeq9w5ZKUVB1nrT2jwFheTUjEmqcgTjXDc959jum+ai1kQ==",
+      "dev": true
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/keygrip": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
+      "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tsscmp": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa": {
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-2.16.4.tgz",
+      "integrity": "sha512-3An0GCLDSR34tsCO4H8Tef8Pp2ngtaZDAZnsWJYelqXUK5wyiHvGItgK/xcSkmHLSTn1Jcho1mRQs2ehRzvKKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^1.3.5",
+        "cache-content-type": "^1.0.0",
+        "content-disposition": "~0.5.2",
+        "content-type": "^1.0.4",
+        "cookies": "~0.9.0",
+        "debug": "^4.3.2",
+        "delegates": "^1.0.0",
+        "depd": "^2.0.0",
+        "destroy": "^1.0.4",
+        "encodeurl": "^1.0.2",
+        "escape-html": "^1.0.3",
+        "fresh": "~0.5.2",
+        "http-assert": "^1.3.0",
+        "http-errors": "^1.6.3",
+        "is-generator-function": "^1.0.7",
+        "koa-compose": "^4.1.0",
+        "koa-convert": "^2.0.0",
+        "on-finished": "^2.3.0",
+        "only": "~0.0.2",
+        "parseurl": "^1.3.2",
+        "statuses": "^1.5.0",
+        "type-is": "^1.6.16",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": "^4.8.4 || ^6.10.1 || ^7.10.1 || >= 8.1.4"
+      }
+    },
+    "node_modules/koa-compose": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
+      "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/koa-convert": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/koa-convert/-/koa-convert-2.0.0.tgz",
+      "integrity": "sha512-asOvN6bFlSnxewce2e/DK3p4tltyfC4VM7ZwuTuepI7dEQVcvpyFuBcEARu1+Hxg8DIwytce2n7jrZtRlPrARA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "co": "^4.6.0",
+        "koa-compose": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/koa-logger": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/koa-logger/-/koa-logger-3.2.1.tgz",
+      "integrity": "sha512-MjlznhLLKy9+kG8nAXKJLM0/ClsQp/Or2vI3a5rbSQmgl8IJBQO0KI5FA70BvW+hqjtxjp49SpH2E7okS6NmHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.0",
+        "chalk": "^2.4.2",
+        "humanize-number": "0.0.2",
+        "passthrough-counter": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 7.6.0"
+      }
+    },
+    "node_modules/koa-logger/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/koa-logger/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/koa-logger/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/koa-logger/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/koa-logger/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/koa/node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/koa/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/logform": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.6.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/moment": {
       "version": "2.29.4",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
@@ -1089,6 +2198,23 @@
       "license": "MIT",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/obsidian": {
@@ -1106,6 +2232,265 @@
         "@codemirror/view": "6.38.6"
       }
     },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fn.name": "1.x.x"
+      }
+    },
+    "node_modules/only": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/only/-/only-0.0.2.tgz",
+      "integrity": "sha512-Fvw+Jemq5fjjyWz6CpKx6w9s7xxqo3+JCyM0WXWeCSOboZ8ABkyvP8ID4CZuChA/wxSx+XSJmdOm8rGVyJ1hdQ==",
+      "dev": true
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/passthrough-counter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passthrough-counter/-/passthrough-counter-1.0.0.tgz",
+      "integrity": "sha512-Wy8PXTLqPAN0oEgBrlnsXPMww3SYJ44tQ8aVrGAI4h4JZYCS0oYqsPqtPR8OhJpv6qFbpbB7XAn0liKV7EXubA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/s3rver": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/s3rver/-/s3rver-3.7.1.tgz",
+      "integrity": "sha512-H9KIX6n8NqcfoE4ziFNbQASBQfjcNJgb+3wbT9L5iotEqfOncFO1c38cfJSFSo7xXTu1zM9HA6t2u9xKNlYRaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@koa/router": "^9.0.0",
+        "busboy": "^0.3.1",
+        "commander": "^5.0.0",
+        "fast-xml-parser": "^3.12.19",
+        "fs-extra": "^8.0.0",
+        "he": "^1.2.0",
+        "koa": "^2.7.0",
+        "koa-logger": "^3.2.0",
+        "lodash": "^4.17.5",
+        "statuses": "^2.0.0",
+        "winston": "^3.0.0"
+      },
+      "bin": {
+        "s3rver": "bin/s3rver.js"
+      },
+      "engines": {
+        "node": ">=8.3.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+      "integrity": "sha512-jos8u++JKm0ARcSUTAZXOVC0mSox7Bhn6sBgty73P1f3JGf7yG2clTbBNHUdde/kdvP2FESam+vM6l8jBrNxHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
+      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/style-mod": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
@@ -1113,6 +2498,87 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/triple-beam": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.x"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/typescript": {
       "version": "7.0.2",
@@ -1156,6 +2622,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
@@ -1163,6 +2656,110 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/winston": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
+      "integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.8",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.7.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.9.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+      "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "logform": "^2.7.0",
+        "readable-stream": "^3.6.2",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/ylru": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ylru/-/ylru-1.4.0.tgz",
+      "integrity": "sha512-2OQsPNEmBCvXuFlIni/a+Rn+R2pHW9INm0BxXJ4hVDA8TirqMj+J/Rp9ItLatT/5pZqWwefVrTQcHpixsxnVlA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Elastic-2.0",
       "devDependencies": {
         "@biomejs/biome": "2.5.3",
+        "@types/node": "24.x.x",
         "esbuild": "0.x.x",
         "obsidian": "1.x.x",
         "typescript": "7.x.x"
@@ -670,6 +671,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
     "node_modules/@types/tern": {
       "version": "0.23.9",
       "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.9.tgz",
@@ -1137,6 +1148,13 @@
         "@typescript/typescript-win32-arm64": "7.0.2",
         "@typescript/typescript-win32-x64": "7.0.2"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",

--- a/package.json
+++ b/package.json
@@ -4,19 +4,26 @@
   "description": "Remote sync, MCP, and an API for your Obsidian vault.",
   "private": true,
   "scripts": {
-    "dev": "node esbuild.config.mjs",
+    "dev": "concurrently -n build,s3 -c blue,yellow \"node esbuild.config.mjs\" \"npm run dev:s3\"",
+    "dev:s3": "s3rver --directory .s3rver-data --address localhost --port 4568 --no-vhost-buckets --configure-bucket geode-dev scripts/s3rver-cors.xml",
     "build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
+    "audit": "npm audit --omit=dev",
     "lint": "biome check .",
     "format": "biome check --write .",
     "check-versions": "node scripts/check-version-sync.mjs",
     "test": "node --test \"src/**/*.test.ts\""
   },
   "license": "Elastic-2.0",
+  "dependencies": {
+    "aws4fetch": "1.x.x"
+  },
   "devDependencies": {
     "@biomejs/biome": "2.5.3",
     "@types/node": "24.x.x",
+    "concurrently": "10.x.x",
     "esbuild": "0.x.x",
     "obsidian": "1.x.x",
+    "s3rver": "3.x.x",
     "typescript": "7.x.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,11 +8,13 @@
     "build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
     "lint": "biome check .",
     "format": "biome check --write .",
-    "check-versions": "node scripts/check-version-sync.mjs"
+    "check-versions": "node scripts/check-version-sync.mjs",
+    "test": "node --test \"src/**/*.test.ts\""
   },
   "license": "Elastic-2.0",
   "devDependencies": {
     "@biomejs/biome": "2.5.3",
+    "@types/node": "24.x.x",
     "esbuild": "0.x.x",
     "obsidian": "1.x.x",
     "typescript": "7.x.x"

--- a/scripts/s3rver-cors.xml
+++ b/scripts/s3rver-cors.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <CORSRule>
+    <AllowedOrigin>*</AllowedOrigin>
+    <AllowedMethod>GET</AllowedMethod>
+    <AllowedMethod>HEAD</AllowedMethod>
+    <AllowedMethod>PUT</AllowedMethod>
+    <AllowedMethod>POST</AllowedMethod>
+    <AllowedMethod>DELETE</AllowedMethod>
+    <AllowedHeader>*</AllowedHeader>
+  </CORSRule>
+</CORSConfiguration>

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ export default class GeodePlugin extends Plugin {
   async onload() {
     await this.loadSettings();
     this.addSettingTab(new GeodeSettingTab(this.app, this));
+    console.log(`geode: loaded (provider=${this.settings.provider})`);
   }
 
   async loadSettings() {
@@ -17,5 +18,6 @@ export default class GeodePlugin extends Plugin {
 
   async saveSettings() {
     await this.saveData(this.settings);
+    console.log("geode: settings saved");
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,27 +1,20 @@
-import { Plugin, type TFile } from "obsidian";
+import { Plugin } from "obsidian";
+import { DEFAULT_SETTINGS, type GeodeSettings, normalizeSettings } from "./settings";
+import { GeodeSettingTab } from "./settings-tab";
 
 export default class GeodePlugin extends Plugin {
+  settings: GeodeSettings = DEFAULT_SETTINGS;
+
   async onload() {
-    console.log("geode: onload");
-
-    this.registerEvent(
-      this.app.workspace.on("active-leaf-change", () => {
-        console.log("geode: active-leaf-change");
-      }),
-    );
-
-    this.registerEvent(
-      this.app.workspace.on("file-open", (file: TFile | null) => {
-        console.log("geode: file-open", file?.path ?? null);
-      }),
-    );
-
-    this.app.workspace.onLayoutReady(() => {
-      console.log("geode: layout-ready");
-    });
+    await this.loadSettings();
+    this.addSettingTab(new GeodeSettingTab(this.app, this));
   }
 
-  onunload() {
-    console.log("geode: onunload");
+  async loadSettings() {
+    this.settings = normalizeSettings(await this.loadData());
+  }
+
+  async saveSettings() {
+    await this.saveData(this.settings);
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { Plugin } from "obsidian";
 import { DEFAULT_SETTINGS, type GeodeSettings, normalizeSettings } from "./settings";
 import { GeodeSettingTab } from "./settings-tab";
 
+// GeodePlugin is the Obsidian plugin entry point that owns settings load and save.
 export default class GeodePlugin extends Plugin {
   settings: GeodeSettings = DEFAULT_SETTINGS;
 

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -1,6 +1,112 @@
 import { type App, PluginSettingTab, SecretComponent, Setting } from "obsidian";
 import type GeodePlugin from "./main";
 
+// renderSettingsTab draws every settings row into containerEl and persists edits via plugin.
+export function renderSettingsTab(
+  plugin: GeodePlugin,
+  containerEl: HTMLElement,
+  rerender: () => void,
+): void {
+  const { settings } = plugin;
+
+  new Setting(containerEl)
+    .setName("Provider")
+    .setDesc("Where your vault is synced to.")
+    .addDropdown((dropdown) =>
+      dropdown
+        .addOptions({ r2: "Cloudflare R2", custom: "Custom" })
+        .setValue(settings.provider)
+        .onChange(async (value) => {
+          settings.provider = "r2";
+          if (value === "custom") {
+            settings.provider = "custom";
+          }
+          await plugin.saveSettings();
+          rerender();
+        }),
+    );
+
+  if (settings.provider === "r2") {
+    new Setting(containerEl)
+      .setName("Account ID")
+      .setDesc("Your Cloudflare account ID.")
+      .addText((text) =>
+        text
+          .setPlaceholder("abc123...")
+          .setValue(settings.accountId)
+          .onChange(async (value) => {
+            settings.accountId = value;
+            await plugin.saveSettings();
+          }),
+      );
+  }
+
+  if (settings.provider === "custom") {
+    new Setting(containerEl)
+      .setName("Endpoint")
+      .setDesc("The S3 compatible endpoint URL for your storage.")
+      .addText((text) =>
+        text
+          .setPlaceholder("https://s3.example.com")
+          .setValue(settings.endpoint)
+          .onChange(async (value) => {
+            settings.endpoint = value;
+            await plugin.saveSettings();
+          }),
+      );
+
+    new Setting(containerEl)
+      .setName("Region")
+      .setDesc("The region your bucket lives in.")
+      .addText((text) =>
+        text
+          .setPlaceholder("us-east-1")
+          .setValue(settings.region)
+          .onChange(async (value) => {
+            settings.region = value;
+            await plugin.saveSettings();
+          }),
+      );
+  }
+
+  new Setting(containerEl)
+    .setName("Bucket")
+    .setDesc("The name of the bucket to sync your vault to.")
+    .addText((text) =>
+      text
+        .setPlaceholder("my-vault")
+        .setValue(settings.bucket)
+        .onChange(async (value) => {
+          settings.bucket = value;
+          await plugin.saveSettings();
+        }),
+    );
+
+  new Setting(containerEl)
+    .setName("Access key ID")
+    .setDesc("The access key ID for your storage credentials.")
+    .addText((text) =>
+      text
+        .setPlaceholder("AKIA...")
+        .setValue(settings.accessKeyId)
+        .onChange(async (value) => {
+          settings.accessKeyId = value;
+          await plugin.saveSettings();
+        }),
+    );
+
+  new Setting(containerEl)
+    .setName("Secret access key")
+    .setDesc("Held in Obsidian's secret storage; only its name is saved in plugin data.")
+    .addComponent((el) =>
+      new SecretComponent(plugin.app, el).setValue(settings.secretId).onChange(async (value) => {
+        settings.secretId = value;
+        await plugin.saveSettings();
+      }),
+    );
+}
+
+// GeodeSettingTab renders and persists the plugin's settings UI.
 export class GeodeSettingTab extends PluginSettingTab {
   plugin: GeodePlugin;
 
@@ -10,102 +116,7 @@ export class GeodeSettingTab extends PluginSettingTab {
   }
 
   display(): void {
-    const { containerEl } = this;
-    containerEl.empty();
-
-    const { settings } = this.plugin;
-
-    new Setting(containerEl)
-      .setName("Provider")
-      .setDesc("Where your vault is synced to.")
-      .addDropdown((dropdown) =>
-        dropdown
-          .addOptions({ r2: "Cloudflare R2", custom: "Custom" })
-          .setValue(settings.provider)
-          .onChange(async (value) => {
-            settings.provider = value === "custom" ? "custom" : "r2";
-            await this.plugin.saveSettings();
-            this.display();
-          }),
-      );
-
-    if (settings.provider === "r2") {
-      new Setting(containerEl)
-        .setName("Account ID")
-        .setDesc("Your Cloudflare account ID.")
-        .addText((text) =>
-          text
-            .setPlaceholder("abc123...")
-            .setValue(settings.accountId)
-            .onChange(async (value) => {
-              settings.accountId = value;
-              await this.plugin.saveSettings();
-            }),
-        );
-    }
-
-    if (settings.provider === "custom") {
-      new Setting(containerEl)
-        .setName("Endpoint")
-        .setDesc("The S3 compatible endpoint URL for your storage.")
-        .addText((text) =>
-          text
-            .setPlaceholder("https://s3.example.com")
-            .setValue(settings.endpoint)
-            .onChange(async (value) => {
-              settings.endpoint = value;
-              await this.plugin.saveSettings();
-            }),
-        );
-
-      new Setting(containerEl)
-        .setName("Region")
-        .setDesc("The region your bucket lives in.")
-        .addText((text) =>
-          text
-            .setPlaceholder("us-east-1")
-            .setValue(settings.region)
-            .onChange(async (value) => {
-              settings.region = value;
-              await this.plugin.saveSettings();
-            }),
-        );
-    }
-
-    new Setting(containerEl)
-      .setName("Bucket")
-      .setDesc("The name of the bucket to sync your vault to.")
-      .addText((text) =>
-        text
-          .setPlaceholder("my-vault")
-          .setValue(settings.bucket)
-          .onChange(async (value) => {
-            settings.bucket = value;
-            await this.plugin.saveSettings();
-          }),
-      );
-
-    new Setting(containerEl)
-      .setName("Access key ID")
-      .setDesc("The access key ID for your storage credentials.")
-      .addText((text) =>
-        text
-          .setPlaceholder("AKIA...")
-          .setValue(settings.accessKeyId)
-          .onChange(async (value) => {
-            settings.accessKeyId = value;
-            await this.plugin.saveSettings();
-          }),
-      );
-
-    new Setting(containerEl)
-      .setName("Secret access key")
-      .setDesc("Held in Obsidian's secret storage; only its name is saved in plugin data.")
-      .addComponent((el) =>
-        new SecretComponent(this.app, el).setValue(settings.secretId).onChange(async (value) => {
-          settings.secretId = value;
-          await this.plugin.saveSettings();
-        }),
-      );
+    this.containerEl.empty();
+    renderSettingsTab(this.plugin, this.containerEl, () => this.display());
   }
 }

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -1,122 +1,459 @@
-import { type App, PluginSettingTab, SecretComponent, Setting } from "obsidian";
+import {
+  type App,
+  apiVersion,
+  ButtonComponent,
+  Platform,
+  PluginSettingTab,
+  SecretComponent,
+  Setting,
+} from "obsidian";
 import type GeodePlugin from "./main";
+import { type GeodeSettings, hasConnectionConfig, providerOr, settingsEqual } from "./settings";
+import { testConnection } from "./storage";
 
-// renderSettingsTab draws every settings row into containerEl and persists edits via plugin.
-export function renderSettingsTab(
-  plugin: GeodePlugin,
-  containerEl: HTMLElement,
-  rerender: () => void,
-): void {
-  const { settings } = plugin;
+// ConnectionStatus is the last known state of a Test Connection check. It lives only in memory;
+// it is never persisted and resets to "unknown" whenever the draft changes.
+type ConnectionStatus = "unknown" | "checking" | "ok" | "error";
+
+// renderHeader draws the plugin title, subtitle, and external link buttons. The title is a plain
+// div rather than an h1: Obsidian's settings pane suppresses nested h1 elements.
+function renderHeader(containerEl: HTMLElement): void {
+  const header = containerEl.createDiv({ cls: "geode-settings-header" });
+
+  const titles = header.createDiv();
+  titles.createDiv({ text: "Geode", cls: "geode-title" });
+  titles.createEl("p", {
+    text: "Remote sync, MCP, and an API for your vault.",
+    cls: "setting-item-description",
+  });
+
+  const links = header.createDiv({ cls: "geode-settings-links" });
+  new ButtonComponent(links).setButtonText("GitHub").onClick(() => {
+    window.open("https://github.com/8thpark/geode", "_blank");
+  });
+  new ButtonComponent(links).setButtonText("Support").onClick(() => {
+    const target = containerEl.querySelector<HTMLElement>(".geode-support-anchor");
+    if (target !== null) {
+      target.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+  });
+  new ButtonComponent(links)
+    .setButtonText("Docs")
+    .setCta()
+    .onClick(() => {
+      window.open("https://docs.geodemd.com", "_blank");
+    });
+}
+
+// onFieldChanged clears any stale connection status and updates the actions row without
+// redrawing the whole tab, so text inputs never lose focus mid keystroke. Whether the draft
+// counts as dirty is derived by comparing it to saved settings, not tracked here.
+function onFieldChanged(tab: GeodeSettingTab): void {
+  tab.connectionStatus = "unknown";
+  tab.connectionMessage = "";
+  tab.refreshActionsUI();
+}
+
+// renderProviderFields draws the fields specific to the selected provider.
+function renderProviderFields(tab: GeodeSettingTab, containerEl: HTMLElement): void {
+  if (tab.draft.provider === "r2") {
+    new Setting(containerEl)
+      .setName("Account ID")
+      .setDesc("Your Cloudflare account ID, found on the R2 overview page.")
+      .addText((text) =>
+        text
+          .setPlaceholder("abc123...")
+          .setValue(tab.draft.accountId)
+          .onChange((value) => {
+            tab.draft.accountId = value;
+            onFieldChanged(tab);
+          }),
+      );
+    return;
+  }
 
   new Setting(containerEl)
+    .setName("Endpoint")
+    .setDesc("The S3 compatible endpoint URL for your storage.")
+    .addText((text) =>
+      text
+        .setPlaceholder("https://s3.example.com")
+        .setValue(tab.draft.endpoint)
+        .onChange((value) => {
+          tab.draft.endpoint = value;
+          onFieldChanged(tab);
+        }),
+    );
+
+  new Setting(containerEl)
+    .setName("Region")
+    .setDesc("The region your bucket lives in.")
+    .addText((text) =>
+      text
+        .setPlaceholder("us-east-1")
+        .setValue(tab.draft.region)
+        .onChange((value) => {
+          tab.draft.region = value;
+          onFieldChanged(tab);
+        }),
+    );
+}
+
+// renderSecretRow draws the secret access key control. SecretComponent's setValue only
+// pre-highlights an existing entry in its picker; it cannot force a newly created secret onto a
+// fixed ID, since Obsidian's own "add secret" dialog always asks the user to name it. So we have
+// to remember whichever ID the user actually picks, the same way we track every other field.
+function renderSecretRow(tab: GeodeSettingTab, containerEl: HTMLElement): void {
+  new Setting(containerEl)
+    .setName("Secret access key")
+    .setDesc("Stored in Obsidian's built in secret manager, never in plugin data or synced files.")
+    .addComponent((el) => {
+      const component = new SecretComponent(tab.app, el)
+        .setValue(tab.draft.secretId)
+        .onChange((value) => {
+          tab.draft.secretId = value;
+          onFieldChanged(tab);
+        });
+
+      // SecretComponent has no label API (obsidian.d.ts), so this renames its button after the
+      // fact; it degrades gracefully to the default "Link..." label if Obsidian's markup changes.
+      const button = el.querySelector("button");
+      if (button !== null) {
+        button.textContent = "Add secret";
+      }
+      return component;
+    });
+}
+
+// connectionMessageFor returns the connection half of the status line for the given state.
+function connectionMessageFor(tab: GeodeSettingTab): string {
+  if (tab.connectionStatus === "checking") {
+    return "Checking connection...";
+  }
+  if (tab.connectionStatus === "ok") {
+    return "Connected";
+  }
+  if (tab.connectionStatus === "error") {
+    return tab.connectionMessage;
+  }
+  return "Not tested yet";
+}
+
+// renderActions draws the status dot, status line, Test Connection button, and Save button, and
+// stashes references on tab so later field edits can update them in place. The connection
+// message and the dirty reminder are separate spans on one line so each keeps its own colour.
+function renderActions(tab: GeodeSettingTab, containerEl: HTMLElement): void {
+  const setting = new Setting(containerEl).setName("Connection");
+
+  tab.statusDotEl = setting.nameEl.createSpan({ cls: "geode-status-dot" });
+  setting.nameEl.prepend(tab.statusDotEl);
+
+  const statusLine = setting.descEl.createSpan({ cls: "geode-status-line" });
+  tab.connectionMessageEl = statusLine.createSpan({ cls: "geode-connection-message" });
+  tab.statusSeparatorEl = statusLine.createSpan({
+    cls: "geode-status-separator",
+    text: " · ",
+  });
+  tab.dirtyTextEl = statusLine.createSpan({
+    cls: "geode-dirty-text",
+    text: "Unsaved changes",
+  });
+
+  setting.addButton((button) =>
+    button.setButtonText("Test").onClick(async () => {
+      await tab.checkConnection();
+    }),
+  );
+
+  setting.addButton((button) => {
+    tab.saveButtonEl = button;
+    // Obsidian's own disabled-button styling forces cursor: not-allowed with its own
+    // !important rule; an inline style is the only thing guaranteed to win over that.
+    button.buttonEl.style.setProperty("cursor", "pointer", "important");
+    button
+      .setButtonText("Save")
+      .setCta()
+      .onClick(async () => {
+        await tab.save();
+      });
+  });
+
+  tab.refreshActionsUI();
+}
+
+// renderStorageSection draws the card of storage related settings.
+function renderStorageSection(tab: GeodeSettingTab, containerEl: HTMLElement): void {
+  const card = containerEl.createDiv({ cls: "geode-card" });
+
+  new Setting(card)
     .setName("Provider")
     .setDesc("Where your vault is synced to.")
     .addDropdown((dropdown) =>
       dropdown
         .addOptions({ r2: "Cloudflare R2", custom: "Custom" })
-        .setValue(settings.provider)
-        .onChange(async (value) => {
-          settings.provider = "r2";
-          if (value === "custom") {
-            settings.provider = "custom";
-          }
-          await plugin.saveSettings();
-          rerender();
+        .setValue(tab.draft.provider)
+        .onChange((value) => {
+          tab.draft.provider = providerOr(value);
+          tab.connectionStatus = "unknown";
+          tab.connectionMessage = "";
+          tab.display(false);
         }),
     );
 
-  if (settings.provider === "r2") {
-    new Setting(containerEl)
-      .setName("Account ID")
-      .setDesc("Your Cloudflare account ID.")
-      .addText((text) =>
-        text
-          .setPlaceholder("abc123...")
-          .setValue(settings.accountId)
-          .onChange(async (value) => {
-            settings.accountId = value;
-            await plugin.saveSettings();
-          }),
-      );
-  }
+  renderProviderFields(tab, card);
 
-  if (settings.provider === "custom") {
-    new Setting(containerEl)
-      .setName("Endpoint")
-      .setDesc("The S3 compatible endpoint URL for your storage.")
-      .addText((text) =>
-        text
-          .setPlaceholder("https://s3.example.com")
-          .setValue(settings.endpoint)
-          .onChange(async (value) => {
-            settings.endpoint = value;
-            await plugin.saveSettings();
-          }),
-      );
-
-    new Setting(containerEl)
-      .setName("Region")
-      .setDesc("The region your bucket lives in.")
-      .addText((text) =>
-        text
-          .setPlaceholder("us-east-1")
-          .setValue(settings.region)
-          .onChange(async (value) => {
-            settings.region = value;
-            await plugin.saveSettings();
-          }),
-      );
-  }
-
-  new Setting(containerEl)
+  new Setting(card)
     .setName("Bucket")
     .setDesc("The name of the bucket to sync your vault to.")
     .addText((text) =>
       text
-        .setPlaceholder("my-vault")
-        .setValue(settings.bucket)
-        .onChange(async (value) => {
-          settings.bucket = value;
-          await plugin.saveSettings();
+        .setPlaceholder("geode-bucket")
+        .setValue(tab.draft.bucket)
+        .onChange((value) => {
+          tab.draft.bucket = value;
+          onFieldChanged(tab);
         }),
     );
 
-  new Setting(containerEl)
+  new Setting(card)
     .setName("Access key ID")
     .setDesc("The access key ID for your storage credentials.")
     .addText((text) =>
       text
         .setPlaceholder("AKIA...")
-        .setValue(settings.accessKeyId)
-        .onChange(async (value) => {
-          settings.accessKeyId = value;
-          await plugin.saveSettings();
+        .setValue(tab.draft.accessKeyId)
+        .onChange((value) => {
+          tab.draft.accessKeyId = value;
+          onFieldChanged(tab);
         }),
     );
 
-  new Setting(containerEl)
-    .setName("Secret access key")
-    .setDesc("Held in Obsidian's secret storage; only its name is saved in plugin data.")
-    .addComponent((el) =>
-      new SecretComponent(plugin.app, el).setValue(settings.secretId).onChange(async (value) => {
-        settings.secretId = value;
-        await plugin.saveSettings();
-      }),
-    );
+  renderSecretRow(tab, card);
+  renderActions(tab, card);
 }
 
-// GeodeSettingTab renders and persists the plugin's settings UI.
+// platformLabel returns a short human readable name for the OS Obsidian is running on.
+function platformLabel(): string {
+  if (Platform.isMacOS) {
+    return "macOS";
+  }
+  if (Platform.isWin) {
+    return "Windows";
+  }
+  if (Platform.isLinux) {
+    return "Linux";
+  }
+  if (Platform.isIosApp) {
+    return "iOS";
+  }
+  if (Platform.isAndroidApp) {
+    return "Android";
+  }
+  return "Unknown";
+}
+
+// connectionSummary returns a one line description of the last connection test, for debug info.
+// Blank when nothing has been tested yet, there's nothing worth reporting.
+function connectionSummary(tab: GeodeSettingTab): string {
+  if (tab.connectionStatus === "error") {
+    return `error - ${tab.connectionMessage}`;
+  }
+  if (tab.connectionStatus === "unknown") {
+    return "";
+  }
+  return tab.connectionStatus;
+}
+
+// DEBUG_LABEL_WIDTH is the column width debug info labels are padded to, so values line up.
+const DEBUG_LABEL_WIDTH = 12;
+
+// debugLine formats one "label: value" row of debug info, padded so values align in a column.
+function debugLine(label: string, value: string): string {
+  return `${label.padEnd(DEBUG_LABEL_WIDTH)}${value}`;
+}
+
+// debugInfoText builds the plain text block a user pastes into a support email or issue.
+function debugInfoText(tab: GeodeSettingTab): string {
+  return [
+    debugLine("Geode:", `v${tab.plugin.manifest.version}`),
+    debugLine("Obsidian:", `v${apiVersion}`),
+    debugLine("Platform:", platformLabel()),
+    debugLine("Provider:", tab.plugin.settings.provider),
+    debugLine("Connection:", connectionSummary(tab)),
+  ].join("\n");
+}
+
+// flashButtonText sets a button's text to feedback, then reverts it to original after a delay.
+function flashButtonText(button: ButtonComponent, original: string, feedback: string): void {
+  button.setButtonText(feedback);
+  window.setTimeout(() => button.setButtonText(original), 1500);
+}
+
+// renderSupportSection draws the Support heading and its card of docs, email, and debug info.
+function renderSupportSection(tab: GeodeSettingTab, containerEl: HTMLElement): void {
+  const heading = new Setting(containerEl).setName("Support").setHeading();
+  heading.settingEl.addClass("geode-support-anchor");
+  const card = containerEl.createDiv({ cls: "geode-card" });
+
+  new Setting(card)
+    .setName("Documentation")
+    .setDesc("Guides for connecting storage, syncing, and troubleshooting.")
+    .addButton((button) =>
+      button.setButtonText("Open").onClick(() => {
+        window.open("https://docs.geodemd.com", "_blank");
+      }),
+    );
+
+  new Setting(card)
+    .setName("Email support")
+    .setDesc("help@geodemd.com")
+    .addButton((button) =>
+      button.setButtonText("Copy").onClick(async () => {
+        try {
+          await navigator.clipboard.writeText("help@geodemd.com");
+          flashButtonText(button, "Copy", "Copied");
+        } catch (err) {
+          console.error("geode: could not copy support email:", err);
+          flashButtonText(button, "Copy", "Failed");
+        }
+      }),
+    );
+
+  const debugSetting = new Setting(card)
+    .setName("Debugging info")
+    .setDesc("Include this when you contact support or open a GitHub issue.");
+
+  tab.debugInfoEl = card.createEl("pre", { cls: "geode-debug-box", text: debugInfoText(tab) });
+
+  debugSetting.addButton((button) => {
+    button.setButtonText("Copy").onClick(async () => {
+      try {
+        await navigator.clipboard.writeText(debugInfoText(tab));
+        flashButtonText(button, "Copy", "Copied");
+      } catch (err) {
+        console.error("geode: could not copy debugging info:", err);
+        flashButtonText(button, "Copy", "Failed");
+      }
+    });
+  });
+}
+
+// renderSettingsTab draws every section into containerEl from the tab's current draft state.
+export function renderSettingsTab(tab: GeodeSettingTab, containerEl: HTMLElement): void {
+  renderHeader(containerEl);
+  renderStorageSection(tab, containerEl);
+  renderSupportSection(tab, containerEl);
+}
+
+// GeodeSettingTab renders the settings UI from an in-memory draft and only writes to plugin
+// settings when the user clicks Save.
 export class GeodeSettingTab extends PluginSettingTab {
   plugin: GeodePlugin;
+  draft: GeodeSettings;
+  connectionStatus: ConnectionStatus = "unknown";
+  connectionMessage = "";
+  saveButtonEl: ButtonComponent | null = null;
+  statusDotEl: HTMLElement | null = null;
+  connectionMessageEl: HTMLElement | null = null;
+  statusSeparatorEl: HTMLElement | null = null;
+  dirtyTextEl: HTMLElement | null = null;
+  debugInfoEl: HTMLElement | null = null;
 
   constructor(app: App, plugin: GeodePlugin) {
     super(app, plugin);
     this.plugin = plugin;
+    this.draft = { ...plugin.settings };
   }
 
-  display(): void {
+  // dirty reports whether the draft differs from the last saved settings. Computed rather than
+  // tracked, so reverting a field back to its saved value clears it automatically.
+  get dirty(): boolean {
+    return !settingsEqual(this.draft, this.plugin.settings);
+  }
+
+  // display renders the tab. When auto is true (every time Obsidian opens this tab, including
+  // the first time) it also fires an automatic connection test if the draft looks complete;
+  // internal re-renders (a provider switch) pass false so they don't retrigger it.
+  display(auto = true): void {
     this.containerEl.empty();
-    renderSettingsTab(this.plugin, this.containerEl, () => this.display());
+    renderSettingsTab(this, this.containerEl);
+
+    if (auto && hasConnectionConfig(this.draft)) {
+      void this.checkConnection();
+    }
+  }
+
+  // refreshActionsUI updates the status dot, status line, Save button, and debug info block
+  // without redrawing the rest of the tab. Empty rows collapse rather than reserving blank line
+  // height, and the connection message and dirty reminder are updated independently so the
+  // dirty reminder never inherits the connection status colour.
+  refreshActionsUI(): void {
+    if (this.saveButtonEl !== null) {
+      this.saveButtonEl.setDisabled(!this.dirty);
+    }
+
+    if (this.statusDotEl !== null) {
+      this.statusDotEl.className = `geode-status-dot is-${this.connectionStatus}`;
+    }
+
+    if (this.connectionMessageEl !== null) {
+      this.connectionMessageEl.setText(connectionMessageFor(this));
+      this.connectionMessageEl.className = `geode-connection-message is-${this.connectionStatus}`;
+    }
+
+    if (this.dirtyTextEl !== null) {
+      let dirtyDisplay = "none";
+      if (this.dirty) {
+        dirtyDisplay = "inline";
+      }
+      this.dirtyTextEl.style.display = dirtyDisplay;
+    }
+
+    if (this.statusSeparatorEl !== null) {
+      let separatorDisplay = "none";
+      if (this.dirty) {
+        separatorDisplay = "inline";
+      }
+      this.statusSeparatorEl.style.display = separatorDisplay;
+    }
+
+    if (this.debugInfoEl !== null) {
+      this.debugInfoEl.setText(debugInfoText(this));
+    }
+  }
+
+  async save(): Promise<void> {
+    console.log(`geode: saving settings (provider=${this.draft.provider})`);
+    this.plugin.settings = { ...this.draft };
+    await this.plugin.saveSettings();
+    this.refreshActionsUI();
+  }
+
+  async checkConnection(): Promise<void> {
+    console.log(
+      `geode: testing connection (provider=${this.draft.provider}, bucket=${this.draft.bucket})`,
+    );
+    this.connectionStatus = "checking";
+    this.connectionMessage = "";
+    this.refreshActionsUI();
+
+    const secretAccessKey = this.app.secretStorage.getSecret(this.draft.secretId) ?? "";
+    if (secretAccessKey === "") {
+      console.warn(`geode: no secret found for ID "${this.draft.secretId}"`);
+    }
+
+    const result = await testConnection(this.draft, secretAccessKey);
+
+    if (result.ok) {
+      console.log("geode: connection ok");
+      this.connectionStatus = "ok";
+      this.refreshActionsUI();
+      return;
+    }
+
+    this.connectionStatus = "error";
+    this.connectionMessage = result.message;
+    console.error("geode: connection test failed:", result.message);
+    this.refreshActionsUI();
   }
 }

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -1,0 +1,111 @@
+import { type App, PluginSettingTab, SecretComponent, Setting } from "obsidian";
+import type GeodePlugin from "./main";
+
+export class GeodeSettingTab extends PluginSettingTab {
+  plugin: GeodePlugin;
+
+  constructor(app: App, plugin: GeodePlugin) {
+    super(app, plugin);
+    this.plugin = plugin;
+  }
+
+  display(): void {
+    const { containerEl } = this;
+    containerEl.empty();
+
+    const { settings } = this.plugin;
+
+    new Setting(containerEl)
+      .setName("Provider")
+      .setDesc("Where your vault is synced to.")
+      .addDropdown((dropdown) =>
+        dropdown
+          .addOptions({ r2: "Cloudflare R2", custom: "Custom" })
+          .setValue(settings.provider)
+          .onChange(async (value) => {
+            settings.provider = value === "custom" ? "custom" : "r2";
+            await this.plugin.saveSettings();
+            this.display();
+          }),
+      );
+
+    if (settings.provider === "r2") {
+      new Setting(containerEl)
+        .setName("Account ID")
+        .setDesc("Your Cloudflare account ID.")
+        .addText((text) =>
+          text
+            .setPlaceholder("abc123...")
+            .setValue(settings.accountId)
+            .onChange(async (value) => {
+              settings.accountId = value;
+              await this.plugin.saveSettings();
+            }),
+        );
+    }
+
+    if (settings.provider === "custom") {
+      new Setting(containerEl)
+        .setName("Endpoint")
+        .setDesc("The S3 compatible endpoint URL for your storage.")
+        .addText((text) =>
+          text
+            .setPlaceholder("https://s3.example.com")
+            .setValue(settings.endpoint)
+            .onChange(async (value) => {
+              settings.endpoint = value;
+              await this.plugin.saveSettings();
+            }),
+        );
+
+      new Setting(containerEl)
+        .setName("Region")
+        .setDesc("The region your bucket lives in.")
+        .addText((text) =>
+          text
+            .setPlaceholder("us-east-1")
+            .setValue(settings.region)
+            .onChange(async (value) => {
+              settings.region = value;
+              await this.plugin.saveSettings();
+            }),
+        );
+    }
+
+    new Setting(containerEl)
+      .setName("Bucket")
+      .setDesc("The name of the bucket to sync your vault to.")
+      .addText((text) =>
+        text
+          .setPlaceholder("my-vault")
+          .setValue(settings.bucket)
+          .onChange(async (value) => {
+            settings.bucket = value;
+            await this.plugin.saveSettings();
+          }),
+      );
+
+    new Setting(containerEl)
+      .setName("Access key ID")
+      .setDesc("The access key ID for your storage credentials.")
+      .addText((text) =>
+        text
+          .setPlaceholder("AKIA...")
+          .setValue(settings.accessKeyId)
+          .onChange(async (value) => {
+            settings.accessKeyId = value;
+            await this.plugin.saveSettings();
+          }),
+      );
+
+    new Setting(containerEl)
+      .setName("Secret access key")
+      .setDesc("Held in Obsidian's secret storage; only its name is saved in plugin data.")
+      .addComponent((el) =>
+        new SecretComponent(this.app, el).setValue(settings.secretId).onChange(async (value) => {
+          settings.secretId = value;
+          await this.plugin.saveSettings();
+        }),
+      );
+  }
+}

--- a/src/settings.test.ts
+++ b/src/settings.test.ts
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  DEFAULT_SETTINGS,
+  endpointFor,
+  type GeodeSettings,
+  normalizeSettings,
+} from "./settings.ts";
+
+const normalizeCases: { name: string; input: unknown; want: GeodeSettings }[] = [
+  {
+    name: "null",
+    input: null,
+    want: DEFAULT_SETTINGS,
+  },
+  {
+    name: "undefined",
+    input: undefined,
+    want: DEFAULT_SETTINGS,
+  },
+  {
+    name: "empty object",
+    input: {},
+    want: DEFAULT_SETTINGS,
+  },
+  {
+    name: "partial legacy object",
+    input: { bucket: "my-bucket", accessKeyId: "AKIA123" },
+    want: { ...DEFAULT_SETTINGS, bucket: "my-bucket", accessKeyId: "AKIA123" },
+  },
+  {
+    name: "junk types in string fields",
+    input: { accountId: 42, endpoint: true, region: [1, 2], bucket: null, accessKeyId: {} },
+    want: DEFAULT_SETTINGS,
+  },
+  {
+    name: "junk version is ignored and forced to 1",
+    input: { version: "not-a-number" },
+    want: DEFAULT_SETTINGS,
+  },
+  {
+    name: "unknown keys dropped",
+    input: { bucket: "my-bucket", secretAccessKey: "x" },
+    want: { ...DEFAULT_SETTINGS, bucket: "my-bucket" },
+  },
+  {
+    name: "provider s3 coerced to r2",
+    input: { provider: "s3" },
+    want: DEFAULT_SETTINGS,
+  },
+  {
+    name: "provider 42 coerced to r2",
+    input: { provider: 42 },
+    want: DEFAULT_SETTINGS,
+  },
+  {
+    name: "provider null coerced to r2",
+    input: { provider: null },
+    want: DEFAULT_SETTINGS,
+  },
+  {
+    name: "provider custom preserved",
+    input: { provider: "custom", endpoint: "https://s3.example.com" },
+    want: { ...DEFAULT_SETTINGS, provider: "custom", endpoint: "https://s3.example.com" },
+  },
+  {
+    name: "secretId missing defaults to empty string",
+    input: {},
+    want: DEFAULT_SETTINGS,
+  },
+  {
+    name: "secretId non-string coerced to empty string",
+    input: { secretId: 42 },
+    want: DEFAULT_SETTINGS,
+  },
+  {
+    name: "secretId valid string passes through",
+    input: { secretId: "geode-my-r2-key" },
+    want: { ...DEFAULT_SETTINGS, secretId: "geode-my-r2-key" },
+  },
+];
+
+for (const { name, input, want } of normalizeCases) {
+  test(`normalizeSettings: ${name}`, () => {
+    assert.deepStrictEqual(normalizeSettings(input), want);
+  });
+}
+
+test("normalizeSettings: unknown keys dropped does not leak them onto the result", () => {
+  const result = normalizeSettings({ bucket: "my-bucket", secretAccessKey: "x" });
+  assert.strictEqual("secretAccessKey" in result, false);
+});
+
+const endpointCases: { name: string; input: GeodeSettings; want: string }[] = [
+  {
+    name: "r2",
+    input: { ...DEFAULT_SETTINGS, accountId: "abc123" },
+    want: "https://abc123.r2.cloudflarestorage.com",
+  },
+  {
+    name: "custom",
+    input: { ...DEFAULT_SETTINGS, provider: "custom", endpoint: "https://s3.example.com" },
+    want: "https://s3.example.com",
+  },
+];
+
+for (const { name, input, want } of endpointCases) {
+  test(`endpointFor: ${name}`, () => {
+    assert.strictEqual(endpointFor(input), want);
+  });
+}

--- a/src/settings.test.ts
+++ b/src/settings.test.ts
@@ -4,7 +4,10 @@ import {
   DEFAULT_SETTINGS,
   endpointFor,
   type GeodeSettings,
+  hasConnectionConfig,
   normalizeSettings,
+  regionFor,
+  settingsEqual,
 } from "./settings.ts";
 
 const normalizeCases: { name: string; input: unknown; want: GeodeSettings }[] = [
@@ -75,8 +78,8 @@ const normalizeCases: { name: string; input: unknown; want: GeodeSettings }[] = 
   },
   {
     name: "secretId valid string passes through",
-    input: { secretId: "geode-my-r2-key" },
-    want: { ...DEFAULT_SETTINGS, secretId: "geode-my-r2-key" },
+    input: { secretId: "foo" },
+    want: { ...DEFAULT_SETTINGS, secretId: "foo" },
   },
 ];
 
@@ -107,5 +110,112 @@ const endpointCases: { name: string; input: GeodeSettings; want: string }[] = [
 for (const { name, input, want } of endpointCases) {
   test(`endpointFor: ${name}`, () => {
     assert.strictEqual(endpointFor(input), want);
+  });
+}
+
+const regionCases: { name: string; input: GeodeSettings; want: string }[] = [
+  {
+    name: "r2 always signs as auto",
+    input: { ...DEFAULT_SETTINGS, region: "us-east-1" },
+    want: "auto",
+  },
+  {
+    name: "custom uses the configured region",
+    input: { ...DEFAULT_SETTINGS, provider: "custom", region: "eu-west-2" },
+    want: "eu-west-2",
+  },
+];
+
+for (const { name, input, want } of regionCases) {
+  test(`regionFor: ${name}`, () => {
+    assert.strictEqual(regionFor(input), want);
+  });
+}
+
+const settingsEqualCases: { name: string; a: GeodeSettings; b: GeodeSettings; want: boolean }[] = [
+  {
+    name: "identical values are equal",
+    a: DEFAULT_SETTINGS,
+    b: { ...DEFAULT_SETTINGS },
+    want: true,
+  },
+  {
+    name: "different bucket is not equal",
+    a: DEFAULT_SETTINGS,
+    b: { ...DEFAULT_SETTINGS, bucket: "my-bucket" },
+    want: false,
+  },
+  {
+    name: "different provider is not equal",
+    a: DEFAULT_SETTINGS,
+    b: { ...DEFAULT_SETTINGS, provider: "custom" },
+    want: false,
+  },
+  {
+    name: "reverting a change back to the original value is equal again",
+    a: DEFAULT_SETTINGS,
+    b: { ...{ ...DEFAULT_SETTINGS, provider: "custom" }, provider: "r2" },
+    want: true,
+  },
+];
+
+for (const { name, a, b, want } of settingsEqualCases) {
+  test(`settingsEqual: ${name}`, () => {
+    assert.strictEqual(settingsEqual(a, b), want);
+  });
+}
+
+const hasConnectionConfigCases: { name: string; input: GeodeSettings; want: boolean }[] = [
+  {
+    name: "empty settings are incomplete",
+    input: DEFAULT_SETTINGS,
+    want: false,
+  },
+  {
+    name: "r2 missing account ID is incomplete",
+    input: { ...DEFAULT_SETTINGS, bucket: "b", accessKeyId: "a", secretId: "s" },
+    want: false,
+  },
+  {
+    name: "r2 with all fields is complete",
+    input: {
+      ...DEFAULT_SETTINGS,
+      accountId: "acc",
+      bucket: "b",
+      accessKeyId: "a",
+      secretId: "s",
+    },
+    want: true,
+  },
+  {
+    name: "custom missing region is incomplete",
+    input: {
+      ...DEFAULT_SETTINGS,
+      provider: "custom",
+      endpoint: "https://s3.example.com",
+      bucket: "b",
+      accessKeyId: "a",
+      secretId: "s",
+    },
+    want: false,
+  },
+  {
+    name: "custom with all fields is complete",
+    input: {
+      ...DEFAULT_SETTINGS,
+      provider: "custom",
+      endpoint: "https://s3.example.com",
+      region: "us-east-1",
+      bucket: "b",
+      accessKeyId: "a",
+      secretId: "s",
+    },
+    want: true,
+  },
+];
+
+for (const { name, input, want } of hasConnectionConfigCases) {
+  test(`hasConnectionConfig: ${name}`, () => {
+    assert.strictEqual(hasConnectionConfig(input), want);
   });
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -7,6 +7,10 @@ export type GeodeSettings = {
   region: string;
   bucket: string;
   accessKeyId: string;
+  // secretId is a SecretStorage reference name, not the secret value itself. Obsidian's
+  // SecretComponent picker lets a user pick or create a secret under any name of their choosing;
+  // it does not support forcing new entries onto a fixed ID, so we have to remember whichever
+  // one they picked.
   secretId: string;
 };
 
@@ -24,13 +28,17 @@ export const DEFAULT_SETTINGS: GeodeSettings = {
 
 // stringOr returns v if it is a string, otherwise fallback.
 function stringOr(v: unknown, fallback: string): string {
-  if (typeof v === "string") return v;
+  if (typeof v === "string") {
+    return v;
+  }
   return fallback;
 }
 
 // providerOr returns "custom" if v is "custom", otherwise "r2".
-function providerOr(v: unknown): "r2" | "custom" {
-  if (v === "custom") return "custom";
+export function providerOr(v: unknown): "r2" | "custom" {
+  if (v === "custom") {
+    return "custom";
+  }
   return "r2";
 }
 
@@ -60,5 +68,42 @@ export function endpointFor(settings: GeodeSettings): string {
   if (settings.provider === "r2") {
     return `https://${settings.accountId}.r2.cloudflarestorage.com`;
   }
+
   return settings.endpoint;
+}
+
+// regionFor returns the signing region to use for the given settings. R2 always signs with
+// "auto" regardless of what a user might type, so custom is the only provider that needs one.
+export function regionFor(settings: GeodeSettings): string {
+  if (settings.provider === "r2") {
+    return "auto";
+  }
+
+  return settings.region;
+}
+
+// settingsEqual reports whether two settings values are identical field for field. Used to
+// derive whether a draft has unsaved changes by comparing it to the last saved settings, rather
+// than tracking a dirty flag that can't self-correct when an edit is reverted by hand.
+export function settingsEqual(a: GeodeSettings, b: GeodeSettings): boolean {
+  return (
+    a.provider === b.provider &&
+    a.accountId === b.accountId &&
+    a.endpoint === b.endpoint &&
+    a.region === b.region &&
+    a.bucket === b.bucket &&
+    a.accessKeyId === b.accessKeyId &&
+    a.secretId === b.secretId
+  );
+}
+
+// hasConnectionConfig reports whether settings have enough filled in to attempt a connection.
+export function hasConnectionConfig(settings: GeodeSettings): boolean {
+  if (settings.bucket === "" || settings.accessKeyId === "" || settings.secretId === "") {
+    return false;
+  }
+  if (settings.provider === "r2") {
+    return settings.accountId !== "";
+  }
+  return settings.endpoint !== "" && settings.region !== "";
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,0 +1,44 @@
+export interface GeodeSettings {
+  version: number;
+  provider: "r2" | "custom";
+  accountId: string;
+  endpoint: string;
+  region: string;
+  bucket: string;
+  accessKeyId: string;
+  secretId: string;
+}
+
+export const DEFAULT_SETTINGS: GeodeSettings = {
+  version: 1,
+  provider: "r2",
+  accountId: "",
+  endpoint: "",
+  region: "",
+  bucket: "",
+  accessKeyId: "",
+  secretId: "",
+};
+
+export function normalizeSettings(raw: unknown): GeodeSettings {
+  const source = raw !== null && typeof raw === "object" ? (raw as Record<string, unknown>) : {};
+
+  return {
+    // Current schema is version 1; future migrations branch on source.version here.
+    version: 1,
+    provider: source.provider === "custom" ? "custom" : "r2",
+    accountId: typeof source.accountId === "string" ? source.accountId : DEFAULT_SETTINGS.accountId,
+    endpoint: typeof source.endpoint === "string" ? source.endpoint : DEFAULT_SETTINGS.endpoint,
+    region: typeof source.region === "string" ? source.region : DEFAULT_SETTINGS.region,
+    bucket: typeof source.bucket === "string" ? source.bucket : DEFAULT_SETTINGS.bucket,
+    accessKeyId:
+      typeof source.accessKeyId === "string" ? source.accessKeyId : DEFAULT_SETTINGS.accessKeyId,
+    secretId: typeof source.secretId === "string" ? source.secretId : DEFAULT_SETTINGS.secretId,
+  };
+}
+
+export function endpointFor(settings: GeodeSettings): string {
+  return settings.provider === "r2"
+    ? `https://${settings.accountId}.r2.cloudflarestorage.com`
+    : settings.endpoint;
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,4 +1,5 @@
-export interface GeodeSettings {
+// GeodeSettings is the persisted shape of a Geode plugin's user configuration.
+export type GeodeSettings = {
   version: number;
   provider: "r2" | "custom";
   accountId: string;
@@ -7,8 +8,9 @@ export interface GeodeSettings {
   bucket: string;
   accessKeyId: string;
   secretId: string;
-}
+};
 
+// DEFAULT_SETTINGS is the complete zero value used before any user configuration is loaded.
 export const DEFAULT_SETTINGS: GeodeSettings = {
   version: 1,
   provider: "r2",
@@ -20,25 +22,43 @@ export const DEFAULT_SETTINGS: GeodeSettings = {
   secretId: "",
 };
 
+// stringOr returns v if it is a string, otherwise fallback.
+function stringOr(v: unknown, fallback: string): string {
+  if (typeof v === "string") return v;
+  return fallback;
+}
+
+// providerOr returns "custom" if v is "custom", otherwise "r2".
+function providerOr(v: unknown): "r2" | "custom" {
+  if (v === "custom") return "custom";
+  return "r2";
+}
+
+// normalizeSettings returns a complete GeodeSettings from whatever loadData produced,
+// filling gaps with defaults.
 export function normalizeSettings(raw: unknown): GeodeSettings {
-  const source = raw !== null && typeof raw === "object" ? (raw as Record<string, unknown>) : {};
+  let source: Record<string, unknown> = {};
+  if (raw !== null && typeof raw === "object") {
+    source = raw as Record<string, unknown>;
+  }
 
   return {
     // Current schema is version 1; future migrations branch on source.version here.
     version: 1,
-    provider: source.provider === "custom" ? "custom" : "r2",
-    accountId: typeof source.accountId === "string" ? source.accountId : DEFAULT_SETTINGS.accountId,
-    endpoint: typeof source.endpoint === "string" ? source.endpoint : DEFAULT_SETTINGS.endpoint,
-    region: typeof source.region === "string" ? source.region : DEFAULT_SETTINGS.region,
-    bucket: typeof source.bucket === "string" ? source.bucket : DEFAULT_SETTINGS.bucket,
-    accessKeyId:
-      typeof source.accessKeyId === "string" ? source.accessKeyId : DEFAULT_SETTINGS.accessKeyId,
-    secretId: typeof source.secretId === "string" ? source.secretId : DEFAULT_SETTINGS.secretId,
+    provider: providerOr(source.provider),
+    accountId: stringOr(source.accountId, DEFAULT_SETTINGS.accountId),
+    endpoint: stringOr(source.endpoint, DEFAULT_SETTINGS.endpoint),
+    region: stringOr(source.region, DEFAULT_SETTINGS.region),
+    bucket: stringOr(source.bucket, DEFAULT_SETTINGS.bucket),
+    accessKeyId: stringOr(source.accessKeyId, DEFAULT_SETTINGS.accessKeyId),
+    secretId: stringOr(source.secretId, DEFAULT_SETTINGS.secretId),
   };
 }
 
+// endpointFor returns the storage endpoint URL to use for the given settings.
 export function endpointFor(settings: GeodeSettings): string {
-  return settings.provider === "r2"
-    ? `https://${settings.accountId}.r2.cloudflarestorage.com`
-    : settings.endpoint;
+  if (settings.provider === "r2") {
+    return `https://${settings.accountId}.r2.cloudflarestorage.com`;
+  }
+  return settings.endpoint;
 }

--- a/src/storage.test.ts
+++ b/src/storage.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { DEFAULT_SETTINGS, type GeodeSettings } from "./settings.ts";
+import { testConnection } from "./storage.ts";
+
+const missingFieldCases: {
+  name: string;
+  settings: GeodeSettings;
+  secretAccessKey: string;
+  want: string;
+}[] = [
+  {
+    name: "missing bucket",
+    settings: { ...DEFAULT_SETTINGS, accessKeyId: "AKIA123" },
+    secretAccessKey: "shh",
+    want: "Fill in bucket first",
+  },
+  {
+    name: "missing access key ID",
+    settings: { ...DEFAULT_SETTINGS, bucket: "my-vault" },
+    secretAccessKey: "shh",
+    want: "Fill in access key ID first",
+  },
+  {
+    name: "missing secret access key",
+    settings: { ...DEFAULT_SETTINGS, bucket: "my-vault", accessKeyId: "AKIA123" },
+    secretAccessKey: "",
+    want: "Fill in secret access key first",
+  },
+];
+
+for (const { name, settings, secretAccessKey, want } of missingFieldCases) {
+  test(`testConnection: ${name}`, async () => {
+    const result = await testConnection(settings, secretAccessKey);
+    assert.equal(result.ok, false);
+    assert.equal(result.message, want);
+  });
+}

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,0 +1,59 @@
+import { AwsClient } from "aws4fetch";
+import { endpointFor, type GeodeSettings, regionFor } from "./settings.ts";
+
+// ConnectionResult reports whether a storage provider accepted a test request. Message is the
+// empty string when ok is true.
+export type ConnectionResult = {
+  ok: boolean;
+  message: string;
+};
+
+// missingFieldFor returns the name of the first field testConnection needs but doesn't have, or
+// "" if everything required is present.
+function missingFieldFor(settings: GeodeSettings, secretAccessKey: string): string {
+  if (settings.bucket === "") {
+    return "bucket";
+  }
+  if (settings.accessKeyId === "") {
+    return "access key ID";
+  }
+  if (secretAccessKey === "") {
+    return "secret access key";
+  }
+  return "";
+}
+
+// testConnection sends a signed HEAD request for the configured bucket and reports whether the
+// provider accepted the credentials.
+export async function testConnection(
+  settings: GeodeSettings,
+  secretAccessKey: string,
+): Promise<ConnectionResult> {
+  const missing = missingFieldFor(settings, secretAccessKey);
+  if (missing !== "") {
+    return { ok: false, message: `Fill in ${missing} first` };
+  }
+
+  const client = new AwsClient({
+    accessKeyId: settings.accessKeyId,
+    secretAccessKey,
+    region: regionFor(settings),
+    service: "s3",
+  });
+  const url = `${endpointFor(settings)}/${settings.bucket}`;
+
+  let response: Response;
+  try {
+    response = await client.fetch(url, { method: "HEAD" });
+  } catch (err) {
+    if (err instanceof Error) {
+      return { ok: false, message: err.message };
+    }
+    return { ok: false, message: "Network error" };
+  }
+
+  if (!response.ok) {
+    return { ok: false, message: `Storage rejected the request (${response.status})` };
+  }
+  return { ok: true, message: "" };
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,104 @@
+.geode-settings-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.75em;
+}
+
+.geode-title {
+  margin: 0;
+  padding: 0;
+  font-size: 1.75em;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.geode-settings-header .setting-item-description {
+  margin-top: 0.25em;
+}
+
+.geode-settings-links {
+  display: flex;
+  gap: 0.5em;
+}
+
+.geode-settings-header button,
+.geode-card button {
+  cursor: pointer;
+}
+
+/* Obsidian boxes every .setting-item by default; group related rows into one card instead of
+   one box per row, matching the flowing layout of Obsidian's own core settings pages. */
+.geode-card {
+  background: var(--background-secondary);
+  border-radius: var(--radius-m, 8px);
+  overflow: hidden;
+}
+
+.geode-card .setting-item {
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  border-bottom: 1px solid var(--background-modifier-border);
+  margin: 0;
+  padding-left: 1em;
+  padding-right: 1em;
+}
+
+.geode-card .setting-item:last-child {
+  border-bottom: none;
+}
+
+.geode-support-anchor {
+  margin-top: 1.5em;
+}
+
+.geode-status-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-right: 8px;
+  margin-bottom: 4px;
+  vertical-align: middle;
+  background: var(--text-faint);
+}
+
+.geode-status-dot.is-checking {
+  background: var(--text-warning);
+}
+
+.geode-status-dot.is-ok {
+  background: var(--text-success);
+}
+
+.geode-status-dot.is-error {
+  background: var(--text-error);
+}
+
+.geode-status-separator {
+  color: var(--text-faint);
+}
+
+.geode-connection-message.is-error {
+  color: var(--text-error);
+}
+
+.geode-connection-message.is-ok {
+  color: var(--text-success);
+}
+
+.geode-dirty-text {
+  color: var(--text-warning);
+}
+
+.geode-debug-box {
+  font-family: var(--font-monospace);
+  font-size: 0.85em;
+  white-space: pre-wrap;
+  background: var(--background-primary);
+  border-radius: var(--radius-s, 4px);
+  padding: 1em;
+  margin: 1em 1em 1em 1em;
+  overflow-x: auto;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,10 @@
     "lib": ["DOM", "ES2020"],
     "strict": true,
     "noImplicitAny": true,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "erasableSyntaxOnly": true,
+    "allowImportingTsExtensions": true,
+    "types": ["node"]
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
Resolves [#6](https://github.com/8thpark/geode/issues/6)

## Problem

- The plugin has no settings surface, so storage credentials have nowhere to live and every sync feature behind them is blocked

## Changes

- Add a settings tab with a provider dropdown, Cloudflare R2 by default with a custom S3 compatible fallback
- Keep the secret access key in Obsidian's native SecretStorage, `data.json` only ever stores a reference name
- Split settings into a pure core with table driven `node:test` coverage and a new `Test` job in CI
- Raise `minAppVersion` to `1.11.4`, required by SecretStorage
- Add a Code Style section to AGENTS.md, TypeScript written as if it were Go

## Why

- Credentials need a home before #7 can connect to remote storage
- No code path in this PR touches the credential value itself, which keeps secrets out of synced plugin data by construction