### PR TITLE
Vault → Track sessions and diff changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ main.js
 # Dev vault (created by `make create-dev-vault`)
 /dev-vault/
 /data.json
+/state.json
 
 # Node
 /node_modules/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,10 +82,10 @@ With `npm run dev` running:
 4. After changing source files, reload Obsidian to pick up the new `main.js` (Cmd-P → "Reload app
    without saving"). Installing the community Hot-Reload plugin removes the need for this step.
 
-Obsidian's plugin data file (`data.json`, which lands at the repo root because the dev vault
-symlinks the whole repo in as the plugin folder) is gitignored and should never be committed.
-The MinIO container's data lives in a Docker volume, not a repo folder — `npm run dev:s3:reset`
-clears it.
+Obsidian's plugin data file (`data.json`) and geode's own vault state file (`state.json`), both
+of which land at the repo root because the dev vault symlinks the whole repo in as the plugin
+folder, are gitignored and should never be committed. The MinIO container's data lives in a
+Docker volume, not a repo folder — `npm run dev:s3:reset` clears it.
 
 ## License
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,15 +1,39 @@
 import { Plugin } from "obsidian";
 import { DEFAULT_SETTINGS, type GeodeSettings, normalizeSettings } from "./settings";
 import { GeodeSettingTab } from "./settings-tab";
+import { createObsidianStateStore, createObsidianVaultReader } from "./vault-adapter";
+import { diffSnapshots, takeSnapshot } from "./vault-state";
+
+// VAULT_STATE_DEBOUNCE_MS delays a vault state refresh after the last file event, so a burst of
+// edits (autosave, bulk rename, etc.) collapses into one snapshot instead of one per file.
+const VAULT_STATE_DEBOUNCE_MS = 2000;
 
 // GeodePlugin is the Obsidian plugin entry point that owns settings load and save.
 export default class GeodePlugin extends Plugin {
   settings: GeodeSettings = DEFAULT_SETTINGS;
+  private refreshTimer: number | undefined;
 
   async onload() {
     await this.loadSettings();
     this.addSettingTab(new GeodeSettingTab(this.app, this));
     console.log(`geode: loaded (provider=${this.settings.provider})`);
+
+    // onLayoutReady, not onload directly: the vault isn't guaranteed fully indexed yet at
+    // onload time, and a snapshot taken too early would see an incomplete file list.
+    this.app.workspace.onLayoutReady(() => {
+      void this.refreshVaultState();
+    });
+
+    this.registerEvent(this.app.vault.on("create", () => this.scheduleVaultStateRefresh()));
+    this.registerEvent(this.app.vault.on("modify", () => this.scheduleVaultStateRefresh()));
+    this.registerEvent(this.app.vault.on("delete", () => this.scheduleVaultStateRefresh()));
+    this.registerEvent(this.app.vault.on("rename", () => this.scheduleVaultStateRefresh()));
+
+    this.register(() => {
+      if (this.refreshTimer !== undefined) {
+        window.clearTimeout(this.refreshTimer);
+      }
+    });
   }
 
   async loadSettings() {
@@ -19,5 +43,36 @@ export default class GeodePlugin extends Plugin {
   async saveSettings() {
     await this.saveData(this.settings);
     console.log("geode: settings saved");
+  }
+
+  // scheduleVaultStateRefresh debounces refreshVaultState so a burst of vault events collapses
+  // into a single snapshot instead of one per file.
+  private scheduleVaultStateRefresh() {
+    if (this.refreshTimer !== undefined) {
+      window.clearTimeout(this.refreshTimer);
+    }
+    this.refreshTimer = window.setTimeout(() => {
+      this.refreshTimer = undefined;
+      void this.refreshVaultState();
+    }, VAULT_STATE_DEBOUNCE_MS);
+  }
+
+  // refreshVaultState snapshots the vault, compares it against what geode saw last time, and
+  // persists the result — the memory push/pull sync will read from and diff against remote.
+  async refreshVaultState() {
+    const dir = this.manifest.dir;
+    if (dir === undefined) {
+      return;
+    }
+
+    const store = createObsidianStateStore(this.app.vault.adapter, `${dir}/state.json`);
+    const reader = createObsidianVaultReader(this.app.vault);
+
+    const previous = await store.read();
+    const current = await takeSnapshot(reader, previous);
+    const changes = diffSnapshots(previous, current);
+
+    console.log(`geode: vault state refreshed (${changes.length} change(s) since last run)`);
+    await store.write(current);
   }
 }

--- a/src/vault-adapter.ts
+++ b/src/vault-adapter.ts
@@ -1,0 +1,50 @@
+import type { DataAdapter, Vault } from "obsidian";
+import type { StateStore, VaultReader, VaultSnapshot } from "./vault-state.ts";
+
+// createObsidianVaultReader returns a VaultReader backed by the real vault's file tree. Obsidian
+// already excludes .obsidian/** from Vault.getFiles(), so the plugin's own state file (which
+// lives inside .obsidian/plugins/geode/) never shows up as a vault file to snapshot.
+export function createObsidianVaultReader(vault: Vault): VaultReader {
+  return {
+    listFiles: async () => {
+      return vault.getFiles().map((file) => ({
+        path: file.path,
+        size: file.stat.size,
+        mtime: file.stat.mtime,
+      }));
+    },
+    readFile: async (path) => {
+      const file = vault.getFileByPath(path);
+      if (file === null) {
+        throw new Error(`file disappeared during snapshot: ${path}`);
+      }
+      const buffer = await vault.readBinary(file);
+      return new Uint8Array(buffer);
+    },
+  };
+}
+
+// createObsidianStateStore returns a StateStore that persists the snapshot at statePath via the
+// vault adapter. A missing or unparseable file is treated as "no snapshot yet" rather than an
+// error, since the safest fallback for corrupt state is to start fresh, not to crash sync.
+export function createObsidianStateStore(adapter: DataAdapter, statePath: string): StateStore {
+  const empty: VaultSnapshot = { files: [] };
+
+  return {
+    read: async () => {
+      const exists = await adapter.exists(statePath);
+      if (!exists) {
+        return empty;
+      }
+      try {
+        const raw = await adapter.read(statePath);
+        return JSON.parse(raw) as VaultSnapshot;
+      } catch {
+        return empty;
+      }
+    },
+    write: async (snapshot) => {
+      await adapter.write(statePath, JSON.stringify(snapshot));
+    },
+  };
+}

--- a/src/vault-state.test.ts
+++ b/src/vault-state.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  diffSnapshots,
+  takeSnapshot,
+  type VaultFile,
+  type VaultReader,
+  type VaultSnapshot,
+} from "./vault-state.ts";
+
+// fakeReader returns a VaultReader backed by an in-memory map, and a counter of how many times
+// readFile was called — used to prove the stat gate skips rereading unchanged files.
+function fakeReader(files: Record<string, { content: string; mtime: number }>): {
+  reader: VaultReader;
+  readCount: () => number;
+} {
+  let reads = 0;
+  const reader: VaultReader = {
+    listFiles: async () => {
+      const list: VaultFile[] = [];
+      for (const [path, file] of Object.entries(files)) {
+        list.push({ path, size: file.content.length, mtime: file.mtime });
+      }
+      return list;
+    },
+    readFile: async (path) => {
+      reads += 1;
+      const file = files[path];
+      if (file === undefined) {
+        throw new Error(`no such file: ${path}`);
+      }
+      return new TextEncoder().encode(file.content);
+    },
+  };
+  return { reader, readCount: () => reads };
+}
+
+const empty: VaultSnapshot = { files: [] };
+
+test("takeSnapshot: a new file is hashed and reported as added", async () => {
+  const { reader } = fakeReader({ "note.md": { content: "hello", mtime: 1 } });
+
+  const snapshot = await takeSnapshot(reader, empty);
+  const changes = diffSnapshots(empty, snapshot);
+
+  assert.equal(snapshot.files.length, 1);
+  assert.equal(snapshot.files[0].path, "note.md");
+  assert.deepEqual(changes, [{ path: "note.md", kind: "added" }]);
+});
+
+test("takeSnapshot: unchanged size and mtime reuse the previous hash without rereading", async () => {
+  const { reader, readCount } = fakeReader({ "note.md": { content: "hello", mtime: 1 } });
+  const first = await takeSnapshot(reader, empty);
+
+  const second = await takeSnapshot(reader, first);
+
+  assert.equal(readCount(), 1);
+  assert.deepEqual(second, first);
+  assert.deepEqual(diffSnapshots(first, second), []);
+});
+
+test("takeSnapshot: a touched file with identical content is not reported as modified", async () => {
+  const { reader: firstReader } = fakeReader({ "note.md": { content: "hello", mtime: 1 } });
+  const first = await takeSnapshot(firstReader, empty);
+
+  const { reader: secondReader } = fakeReader({ "note.md": { content: "hello", mtime: 2 } });
+  const second = await takeSnapshot(secondReader, first);
+
+  assert.deepEqual(diffSnapshots(first, second), []);
+});
+
+test("takeSnapshot: changed content under a new mtime is detected on reread", async () => {
+  const { reader: firstReader } = fakeReader({ "note.md": { content: "hello", mtime: 1 } });
+  const first = await takeSnapshot(firstReader, empty);
+
+  const { reader: secondReader } = fakeReader({ "note.md": { content: "goodbye", mtime: 2 } });
+  const second = await takeSnapshot(secondReader, first);
+
+  assert.deepEqual(diffSnapshots(first, second), [{ path: "note.md", kind: "modified" }]);
+});
+
+test("diffSnapshots: a file missing from the current listing is reported as deleted", async () => {
+  const { reader } = fakeReader({ "note.md": { content: "hello", mtime: 1 } });
+  const first = await takeSnapshot(reader, empty);
+
+  const changes = diffSnapshots(first, empty);
+
+  assert.deepEqual(changes, [{ path: "note.md", kind: "deleted" }]);
+});

--- a/src/vault-state.ts
+++ b/src/vault-state.ts
@@ -1,0 +1,101 @@
+// FileState is what geode remembers about one vault file as of the last snapshot.
+export type FileState = {
+  path: string;
+  size: number;
+  mtime: number;
+  hash: string;
+};
+
+// VaultSnapshot is every file geode saw the last time it took a snapshot.
+export type VaultSnapshot = {
+  files: FileState[];
+};
+
+// VaultFile is one file as seen live in the vault, before hashing.
+export type VaultFile = {
+  path: string;
+  size: number;
+  mtime: number;
+};
+
+// VaultReader lists files present in the vault right now and reads their bytes. The real
+// implementation wraps Obsidian's Vault API (see vault-adapter.ts); tests use an in-memory fake.
+export type VaultReader = {
+  listFiles: () => Promise<VaultFile[]>;
+  readFile: (path: string) => Promise<Uint8Array>;
+};
+
+// StateStore reads and writes the persisted snapshot. The real implementation stores it inside
+// the plugin's own data directory (see vault-adapter.ts); tests use an in-memory fake.
+export type StateStore = {
+  read: () => Promise<VaultSnapshot>;
+  write: (snapshot: VaultSnapshot) => Promise<void>;
+};
+
+// Change describes one path whose state differs between two snapshots.
+export type Change = {
+  path: string;
+  kind: "added" | "modified" | "deleted";
+};
+
+// hashBytes returns the lowercase hex SHA-256 digest of data.
+async function hashBytes(data: Uint8Array): Promise<string> {
+  // Same TS/DOM lib generic mismatch as storage.ts's BodyInit cast: Uint8Array<ArrayBufferLike>
+  // vs BufferSource's stricter ArrayBuffer expectation. Not a real runtime issue.
+  const digest = await crypto.subtle.digest("SHA-256", data as BufferSource);
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+// takeSnapshot walks every file the reader currently sees and returns their content hashes. A
+// file whose size and mtime both match the previous snapshot reuses that hash instead of
+// rereading content — the same stat gated hashing rsync, git, and Syncthing all use, since mtime
+// and size alone aren't reliable enough to trust as identity, but are cheap enough to skip a
+// rehash when neither has moved.
+export async function takeSnapshot(
+  reader: VaultReader,
+  previous: VaultSnapshot,
+): Promise<VaultSnapshot> {
+  const previousByPath = new Map(previous.files.map((file) => [file.path, file]));
+  const liveFiles = await reader.listFiles();
+
+  const files = await Promise.all(
+    liveFiles.map(async (file) => {
+      const known = previousByPath.get(file.path);
+      if (known !== undefined && known.size === file.size && known.mtime === file.mtime) {
+        return known;
+      }
+      const bytes = await reader.readFile(file.path);
+      return { path: file.path, size: file.size, mtime: file.mtime, hash: await hashBytes(bytes) };
+    }),
+  );
+
+  return { files };
+}
+
+// diffSnapshots compares two snapshots and reports every path whose content differs.
+export function diffSnapshots(previous: VaultSnapshot, current: VaultSnapshot): Change[] {
+  const previousByPath = new Map(previous.files.map((file) => [file.path, file]));
+  const currentByPath = new Map(current.files.map((file) => [file.path, file]));
+  const changes: Change[] = [];
+
+  for (const file of current.files) {
+    const known = previousByPath.get(file.path);
+    if (known === undefined) {
+      changes.push({ path: file.path, kind: "added" });
+      continue;
+    }
+    if (known.hash !== file.hash) {
+      changes.push({ path: file.path, kind: "modified" });
+    }
+  }
+
+  for (const file of previous.files) {
+    if (!currentByPath.has(file.path)) {
+      changes.push({ path: file.path, kind: "deleted" });
+    }
+  }
+
+  return changes;
+}


### PR DESCRIPTION
Resolves #8

## Problem

Geode has no memory of what the vault looked like the last time it ran, so change detection, deletion propagation, and conflict handling are all impossible

## Changes

- Add a `VaultReader`/`StateStore` pair and a pure `takeSnapshot`/`diffSnapshots` engine that classifies every path as added, modified, or deleted
- Hash file content with stat gating, reuse the previous hash when `size`/`mtime` are unchanged, rehash only when either moves, matching the approach `rsync`, `git`, and `Syncthing` all use
- Persist the snapshot to the plugin's own data directory via a real Obsidian adapter, kept separate from the pure engine so it stays testable under `node:test`
- Wire the snapshot into `onLayoutReady` on startup, plus debounced `create`/`modify`/`delete`/`rename` vault events

## Why

- This is the foundation push and pull sync depends on, without a record of prior state there's nothing to diff a fresh vault scan against
- Stat gated hashing avoids rereading every file's content on every snapshot while still using content hash, not just timestamps, as the source of truth for whether something actually changed