### PR TITLE
fix: decode XML entities in listed object keys

### DIFF
--- a/src/storage.test.ts
+++ b/src/storage.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import { DEFAULT_SETTINGS, type GeodeSettings } from "./settings.ts";
-import { testConnection } from "./storage.ts";
+import { parseListObjectsXml, testConnection } from "./storage.ts";
 
 const missingFieldCases: {
   name: string;
@@ -36,3 +36,24 @@ for (const { name, settings, secretAccessKey, want } of missingFieldCases) {
     assert.equal(result.message, want);
   });
 }
+
+test("parseListObjectsXml decodes XML entities in object keys", () => {
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult>
+  <Contents>
+    <Key>notes/Foo &amp; Bar &#40;draft&#41;.md</Key>
+    <LastModified>2026-07-13T00:00:00.000Z</LastModified>
+    <Size>12</Size>
+  </Contents>
+  <Contents>
+    <Key>notes/2 &lt; 3 &#x1F600;.md</Key>
+    <LastModified>2026-07-13T00:01:00.000Z</LastModified>
+    <Size>34</Size>
+  </Contents>
+</ListBucketResult>`;
+
+  assert.deepEqual(parseListObjectsXml(xml), [
+    { key: "notes/Foo & Bar (draft).md", size: 12, lastModified: "2026-07-13T00:00:00.000Z" },
+    { key: "notes/2 < 3 😀.md", size: 34, lastModified: "2026-07-13T00:01:00.000Z" },
+  ]);
+});

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -175,11 +175,49 @@ function fieldFrom(block: string, tag: string): string {
   return found[1];
 }
 
+// decodeXmlText returns the plain text represented by XML character and entity references.
+function decodeXmlText(text: string): string {
+  return text.replace(
+    /&#(x[0-9a-fA-F]+|[0-9]+);|&(amp|lt|gt|quot|apos);/g,
+    (match, numeric, named) => {
+      if (numeric !== undefined) {
+        let codePoint = 0;
+        if (numeric.startsWith("x") || numeric.startsWith("X")) {
+          codePoint = Number.parseInt(numeric.slice(1), 16);
+        } else {
+          codePoint = Number.parseInt(numeric, 10);
+        }
+        if (Number.isNaN(codePoint)) {
+          return match;
+        }
+        return String.fromCodePoint(codePoint);
+      }
+
+      if (named === "amp") {
+        return "&";
+      }
+      if (named === "lt") {
+        return "<";
+      }
+      if (named === "gt") {
+        return ">";
+      }
+      if (named === "quot") {
+        return '"';
+      }
+      if (named === "apos") {
+        return "'";
+      }
+      return match;
+    },
+  );
+}
+
 // parseListObjectsXml extracts object keys, sizes, and last-modified timestamps from an S3
 // ListObjectsV2 XML response. Regex rather than a DOM parser: the schema is narrow and stable,
 // and DOMParser isn't available outside a browser-like runtime, which would make this untestable
 // under node:test.
-function parseListObjectsXml(xml: string): ObjectMeta[] {
+export function parseListObjectsXml(xml: string): ObjectMeta[] {
   const objects: ObjectMeta[] = [];
   const contentsPattern = /<Contents>([\s\S]*?)<\/Contents>/g;
   let match = contentsPattern.exec(xml);
@@ -187,7 +225,7 @@ function parseListObjectsXml(xml: string): ObjectMeta[] {
   while (match !== null) {
     const block = match[1];
     objects.push({
-      key: fieldFrom(block, "Key"),
+      key: decodeXmlText(fieldFrom(block, "Key")),
       size: Number(fieldFrom(block, "Size")),
       lastModified: fieldFrom(block, "LastModified"),
     });


### PR DESCRIPTION
## Summary
- Decode XML named and numeric character references when parsing S3 ListObjectsV2 keys
- Add node:test coverage for ampersands, angle brackets, decimal references, and hex Unicode references

Fixes #40

## Validation
- npm test
- npm run lint