### PR TITLE
CI → Migrate CodeQL to advanced setup

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,37 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: "12 4 * * 1"
+
+permissions: read-all
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: javascript-typescript
+            build-mode: none
+          - language: actions
+            build-mode: none
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+      - uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Problem

- CodeQL currently runs through GitHub's default setup, which does not scan pull requests opened from forks
- Both `Analyze` checks and the summary `CodeQL` check are required for merge, so every external contribution sits permanently blocked with no self service way to trigger a scan

## Changes

- Add `.github/workflows/codeql.yml`, a workflow based CodeQL setup covering the same `javascript-typescript` and `actions` languages the default setup already scanned
- Reuse the `checkout` and `codeql-action` versions already pinned elsewhere in `.github/workflows`

## Why

- Workflow based CodeQL runs on `pull_request` events regardless of whether the head branch is a fork, unblocking contributions from outside collaborators
- Keeps the same scan coverage and pinned action style as the rest of the workflows