### PR TITLE
Logging → Persistent log with in app viewer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ main.js
 /dev-vault/
 /data.json
 /state.json
+/geode.log
 
 # Node
 /node_modules/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,8 +22,9 @@
 ## Documentation
 
 Ensure that documentation is added to, and updated, as the project progresses; as well as continue
-to update the private [Working Document](fa8682d6-0677-4d6c-a32d-c91e51411d8f) artifact as we make
-decisions together about the project, and to track progress.
+to update the private
+[Working Document](https://claude.ai/code/artifact/fa8682d6-0677-4d6c-a32d-c91e51411d8f) artifact as
+we make decisions together about the project, and to track progress.
 
 ## Competitors
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,10 +82,10 @@ With `npm run dev` running:
 4. After changing source files, reload Obsidian to pick up the new `main.js` (Cmd-P → "Reload app
    without saving"). Installing the community Hot-Reload plugin removes the need for this step.
 
-Obsidian's plugin data file (`data.json`) and geode's own vault state file (`state.json`), both
-of which land at the repo root because the dev vault symlinks the whole repo in as the plugin
-folder, are gitignored and should never be committed. The MinIO container's data lives in a
-Docker volume, not a repo folder — `npm run dev:s3:reset` clears it.
+Obsidian's plugin data file (`data.json`), geode's own vault state file (`state.json`), and its
+log file (`geode.log`), all of which land at the repo root because the dev vault symlinks the
+whole repo in as the plugin folder, are gitignored and should never be committed. The MinIO
+container's data lives in a Docker volume, not a repo folder — `npm run dev:s3:reset` clears it.
 
 ## License
 

--- a/src/log-adapter.ts
+++ b/src/log-adapter.ts
@@ -1,0 +1,83 @@
+import type { DataAdapter } from "obsidian";
+import {
+  createMemorySink,
+  formatLogLine,
+  type LogEntry,
+  type LogSink,
+  parseLogLine,
+  trimLogLines,
+} from "./log.ts";
+
+// createLogSink returns the real file backed sink, or an in-memory fallback when dir is
+// undefined (some embedded/test hosts never set manifest.dir).
+export function createLogSink(
+  adapter: DataAdapter,
+  dir: string | undefined,
+  maxLines: number,
+): LogSink {
+  if (dir === undefined) {
+    return createMemorySink(maxLines);
+  }
+  return createObsidianLogSink(adapter, `${dir}/geode.log`, maxLines);
+}
+
+// COMPACT_INTERVAL is how many appends accumulate before the log file is trimmed back down to
+// maxLines. Appending is cheap (DataAdapter.append); a full read/trim/write is not, so
+// compaction runs in batches rather than after every single line.
+const COMPACT_INTERVAL = 50;
+
+// createObsidianLogSink returns a LogSink that persists to a capped file at logPath via the vault
+// adapter, appending cheaply and periodically trimming back down to maxLines so the file can't
+// grow unbounded over a long running session.
+export function createObsidianLogSink(
+  adapter: DataAdapter,
+  logPath: string,
+  maxLines: number,
+): LogSink {
+  let appendsSinceCompact = 0;
+
+  const compact = async () => {
+    const exists = await adapter.exists(logPath);
+    if (!exists) {
+      return;
+    }
+    const raw = await adapter.read(logPath);
+    await adapter.write(logPath, trimLogLines(raw, maxLines));
+  };
+
+  return {
+    append: async (entry) => {
+      const line = `${formatLogLine(entry)}\n`;
+      const exists = await adapter.exists(logPath);
+      if (exists) {
+        await adapter.append(logPath, line);
+      } else {
+        await adapter.write(logPath, line);
+      }
+
+      appendsSinceCompact += 1;
+      if (appendsSinceCompact >= COMPACT_INTERVAL) {
+        appendsSinceCompact = 0;
+        await compact();
+      }
+    },
+    read: async () => {
+      const exists = await adapter.exists(logPath);
+      if (!exists) {
+        return [];
+      }
+      const raw = await adapter.read(logPath);
+      const entries: LogEntry[] = [];
+      for (const line of raw.split("\n")) {
+        const entry = parseLogLine(line);
+        if (entry !== undefined) {
+          entries.push(entry);
+        }
+      }
+      return entries;
+    },
+    clear: async () => {
+      await adapter.write(logPath, "");
+    },
+  };
+}

--- a/src/log-view.ts
+++ b/src/log-view.ts
@@ -1,0 +1,74 @@
+import { ItemView, type WorkspaceLeaf } from "obsidian";
+import type { LogEntry, LogSink } from "./log.ts";
+
+// LOG_VIEW_TYPE identifies geode's log pane to Obsidian's workspace leaf API.
+export const LOG_VIEW_TYPE = "geode-log-view";
+
+// POLL_INTERVAL_MS is how often an open log view re-reads the sink, so entries logged while the
+// pane is sitting open still show up without a manual refresh.
+const POLL_INTERVAL_MS = 2000;
+
+// renderRow draws one entry into list, colour coded by level via a geode-log-row.is-<level> class.
+function renderRow(list: HTMLElement, entry: LogEntry): void {
+  const row = list.createDiv({ cls: `geode-log-row is-${entry.level}` });
+  row.createSpan({ cls: "geode-log-time", text: new Date(entry.time).toLocaleString() });
+  row.createSpan({ cls: "geode-log-level", text: entry.level.toUpperCase() });
+  row.createSpan({ cls: "geode-log-message", text: entry.message });
+}
+
+// renderLogView draws entries into containerEl, most recent first.
+function renderLogView(containerEl: HTMLElement, entries: LogEntry[]): void {
+  containerEl.empty();
+  containerEl.addClass("geode-log-view");
+
+  if (entries.length === 0) {
+    containerEl.createEl("p", { text: "No log entries yet.", cls: "setting-item-description" });
+    return;
+  }
+
+  const list = containerEl.createDiv({ cls: "geode-log-list" });
+  for (const entry of [...entries].reverse()) {
+    renderRow(list, entry);
+  }
+}
+
+// GeodeLogView renders geode's persisted log as a plain, most recent first list. Read only: it
+// has no way to write log entries, only display what the sink already recorded.
+export class GeodeLogView extends ItemView {
+  private sink: LogSink;
+
+  constructor(leaf: WorkspaceLeaf, sink: LogSink) {
+    super(leaf);
+    this.sink = sink;
+  }
+
+  getViewType(): string {
+    return LOG_VIEW_TYPE;
+  }
+
+  getDisplayText(): string {
+    return "Geode logs";
+  }
+
+  getIcon(): string {
+    return "scroll-text";
+  }
+
+  async onOpen(): Promise<void> {
+    this.addAction("refresh-cw", "Refresh", () => {
+      void this.refresh();
+    });
+    this.addAction("trash-2", "Clear", async () => {
+      await this.sink.clear();
+      await this.refresh();
+    });
+    await this.refresh();
+    this.registerInterval(window.setInterval(() => void this.refresh(), POLL_INTERVAL_MS));
+  }
+
+  // refresh re-reads the sink and redraws the pane.
+  private async refresh(): Promise<void> {
+    const entries = await this.sink.read();
+    renderLogView(this.contentEl, entries);
+  }
+}

--- a/src/log.test.ts
+++ b/src/log.test.ts
@@ -1,0 +1,167 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  createLogger,
+  createMemorySink,
+  formatLogLine,
+  type LogEntry,
+  levelEnabled,
+  parseLogLine,
+  trimLogLines,
+} from "./log.ts";
+
+test("formatLogLine and parseLogLine round trip", () => {
+  const entry: LogEntry = {
+    time: Date.parse("2026-07-14T10:00:00.000Z"),
+    level: "warn",
+    message: "disk nearly full",
+  };
+
+  const parsed = parseLogLine(formatLogLine(entry));
+
+  assert.deepEqual(parsed, entry);
+});
+
+test("parseLogLine preserves tabs inside the message", () => {
+  const entry: LogEntry = {
+    time: Date.parse("2026-07-14T10:00:00.000Z"),
+    level: "info",
+    message: "a\tb",
+  };
+
+  const parsed = parseLogLine(formatLogLine(entry));
+
+  assert.deepEqual(parsed, entry);
+});
+
+const malformedLines = [
+  "",
+  "not a log line",
+  "2026-07-14T10:00:00.000Z\tinfo",
+  "garbage\tinfo\thello",
+];
+
+for (const line of malformedLines) {
+  test(`parseLogLine: rejects malformed line ${JSON.stringify(line)}`, () => {
+    assert.equal(parseLogLine(line), undefined);
+  });
+}
+
+test("trimLogLines keeps only the last maxLines lines", () => {
+  const text = ["a", "b", "c", "d", "e"].join("\n");
+
+  assert.equal(trimLogLines(text, 2), "d\ne\n");
+});
+
+test("trimLogLines is a no-op when under the limit", () => {
+  const text = ["a", "b"].join("\n");
+
+  assert.equal(trimLogLines(text, 5), "a\nb\n");
+});
+
+test("trimLogLines preserves the trailing newline appending relies on", () => {
+  const text = "a\nb\nc\n";
+
+  assert.equal(trimLogLines(text, 2), "b\nc\n");
+});
+
+test("trimLogLines of an already empty log stays empty", () => {
+  assert.equal(trimLogLines("", 5), "");
+});
+
+test("a line appended after trimLogLines still parses on its own, not merged into the last kept line", () => {
+  const a: LogEntry = { time: 1, level: "info", message: "a" };
+  const b: LogEntry = { time: 2, level: "info", message: "b" };
+  const c: LogEntry = { time: 3, level: "info", message: "c" };
+  const beforeCompaction = `${formatLogLine(a)}\n${formatLogLine(b)}\n`;
+
+  const compacted = trimLogLines(beforeCompaction, 1);
+  const appended = `${compacted}${formatLogLine(c)}\n`;
+
+  const parsedLines: (LogEntry | undefined)[] = [];
+  for (const line of appended.split("\n")) {
+    if (line !== "") {
+      parsedLines.push(parseLogLine(line));
+    }
+  }
+  assert.deepEqual(parsedLines, [b, c]);
+});
+
+const levelEnabledCases: {
+  level: "debug" | "info" | "warn" | "error";
+  minLevel: "debug" | "info" | "warn" | "error";
+  want: boolean;
+}[] = [
+  { level: "debug", minLevel: "info", want: false },
+  { level: "info", minLevel: "info", want: true },
+  { level: "error", minLevel: "debug", want: true },
+  { level: "warn", minLevel: "error", want: false },
+];
+
+for (const { level, minLevel, want } of levelEnabledCases) {
+  test(`levelEnabled: ${level} at minimum ${minLevel}`, () => {
+    assert.equal(levelEnabled(level, minLevel), want);
+  });
+}
+
+test("createMemorySink: append then read returns entries in order", async () => {
+  const sink = createMemorySink(10);
+
+  await sink.append({ time: 1, level: "info", message: "first" });
+  await sink.append({ time: 2, level: "warn", message: "second" });
+
+  assert.deepEqual(await sink.read(), [
+    { time: 1, level: "info", message: "first" },
+    { time: 2, level: "warn", message: "second" },
+  ]);
+});
+
+test("createMemorySink: caps at maxLines, dropping the oldest", async () => {
+  const sink = createMemorySink(2);
+
+  await sink.append({ time: 1, level: "info", message: "first" });
+  await sink.append({ time: 2, level: "info", message: "second" });
+  await sink.append({ time: 3, level: "info", message: "third" });
+
+  assert.deepEqual(await sink.read(), [
+    { time: 2, level: "info", message: "second" },
+    { time: 3, level: "info", message: "third" },
+  ]);
+});
+
+test("createMemorySink: clear empties the log", async () => {
+  const sink = createMemorySink(10);
+  await sink.append({ time: 1, level: "info", message: "first" });
+
+  await sink.clear();
+
+  assert.deepEqual(await sink.read(), []);
+});
+
+test("createLogger: messages below minLevel are not persisted", async () => {
+  const sink = createMemorySink(10);
+  const logger = createLogger(sink, "warn");
+
+  logger.debug("noisy");
+  logger.info("still noisy");
+  logger.warn("worth keeping");
+
+  const messages: string[] = [];
+  for (const entry of await sink.read()) {
+    messages.push(entry.message);
+  }
+  assert.deepEqual(messages, ["worth keeping"]);
+});
+
+test("createLogger: debug messages persist once minLevel is debug", async () => {
+  const sink = createMemorySink(10);
+  const logger = createLogger(sink, "debug");
+
+  logger.debug("verbose detail");
+
+  const messages: string[] = [];
+  for (const entry of await sink.read()) {
+    messages.push(entry.message);
+  }
+  assert.deepEqual(messages, ["verbose detail"]);
+});

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,0 +1,137 @@
+// LogLevel orders from least to most severe.
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+// LogEntry is one line of geode's log.
+export type LogEntry = {
+  time: number;
+  level: LogLevel;
+  message: string;
+};
+
+// LogSink persists log entries and reads them back. The real implementation writes to a capped
+// file inside the plugin's own data directory (see log-adapter.ts); tests, and the fallback used
+// when there's nowhere to persist to, use an in-memory sink (see createMemorySink below).
+export type LogSink = {
+  append: (entry: LogEntry) => Promise<void>;
+  read: () => Promise<LogEntry[]>;
+  clear: () => Promise<void>;
+};
+
+// Logger is the interface the rest of the plugin logs through.
+export type Logger = {
+  debug: (message: string) => void;
+  info: (message: string) => void;
+  warn: (message: string) => void;
+  error: (message: string) => void;
+};
+
+const LEVEL_ORDER: Record<LogLevel, number> = { debug: 0, info: 1, warn: 2, error: 3 };
+
+// levelEnabled reports whether a message at level should be logged when the minimum is minLevel.
+export function levelEnabled(level: LogLevel, minLevel: LogLevel): boolean {
+  return LEVEL_ORDER[level] >= LEVEL_ORDER[minLevel];
+}
+
+function isLogLevel(value: string): value is LogLevel {
+  return value === "debug" || value === "info" || value === "warn" || value === "error";
+}
+
+// formatLogLine renders one entry as a single persisted line: an ISO timestamp, the level, then
+// the message, tab separated so parseLogLine can split on the same delimiter without tripping
+// over spaces in either the level or the message.
+export function formatLogLine(entry: LogEntry): string {
+  return `${new Date(entry.time).toISOString()}\t${entry.level}\t${entry.message}`;
+}
+
+// parseLogLine reverses formatLogLine. A malformed line (a corrupt or truncated file) is dropped
+// rather than thrown, consistent with how state.json failures fail open elsewhere.
+export function parseLogLine(line: string): LogEntry | undefined {
+  const [rawTime, rawLevel, ...rest] = line.split("\t");
+  if (rawTime === undefined || rawLevel === undefined || rest.length === 0) {
+    return undefined;
+  }
+  const time = Date.parse(rawTime);
+  if (Number.isNaN(time) || !isLogLevel(rawLevel)) {
+    return undefined;
+  }
+  return { time, level: rawLevel, message: rest.join("\t") };
+}
+
+// linesOf splits a log's text into its lines. Every persisted line ends in "\n", so a naive split
+// leaves one trailing empty element; drop only that one rather than filtering every blank line
+// generically, so a line that was genuinely empty for some other reason is never silently eaten.
+function linesOf(text: string): string[] {
+  if (text === "") {
+    return [];
+  }
+  const parts = text.split("\n");
+  if (parts[parts.length - 1] === "") {
+    return parts.slice(0, -1);
+  }
+  return parts;
+}
+
+// trimLogLines keeps only the last maxLines lines of a log, dropping the oldest. The result keeps
+// the same trailing newline the input had: appending assumes the file already ends in one, and
+// dropping it here would glue the next appended line onto the last one still kept.
+export function trimLogLines(text: string, maxLines: number): string {
+  const lines = linesOf(text);
+  let kept = lines;
+  if (lines.length > maxLines) {
+    kept = lines.slice(lines.length - maxLines);
+  }
+  if (kept.length === 0) {
+    return "";
+  }
+  return `${kept.join("\n")}\n`;
+}
+
+// createMemorySink returns a LogSink backed by an in-memory array, capped at maxLines. Used as
+// the fallback logger when there's nowhere to persist to, and as the fake sink in tests.
+export function createMemorySink(maxLines: number): LogSink {
+  let entries: LogEntry[] = [];
+
+  return {
+    append: async (entry) => {
+      entries.push(entry);
+      if (entries.length > maxLines) {
+        entries = entries.slice(entries.length - maxLines);
+      }
+    },
+    read: async () => [...entries],
+    clear: async () => {
+      entries = [];
+    },
+  };
+}
+
+// consoleFor returns the console method matching level, so console and persisted output agree on
+// severity.
+function consoleFor(level: LogLevel): (message: string) => void {
+  if (level === "warn") {
+    return (message) => console.warn(message);
+  }
+  if (level === "error") {
+    return (message) => console.error(message);
+  }
+  return (message) => console.log(message);
+}
+
+// createLogger returns a Logger that mirrors every message to the console and persists it via
+// sink, both gated by the same minLevel.
+export function createLogger(sink: LogSink, minLevel: LogLevel): Logger {
+  const log = (level: LogLevel, message: string) => {
+    if (!levelEnabled(level, minLevel)) {
+      return;
+    }
+    consoleFor(level)(`geode: ${message}`);
+    void sink.append({ time: Date.now(), level, message });
+  };
+
+  return {
+    debug: (message) => log("debug", message),
+    info: (message) => log("info", message),
+    warn: (message) => log("warn", message),
+    error: (message) => log("error", message),
+  };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,8 @@
+import type { App } from "obsidian";
 import { Plugin } from "obsidian";
+import { createLogger, type Logger, type LogSink } from "./log";
+import { createLogSink } from "./log-adapter";
+import { GeodeLogView, LOG_VIEW_TYPE } from "./log-view";
 import { DEFAULT_SETTINGS, type GeodeSettings, normalizeSettings } from "./settings";
 import { GeodeSettingTab } from "./settings-tab";
 import { createObsidianStateStore, createObsidianVaultReader } from "./vault-adapter";
@@ -8,15 +12,50 @@ import { diffSnapshots, takeSnapshot } from "./vault-state";
 // edits (autosave, bulk rename, etc.) collapses into one snapshot instead of one per file.
 const VAULT_STATE_DEBOUNCE_MS = 2000;
 
+// MAX_LOG_LINES caps how many lines geode.log keeps on disk, so a long running session can't
+// grow it unbounded.
+const MAX_LOG_LINES = 500;
+
+// LOG_MIN_LEVEL is fixed rather than user configurable: there's no meaningful "quiet" mode to
+// offer today, so a verbosity setting would be a toggle with no observable effect.
+const LOG_MIN_LEVEL = "debug";
+
+// AppWithSetting adds Obsidian's internal, undocumented settings-window API (there is no public
+// equivalent) so the Settings command can jump straight to Geode's tab, and opening the log view
+// can close the settings modal out from under itself.
+type AppWithSetting = App & {
+  setting: { open: () => void; close: () => void; openTabById: (id: string) => void };
+};
+
 // GeodePlugin is the Obsidian plugin entry point that owns settings load and save.
 export default class GeodePlugin extends Plugin {
   settings: GeodeSettings = DEFAULT_SETTINGS;
+  // Both are assigned in onload, which Obsidian always runs before any other plugin method.
+  logger!: Logger;
+  private logSink!: LogSink;
   private refreshTimer: number | undefined;
 
   async onload() {
     await this.loadSettings();
+
+    this.logSink = createLogSink(this.app.vault.adapter, this.manifest.dir, MAX_LOG_LINES);
+    this.logger = createLogger(this.logSink, LOG_MIN_LEVEL);
+
+    this.registerView(LOG_VIEW_TYPE, (leaf) => new GeodeLogView(leaf, this.logSink));
+    this.addCommand({
+      id: "logs",
+      name: "Logs",
+      callback: () => void this.openLogView(),
+    });
+    this.addCommand({
+      id: "settings",
+      name: "Settings",
+      callback: () => this.openSettingsTab(),
+    });
+    this.register(() => this.app.workspace.detachLeavesOfType(LOG_VIEW_TYPE));
+
     this.addSettingTab(new GeodeSettingTab(this.app, this));
-    console.log(`geode: loaded (provider=${this.settings.provider})`);
+    this.logger.info(`loaded (provider=${this.settings.provider})`);
 
     // onLayoutReady, not onload directly: the vault isn't guaranteed fully indexed yet at
     // onload time, and a snapshot taken too early would see an incomplete file list.
@@ -36,13 +75,40 @@ export default class GeodePlugin extends Plugin {
     });
   }
 
+  // openLogView reveals the existing log leaf if one is already open, otherwise creates one in
+  // the right sidebar. The settings window is a modal sitting on top of the whole app, so
+  // revealing a leaf underneath it does nothing visible until it's closed first.
+  async openLogView(): Promise<void> {
+    (this.app as AppWithSetting).setting.close();
+
+    const existing = this.app.workspace.getLeavesOfType(LOG_VIEW_TYPE);
+    if (existing.length > 0) {
+      this.app.workspace.revealLeaf(existing[0]);
+      return;
+    }
+
+    const leaf = this.app.workspace.getRightLeaf(false);
+    if (leaf === null) {
+      return;
+    }
+    await leaf.setViewState({ type: LOG_VIEW_TYPE, active: true });
+    this.app.workspace.revealLeaf(leaf);
+  }
+
+  // openSettingsTab opens Obsidian's settings window directly on Geode's tab.
+  openSettingsTab(): void {
+    const app = this.app as AppWithSetting;
+    app.setting.open();
+    app.setting.openTabById(this.manifest.id);
+  }
+
   async loadSettings() {
     this.settings = normalizeSettings(await this.loadData());
   }
 
   async saveSettings() {
     await this.saveData(this.settings);
-    console.log("geode: settings saved");
+    this.logger.info("settings saved");
   }
 
   // scheduleVaultStateRefresh debounces refreshVaultState so a burst of vault events collapses
@@ -72,7 +138,7 @@ export default class GeodePlugin extends Plugin {
     const current = await takeSnapshot(reader, previous);
     const changes = diffSnapshots(previous, current);
 
-    console.log(`geode: vault state refreshed (${changes.length} change(s) since last run)`);
+    this.logger.info(`vault state refreshed (${changes.length} change(s) since last run)`);
     await store.write(current);
   }
 }

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -313,9 +313,18 @@ function renderSupportSection(tab: GeodeSettingTab, containerEl: HTMLElement): v
           await navigator.clipboard.writeText("help@geodemd.com");
           flashButtonText(button, "Copy", "Copied");
         } catch (err) {
-          console.error("geode: could not copy support email:", err);
+          tab.plugin.logger.error(`could not copy support email: ${err}`);
           flashButtonText(button, "Copy", "Failed");
         }
+      }),
+    );
+
+  new Setting(card)
+    .setName("Logs")
+    .setDesc("What geode has done, most recent first.")
+    .addButton((button) =>
+      button.setButtonText("View").onClick(() => {
+        void tab.plugin.openLogView();
       }),
     );
 
@@ -331,7 +340,7 @@ function renderSupportSection(tab: GeodeSettingTab, containerEl: HTMLElement): v
         await navigator.clipboard.writeText(debugInfoText(tab));
         flashButtonText(button, "Copy", "Copied");
       } catch (err) {
-        console.error("geode: could not copy debugging info:", err);
+        tab.plugin.logger.error(`could not copy debugging info: ${err}`);
         flashButtonText(button, "Copy", "Failed");
       }
     });
@@ -423,15 +432,15 @@ export class GeodeSettingTab extends PluginSettingTab {
   }
 
   async save(): Promise<void> {
-    console.log(`geode: saving settings (provider=${this.draft.provider})`);
+    this.plugin.logger.info(`saving settings (provider=${this.draft.provider})`);
     this.plugin.settings = { ...this.draft };
     await this.plugin.saveSettings();
     this.refreshActionsUI();
   }
 
   async checkConnection(): Promise<void> {
-    console.log(
-      `geode: testing connection (provider=${this.draft.provider}, bucket=${this.draft.bucket})`,
+    this.plugin.logger.info(
+      `testing connection (provider=${this.draft.provider}, bucket=${this.draft.bucket})`,
     );
     this.connectionStatus = "checking";
     this.connectionMessage = "";
@@ -439,13 +448,13 @@ export class GeodeSettingTab extends PluginSettingTab {
 
     const secretAccessKey = this.app.secretStorage.getSecret(this.draft.secretId) ?? "";
     if (secretAccessKey === "") {
-      console.warn(`geode: no secret found for ID "${this.draft.secretId}"`);
+      this.plugin.logger.warn(`no secret found for ID "${this.draft.secretId}"`);
     }
 
     const result = await testConnection(this.draft, secretAccessKey);
 
     if (result.ok) {
-      console.log("geode: connection ok");
+      this.plugin.logger.info("connection ok");
       this.connectionStatus = "ok";
       this.refreshActionsUI();
       return;
@@ -453,7 +462,7 @@ export class GeodeSettingTab extends PluginSettingTab {
 
     this.connectionStatus = "error";
     this.connectionMessage = result.message;
-    console.error("geode: connection test failed:", result.message);
+    this.plugin.logger.error(`connection test failed: ${result.message}`);
     this.refreshActionsUI();
   }
 }

--- a/src/storage.itest.ts
+++ b/src/storage.itest.ts
@@ -61,7 +61,11 @@ test("listObjects returns only keys under the given prefix", async () => {
 
   const result = await client.listObjects("list-test/");
   assert.equal(result.ok, true);
-  const keys = result.objects.map((object) => object.key).sort();
+  const keys: string[] = [];
+  for (const object of result.objects) {
+    keys.push(object.key);
+  }
+  keys.sort();
   assert.deepEqual(keys, ["list-test/a.md", "list-test/b.md"]);
 });
 
@@ -71,5 +75,12 @@ test("listObjects with no prefix returns everything", async () => {
 
   const result = await client.listObjects();
   assert.equal(result.ok, true);
-  assert.ok(result.objects.some((object) => object.key === "unprefixed.md"));
+  let found = false;
+  for (const object of result.objects) {
+    if (object.key === "unprefixed.md") {
+      found = true;
+      break;
+    }
+  }
+  assert.ok(found);
 });

--- a/src/vault-adapter.ts
+++ b/src/vault-adapter.ts
@@ -1,5 +1,5 @@
 import type { DataAdapter, Vault } from "obsidian";
-import type { StateStore, VaultReader, VaultSnapshot } from "./vault-state.ts";
+import type { StateStore, VaultFile, VaultReader, VaultSnapshot } from "./vault-state.ts";
 
 // createObsidianVaultReader returns a VaultReader backed by the real vault's file tree. Obsidian
 // already excludes .obsidian/** from Vault.getFiles(), so the plugin's own state file (which
@@ -7,11 +7,11 @@ import type { StateStore, VaultReader, VaultSnapshot } from "./vault-state.ts";
 export function createObsidianVaultReader(vault: Vault): VaultReader {
   return {
     listFiles: async () => {
-      return vault.getFiles().map((file) => ({
-        path: file.path,
-        size: file.stat.size,
-        mtime: file.stat.mtime,
-      }));
+      const files: VaultFile[] = [];
+      for (const file of vault.getFiles()) {
+        files.push({ path: file.path, size: file.stat.size, mtime: file.stat.mtime });
+      }
+      return files;
     },
     readFile: async (path) => {
       const file = vault.getFileByPath(path);

--- a/src/vault-state.ts
+++ b/src/vault-state.ts
@@ -43,9 +43,21 @@ async function hashBytes(data: Uint8Array): Promise<string> {
   // Same TS/DOM lib generic mismatch as storage.ts's BodyInit cast: Uint8Array<ArrayBufferLike>
   // vs BufferSource's stricter ArrayBuffer expectation. Not a real runtime issue.
   const digest = await crypto.subtle.digest("SHA-256", data as BufferSource);
-  return Array.from(new Uint8Array(digest))
-    .map((byte) => byte.toString(16).padStart(2, "0"))
-    .join("");
+  let hex = "";
+  for (const byte of new Uint8Array(digest)) {
+    hex += byte.toString(16).padStart(2, "0");
+  }
+  return hex;
+}
+
+// byPath builds a lookup from path to file state, for matching a live file against what the
+// previous snapshot last saw at that same path.
+function byPath(files: FileState[]): Map<string, FileState> {
+  const result = new Map<string, FileState>();
+  for (const file of files) {
+    result.set(file.path, file);
+  }
+  return result;
 }
 
 // takeSnapshot walks every file the reader currently sees and returns their content hashes. A
@@ -57,27 +69,35 @@ export async function takeSnapshot(
   reader: VaultReader,
   previous: VaultSnapshot,
 ): Promise<VaultSnapshot> {
-  const previousByPath = new Map(previous.files.map((file) => [file.path, file]));
+  const previousByPath = byPath(previous.files);
   const liveFiles = await reader.listFiles();
 
-  const files = await Promise.all(
-    liveFiles.map(async (file) => {
-      const known = previousByPath.get(file.path);
-      if (known !== undefined && known.size === file.size && known.mtime === file.mtime) {
-        return known;
-      }
-      const bytes = await reader.readFile(file.path);
-      return { path: file.path, size: file.size, mtime: file.mtime, hash: await hashBytes(bytes) };
-    }),
-  );
+  const pending: Promise<FileState>[] = [];
+  for (const file of liveFiles) {
+    pending.push(
+      (async () => {
+        const known = previousByPath.get(file.path);
+        if (known !== undefined && known.size === file.size && known.mtime === file.mtime) {
+          return known;
+        }
+        const bytes = await reader.readFile(file.path);
+        return {
+          path: file.path,
+          size: file.size,
+          mtime: file.mtime,
+          hash: await hashBytes(bytes),
+        };
+      })(),
+    );
+  }
 
-  return { files };
+  return { files: await Promise.all(pending) };
 }
 
 // diffSnapshots compares two snapshots and reports every path whose content differs.
 export function diffSnapshots(previous: VaultSnapshot, current: VaultSnapshot): Change[] {
-  const previousByPath = new Map(previous.files.map((file) => [file.path, file]));
-  const currentByPath = new Map(current.files.map((file) => [file.path, file]));
+  const previousByPath = byPath(previous.files);
+  const currentByPath = byPath(current.files);
   const changes: Change[] = [];
 
   for (const file of current.files) {

--- a/styles.css
+++ b/styles.css
@@ -102,3 +102,60 @@
   margin: 1em 1em 1em 1em;
   overflow-x: auto;
 }
+
+.geode-log-view {
+  padding: 1em;
+}
+
+.geode-log-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25em;
+  font-family: var(--font-monospace);
+  font-size: 0.85em;
+}
+
+.geode-log-row {
+  display: flex;
+  gap: 0.75em;
+  align-items: baseline;
+  padding: 0.35em 0.5em;
+  border-radius: var(--radius-s, 4px);
+}
+
+.geode-log-row:nth-child(odd) {
+  background: var(--background-secondary);
+}
+
+.geode-log-time {
+  flex-shrink: 0;
+  white-space: nowrap;
+  color: var(--text-faint);
+}
+
+.geode-log-level {
+  flex-shrink: 0;
+  width: 4em;
+  font-weight: 700;
+}
+
+.geode-log-row.is-debug .geode-log-level {
+  color: var(--text-faint);
+}
+
+.geode-log-row.is-info .geode-log-level {
+  color: var(--text-muted);
+}
+
+.geode-log-row.is-warn .geode-log-level {
+  color: var(--text-warning);
+}
+
+.geode-log-row.is-error .geode-log-level {
+  color: var(--text-error);
+}
+
+.geode-log-message {
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}


### PR DESCRIPTION
Resolves [#31](https://github.com/8thpark/geode/issues/31)

## Problem

- Everything geode logs today only exists in the browser console, gone the moment devtools closes or Obsidian reloads
- There is no way to see what happened during a sync issue after the fact, or hand a log to support

## Changes

- Add a leveled logger (`debug`/`info`/`warn`/`error`) that mirrors every message to both the console and a capped `geode.log` file
- Persist the log via the vault adapter, appending cheaply and periodically compacting back down to a fixed line cap rather than rewriting the file on every entry
- Add a read only pane that lists log entries most recent first, colour coded by level, polling while open so it stays current
- Add `Geode: Logs` and `Geode: Settings` commands, and a `Logs` row in the settings tab's support section that opens the pane directly
- Replace remaining array combinator chains in `vault-state.ts`, `vault-adapter.ts`, and a storage integration test with explicit loops, matching the rest of the codebase

## Why

- A sync plugin needs a persistent record of what it did, matching the pattern used by comparable Obsidian sync plugins
- Console only logging is useless for diagnosing anything after the fact, especially on mobile where there is no devtools at all
- A capped, compacted file avoids unbounded growth while still keeping enough history to be useful