### PR TITLE
Contributing → Fix Windows and WSL dev vault setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,8 +67,8 @@ noise; `npm run audit` is the one that matches CI. `npm run format` applies Biom
 
 ## Testing locally
 
-Never point this at your real vault. Run `make create-dev-vault` instead, it creates `dev-vault/`
-inside this repo and symlinks the repo itself in as the plugin folder
+Never point this at your real vault. Run `npm run create-dev-vault` instead, it creates
+`dev-vault/` inside this repo and links the repo itself in as the plugin folder
 (`dev-vault/.obsidian/plugins/geode`). Safe to re-run any time.
 
 With `npm run dev` running:
@@ -86,6 +86,28 @@ Obsidian's plugin data file (`data.json`), geode's own vault state file (`state.
 log file (`geode.log`), all of which land at the repo root because the dev vault symlinks the
 whole repo in as the plugin folder, are gitignored and should never be committed. The MinIO
 container's data lives in a Docker volume, not a repo folder — `npm run dev:s3:reset` clears it.
+
+## Windows
+
+Clone the repo onto the Windows filesystem (`C:\...`, not a WSL path) and everything above just
+works: `npm run create-dev-vault` detects Windows and creates the plugin folder as an NTFS
+junction rather than a symlink, which needs neither Administrator rights nor Developer Mode
+enabled. Install [Docker Desktop](https://www.docker.com/products/docker-desktop) for the storage
+server, everything else in "Building" above is unchanged.
+
+## WSL
+
+WSL (Windows Subsystem for Linux) runs a real Linux environment alongside Windows, and it's a
+reasonable place to clone the repo, but keep the repo and Obsidian on the same side of that
+boundary. If the repo lives inside WSL, run Obsidian's Linux build inside WSL too (via
+[WSLg](https://github.com/microsoft/wslg), built into Windows 11), pointed at the native
+`/home/.../dev-vault` path.
+
+Don't open that same vault from a Windows native install of Obsidian over the
+`\\wsl.localhost\...` network share. Windows' client for that share has long standing trouble
+following symlinks created inside WSL's filesystem, so a Windows native Obsidian fails to load the
+plugin with an `ENOENT` on `dev-vault\.obsidian\plugins\geode`, even though the link is perfectly
+valid from the Linux side.
 
 ## License
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,0 @@
-.PHONY: create-dev-vault
-
-create-dev-vault:
-	mkdir -p dev-vault/.obsidian/plugins
-	ln -sfn $(CURDIR) dev-vault/.obsidian/plugins/geode

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint": "biome check .",
     "format": "biome check --write .",
     "check-versions": "node scripts/check-version-sync.mjs",
+    "create-dev-vault": "node scripts/create-dev-vault.mjs",
     "test": "node --test \"src/**/*.test.ts\"",
     "test:integration": "docker compose up -d minio && docker compose up create-bucket && node --test \"src/**/*.itest.ts\""
   },

--- a/scripts/create-dev-vault.mjs
+++ b/scripts/create-dev-vault.mjs
@@ -1,0 +1,28 @@
+import { lstatSync, mkdirSync, rmSync, symlinkSync } from "node:fs";
+import { resolve } from "node:path";
+
+const repoRoot = process.cwd();
+const pluginsDir = resolve(repoRoot, "dev-vault", ".obsidian", "plugins");
+const pluginLink = resolve(pluginsDir, "geode");
+
+function pathExists(path) {
+  try {
+    lstatSync(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+mkdirSync(pluginsDir, { recursive: true });
+
+if (pathExists(pluginLink)) {
+  rmSync(pluginLink, { recursive: true, force: true });
+}
+
+// A real symlink needs admin rights or Developer Mode enabled on Windows; a junction needs
+// neither and behaves the same for a directory link, so use one there instead.
+const linkType = process.platform === "win32" ? "junction" : "dir";
+symlinkSync(repoRoot, pluginLink, linkType);
+
+console.log(`dev vault ready: ${pluginLink} -> ${repoRoot}`);


### PR DESCRIPTION
Resolves [#47](https://github.com/8thpark/geode/issues/47)

## Problem

- A Windows contributor following the existing dev vault setup hit an `ENOENT` loading the plugin, caused by the `Makefile`'s symlink not resolving over the `\\wsl.localhost\...` network share
- The setup docs only ever covered macOS, leaving Windows and WSL contributors to guess at the rest

## Changes

- Replace the `Makefile` with a cross platform `npm run create-dev-vault` script that creates an NTFS junction on Windows instead of a symlink
- Split the dev vault setup notes into two separate guides in `CONTRIBUTING.md`, one for native Windows and one for WSL

## Why

- A junction needs neither Administrator rights nor Developer Mode enabled, so it sidesteps the underlying Windows limitation rather than just documenting around it
- A native Windows contributor and a WSL contributor each hit different constraints, one combined caveat was doing neither justice