### PR TITLE
fix: re-seed settings draft when the tab opens (#42)

### DIFF
--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -8,7 +8,13 @@ import {
   Setting,
 } from "obsidian";
 import type GeodePlugin from "./main";
-import { type GeodeSettings, hasConnectionConfig, providerOr, settingsEqual } from "./settings";
+import {
+  draftForDisplay,
+  type GeodeSettings,
+  hasConnectionConfig,
+  providerOr,
+  settingsEqual,
+} from "./settings";
 import { testConnection } from "./storage";
 
 // ConnectionStatus is the last known state of a Test Connection check. It lives only in memory;
@@ -372,9 +378,19 @@ export class GeodeSettingTab extends PluginSettingTab {
   }
 
   // display renders the tab. When auto is true (every time Obsidian opens this tab, including
-  // the first time) it also fires an automatic connection test if the draft looks complete;
-  // internal re-renders (a provider switch) pass false so they don't retrigger it.
+  // the first time) it re-seeds the draft from live plugin settings, then fires an automatic
+  // connection test if the draft looks complete. Internal re-renders (a provider switch) pass
+  // false so they keep the in-progress draft and don't retrigger the connection test.
   display(auto = true): void {
+    // Constructor only runs once for the life of this tab instance. Without re-seeding here,
+    // a reopened tab keeps a stale draft after settings change elsewhere (e.g. data.json via
+    // sync) and can show phantom "Unsaved changes" against the newer saved settings.
+    this.draft = draftForDisplay(auto, this.draft, this.plugin.settings);
+    if (auto) {
+      this.connectionStatus = "unknown";
+      this.connectionMessage = "";
+    }
+
     this.containerEl.empty();
     renderSettingsTab(this, this.containerEl);
 

--- a/src/settings.test.ts
+++ b/src/settings.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
   DEFAULT_SETTINGS,
+  draftForDisplay,
   endpointFor,
   type GeodeSettings,
   hasConnectionConfig,
@@ -219,3 +220,61 @@ for (const { name, input, want } of hasConnectionConfigCases) {
     assert.strictEqual(hasConnectionConfig(input), want);
   });
 }
+
+const draftForDisplayCases: {
+  name: string;
+  auto: boolean;
+  currentDraft: GeodeSettings;
+  savedSettings: GeodeSettings;
+  want: GeodeSettings;
+}[] = [
+  {
+    name: "auto open re-seeds from saved settings after external update",
+    auto: true,
+    currentDraft: { ...DEFAULT_SETTINGS, bucket: "stale-bucket" },
+    savedSettings: { ...DEFAULT_SETTINGS, bucket: "synced-bucket" },
+    want: { ...DEFAULT_SETTINGS, bucket: "synced-bucket" },
+  },
+  {
+    name: "auto open clears a phantom dirty draft against newer saved settings",
+    auto: true,
+    currentDraft: { ...DEFAULT_SETTINGS, accessKeyId: "OLD" },
+    savedSettings: { ...DEFAULT_SETTINGS, accessKeyId: "NEW" },
+    want: { ...DEFAULT_SETTINGS, accessKeyId: "NEW" },
+  },
+  {
+    name: "internal re-render keeps the in-progress draft",
+    auto: false,
+    currentDraft: { ...DEFAULT_SETTINGS, provider: "custom", endpoint: "https://s3.example.com" },
+    savedSettings: DEFAULT_SETTINGS,
+    want: { ...DEFAULT_SETTINGS, provider: "custom", endpoint: "https://s3.example.com" },
+  },
+  {
+    name: "auto open returns a shallow copy, not the saved settings object itself",
+    auto: true,
+    currentDraft: DEFAULT_SETTINGS,
+    savedSettings: { ...DEFAULT_SETTINGS, bucket: "b" },
+    want: { ...DEFAULT_SETTINGS, bucket: "b" },
+  },
+];
+
+for (const { name, auto, currentDraft, savedSettings, want } of draftForDisplayCases) {
+  test(`draftForDisplay: ${name}`, () => {
+    const got = draftForDisplay(auto, currentDraft, savedSettings);
+    assert.deepStrictEqual(got, want);
+  });
+}
+
+test("draftForDisplay: auto open returns a new object so later draft edits do not mutate saved settings", () => {
+  const saved = { ...DEFAULT_SETTINGS, bucket: "saved" };
+  const got = draftForDisplay(true, DEFAULT_SETTINGS, saved);
+  assert.notStrictEqual(got, saved);
+  got.bucket = "edited";
+  assert.strictEqual(saved.bucket, "saved");
+});
+
+test("draftForDisplay: internal re-render returns the same draft reference", () => {
+  const draft = { ...DEFAULT_SETTINGS, bucket: "in-progress" };
+  const got = draftForDisplay(false, draft, DEFAULT_SETTINGS);
+  assert.strictEqual(got, draft);
+});

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -107,3 +107,19 @@ export function hasConnectionConfig(settings: GeodeSettings): boolean {
   }
   return settings.endpoint !== "" && settings.region !== "";
 }
+
+// draftForDisplay returns the draft a settings tab should show for a given render.
+// When auto is true (Obsidian is opening the tab), the draft is re-seeded from saved
+// settings so an external data.json update cannot leave a stale draft and phantom
+// "Unsaved changes". When auto is false (an internal re-render such as a provider
+// switch), the in-progress draft is kept.
+export function draftForDisplay(
+  auto: boolean,
+  currentDraft: GeodeSettings,
+  savedSettings: GeodeSettings,
+): GeodeSettings {
+  if (auto) {
+    return { ...savedSettings };
+  }
+  return currentDraft;
+}


### PR DESCRIPTION
## Summary
- Re-seed `GeodeSettingTab.draft` from live plugin settings when the tab opens (`display(auto=true)`).
- Keep the in-progress draft on internal re-renders (provider switch).
- Add unit coverage for the pure `draftForDisplay` helper.

Fixes #42

## Test plan
- [x] `npm test` (42 pass)
- [x] `npm run lint`
- [x] `npm run build`
