### PR TITLE
refactor: use bounded concurrency on takeSnapshot function

### DIFF
--- a/src/vault-state.test.ts
+++ b/src/vault-state.test.ts
@@ -87,3 +87,41 @@ test("diffSnapshots: a file missing from the current listing is reported as dele
 
   assert.deepEqual(changes, [{ path: "note.md", kind: "deleted" }]);
 });
+
+test("takeSnapshot: concurrency is bounded by the limit", async () => {
+  const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+  const files: Record<string, { content: string; mtime: number }> = {};
+  for (let i = 0; i < 10; i++) {
+    files[`${i}.md`] = { content: `body ${i}`, mtime: 1 };
+  }
+
+  let inflight = 0;
+  let peakInflight = 0;
+  const reader: VaultReader = {
+    listFiles: async () => {
+      const list: VaultFile[] = [];
+      for (const [path, file] of Object.entries(files)) {
+        list.push({ path, size: file.content.length, mtime: file.mtime });
+      }
+      return list;
+    },
+    readFile: async (path) => {
+      inflight += 1;
+      if (inflight > peakInflight) {
+        peakInflight = inflight;
+      }
+      await delay(10);
+      inflight -= 1;
+      const file = files[path];
+      if (file === undefined) {
+        throw new Error(`no such file: ${path}`);
+      }
+      return new TextEncoder().encode(file.content);
+    },
+  };
+
+  const snapshot = await takeSnapshot(reader, empty, 2);
+
+  assert.equal(snapshot.files.length, 10);
+  assert.ok(peakInflight <= 2, `expected at most 2 concurrent reads, got ${peakInflight}`);
+});

--- a/src/vault-state.ts
+++ b/src/vault-state.ts
@@ -60,38 +60,58 @@ function byPath(files: FileState[]): Map<string, FileState> {
   return result;
 }
 
+// mapWithConcurrency runs fn over each item with at most limit concurrent invocations, preserving
+// input order in the returned results.
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let nextIndex = 0;
+
+  async function worker(): Promise<void> {
+    while (nextIndex < items.length) {
+      const currentIndex = nextIndex++;
+      results[currentIndex] = await fn(items[currentIndex]);
+    }
+  }
+
+  const workers = Array.from({ length: Math.min(limit, items.length) }, worker);
+  await Promise.all(workers);
+
+  return results;
+}
+
 // takeSnapshot walks every file the reader currently sees and returns their content hashes. A
 // file whose size and mtime both match the previous snapshot reuses that hash instead of
 // rereading content — the same stat gated hashing rsync, git, and Syncthing all use, since mtime
 // and size alone aren't reliable enough to trust as identity, but are cheap enough to skip a
-// rehash when neither has moved.
+// rehash when neither has moved. Concurrency is bounded by limit to avoid unbounded memory
+// pressure on large vaults.
 export async function takeSnapshot(
   reader: VaultReader,
   previous: VaultSnapshot,
+  concurrency = 8,
 ): Promise<VaultSnapshot> {
   const previousByPath = byPath(previous.files);
   const liveFiles = await reader.listFiles();
 
-  const pending: Promise<FileState>[] = [];
-  for (const file of liveFiles) {
-    pending.push(
-      (async () => {
-        const known = previousByPath.get(file.path);
-        if (known !== undefined && known.size === file.size && known.mtime === file.mtime) {
-          return known;
-        }
-        const bytes = await reader.readFile(file.path);
-        return {
-          path: file.path,
-          size: file.size,
-          mtime: file.mtime,
-          hash: await hashBytes(bytes),
-        };
-      })(),
-    );
-  }
+  const files = await mapWithConcurrency(liveFiles, concurrency, async (file) => {
+    const known = previousByPath.get(file.path);
+    if (known !== undefined && known.size === file.size && known.mtime === file.mtime) {
+      return known;
+    }
+    const bytes = await reader.readFile(file.path);
+    return {
+      path: file.path,
+      size: file.size,
+      mtime: file.mtime,
+      hash: await hashBytes(bytes),
+    };
+  });
 
-  return { files: await Promise.all(pending) };
+  return { files };
 }
 
 // diffSnapshots compares two snapshots and reports every path whose content differs.


### PR DESCRIPTION
resolves #38

## Problem
`takeSnapshot` in src/vault-state.ts uses one Promise.all over all changed files. On first run (or after state corruption resets to an empty snapshot) it reads and hashes the entire vault concurrently, buffering whole files in memory. On a large vault that is a memory spike and a pile of simultaneous I/O; worse on mobile. Needs a small concurrency limit

## Changes 
src/vault-state.ts
- Add `mapWithConcurrency<T, R>`: a generic worker pool that processes items with at most limit concurrent async invocations while preserving input order in results. Spawns min(limit, items.length) workers that pull from a shared index.
- `takeSnapshot` gains an optional third parameter concurrency = 8. Replaces the unbounded for/Promise.all loop with a single `mapWithConcurrency`call. The default keeps existing callers (including main.ts) working without changes.

## Why
Now the`takeSnapshot` function is not going to eat as much memory compared to using promise.all() for all the file states, so for vaults with large files the difference in performance will be significant and better than the old unbounded way.