### PR TITLE
fix: encode object keys 

### DIFF
--- a/src/storage.itest.ts
+++ b/src/storage.itest.ts
@@ -84,3 +84,27 @@ test("listObjects with no prefix returns everything", async () => {
   }
   assert.ok(found);
 });
+
+test("putObject/getObject round-trips a key containing a space and ampersand", async () => {
+  const client = createS3Client(liveSettings, SECRET_ACCESS_KEY);
+  const body = new TextEncoder().encode("special chars");
+
+  const putResult = await client.putObject("encode-test/Foo & Bar.md", body);
+  assert.equal(putResult.ok, true);
+
+  const getResult = await client.getObject("encode-test/Foo & Bar.md");
+  assert.equal(getResult.ok, true);
+  assert.deepEqual(getResult.body, body);
+});
+
+test("putObject/getObject round-trips a key containing a hash and percent", async () => {
+  const client = createS3Client(liveSettings, SECRET_ACCESS_KEY);
+  const body = new TextEncoder().encode("edge cases");
+
+  const putResult = await client.putObject("encode-test/100% #special.md", body);
+  assert.equal(putResult.ok, true);
+
+  const getResult = await client.getObject("encode-test/100% #special.md");
+  assert.equal(getResult.ok, true);
+  assert.deepEqual(getResult.body, body);
+});

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -60,6 +60,15 @@ function messageFor(err: unknown): string {
   return "Network error";
 }
 
+// encodeKey percent-encodes each path segment of an S3 object key individually, preserving "/" as
+// the separator so keys like "notes/Foo & Bar.md" become "notes/Foo%20%26%20Bar.md".
+function encodeKey(key: string): string {
+  const segments = key.split("/");
+  const encodedSegments = segments.map((segment) => encodeURIComponent(segment));
+  const encodedKey = encodedSegments.join("/");
+  return encodedKey;
+}
+
 // missingFieldFor returns the name of the first field testConnection needs but doesn't have, or
 // "" if everything required is present.
 function missingFieldFor(settings: GeodeSettings, secretAccessKey: string): string {
@@ -118,7 +127,10 @@ async function s3PutObject(
   try {
     // Uint8Array<ArrayBufferLike> vs DOM's ArrayBufferView<ArrayBuffer> is a TS lib mismatch,
     // not a real runtime issue; every JS engine accepts a Uint8Array as a fetch body.
-    response = await client.fetch(`${baseUrl}/${key}`, { method: "PUT", body: body as BodyInit });
+    response = await client.fetch(`${baseUrl}/${encodeKey(key)}`, {
+      method: "PUT",
+      body: body as BodyInit,
+    });
   } catch (err) {
     return { ok: false, message: messageFor(err) };
   }
@@ -133,7 +145,7 @@ async function s3PutObject(
 async function s3GetObject(client: AwsClient, baseUrl: string, key: string): Promise<GetResult> {
   let response: Response;
   try {
-    response = await client.fetch(`${baseUrl}/${key}`, { method: "GET" });
+    response = await client.fetch(`${baseUrl}/${encodeKey(key)}`, { method: "GET" });
   } catch (err) {
     return { ok: false, message: messageFor(err), body: null };
   }
@@ -153,7 +165,7 @@ async function s3DeleteObject(
 ): Promise<DeleteResult> {
   let response: Response;
   try {
-    response = await client.fetch(`${baseUrl}/${key}`, { method: "DELETE" });
+    response = await client.fetch(`${baseUrl}/${encodeKey(key)}`, { method: "DELETE" });
   } catch (err) {
     return { ok: false, message: messageFor(err) };
   }


### PR DESCRIPTION
resolves #36 

## Problem

`s3PutObject`, `s3GetObject`, and `s3DeleteObject` interpolate keys into URLs unencoded (`${baseUrl}/${key}`). A filename containing `#` gets truncated at the fragment, `?` starts a query string, and a literal `%` can produce invalid escapes, so requests hit the wrong key or fail. This is inconsistent with `s3ListObjects`, which already encodes its prefix with `encodeURIComponent`.

## Changes

- Add module-private `encodeKey` helper that splits a key on `/`, encodes each segment with `encodeURIComponent`, and rejoins with `/`,  preserving path structure while escaping special characters within filenames.
- Update `s3PutObject`, `s3GetObject`, and `s3DeleteObject` to pass keys through `encodeKey` before building the request URL.
- Add two integration tests against live MinIO: one round-trips a key with space and ampersand (`Foo & Bar.md`), the other with percent and hash (`100% #special.md`).

## Why

Vault files aren't restricted to URL-safe characters, Obsidian lets users create notes with `#`, `?`, `%`, spaces, and `&` in their names. Without encoding, these keys silently corrupt the request URL or produce 404s. `s3ListObjects` already handled this correctly; the other three functions were the gap.