### PR TITLE
fix: move register event calls inside onLayoutReady

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -68,7 +68,6 @@ export default class GeodePlugin extends Plugin {
       this.registerEvent(this.app.vault.on("rename", () => this.scheduleVaultStateRefresh()));
     });
 
-
     this.register(() => {
       if (this.refreshTimer !== undefined) {
         window.clearTimeout(this.refreshTimer);

--- a/src/main.ts
+++ b/src/main.ts
@@ -61,12 +61,13 @@ export default class GeodePlugin extends Plugin {
     // onload time, and a snapshot taken too early would see an incomplete file list.
     this.app.workspace.onLayoutReady(() => {
       void this.refreshVaultState();
+
+      this.registerEvent(this.app.vault.on("create", () => this.scheduleVaultStateRefresh()));
+      this.registerEvent(this.app.vault.on("modify", () => this.scheduleVaultStateRefresh()));
+      this.registerEvent(this.app.vault.on("delete", () => this.scheduleVaultStateRefresh()));
+      this.registerEvent(this.app.vault.on("rename", () => this.scheduleVaultStateRefresh()));
     });
 
-    this.registerEvent(this.app.vault.on("create", () => this.scheduleVaultStateRefresh()));
-    this.registerEvent(this.app.vault.on("modify", () => this.scheduleVaultStateRefresh()));
-    this.registerEvent(this.app.vault.on("delete", () => this.scheduleVaultStateRefresh()));
-    this.registerEvent(this.app.vault.on("rename", () => this.scheduleVaultStateRefresh()));
 
     this.register(() => {
       if (this.refreshTimer !== undefined) {


### PR DESCRIPTION
resolves #44

## Problem
src/main.ts registers the vault create handler in onload. Obsidian fires create for every file during vault load, so startup schedules a redundant debounced refresh on top of the onLayoutReady one. The documented pattern is to register vault event handlers inside onLayoutReady.

## Changes
move the event handlers inside the `onLayoutReady` callback

# Why
This is the documented pattern and also we do not want to fire these register vault event handlers for every file.