### PR TITLE
fix: discard stale checkConnection results with a generation counter

### DIFF
--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -367,6 +367,9 @@ export class GeodeSettingTab extends PluginSettingTab {
   draft: GeodeSettings;
   connectionStatus: ConnectionStatus = "unknown";
   connectionMessage = "";
+  // checkId is incremented on every checkConnection call so a stale response
+  // that resolves after a newer one has already started can be discarded.
+  checkId = 0;
   saveButtonEl: ButtonComponent | null = null;
   statusDotEl: HTMLElement | null = null;
   connectionMessageEl: HTMLElement | null = null;
@@ -455,6 +458,9 @@ export class GeodeSettingTab extends PluginSettingTab {
   }
 
   async checkConnection(): Promise<void> {
+    this.checkId += 1;
+    const id = this.checkId;
+
     this.plugin.logger.info(
       `testing connection (provider=${this.draft.provider}, bucket=${this.draft.bucket})`,
     );
@@ -468,6 +474,10 @@ export class GeodeSettingTab extends PluginSettingTab {
     }
 
     const result = await testConnection(this.draft, secretAccessKey);
+
+    if (id !== this.checkId) {
+      return;
+    }
 
     if (result.ok) {
       this.plugin.logger.info("connection ok");


### PR DESCRIPTION
Fixes #43

## What was the bug?

Rapid "Test" clicks, or the automatic check on tab open racing a manual
click, ran `checkConnection` concurrently. There was no guard after the
`await`, so whichever promise settled last would overwrite the UI status —
even if it was the older/staler request.

## Fix

Added a `checkId` generation counter on `GeodeSettingTab`.

- Incremented at the **start** of every `checkConnection` call
- Captured into a local `id` variable before the `await`
- After `await testConnection(...)` resolves, if `id !== this.checkId` a
  newer call has started — the stale result is silently discarded

## Testing

- All 57 existing tests pass (`npm test`)
- TypeScript compiles cleanly (`tsc -noEmit`)
