### PR TITLE
Ignore agent skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@ main.js
 .idea/
 .vscode/
 *.swp
+
+# Agent skills
+.agents/
+plans/
+skills-lock.json


### PR DESCRIPTION
Ignore the following, so that contributors can use local skills as they like:

- `.agents/`
- `plans/`
- `skills-lock.json`