### PR TITLE
Storage → Drop dead branch in HTTP status mapping

### DIFF
--- a/src/utils/storage/errors.ts
+++ b/src/utils/storage/errors.ts
@@ -8,9 +8,8 @@ export function messageFor(err: unknown): string {
   return "Network error";
 }
 
-// statusForHttp maps an HTTP status code to a ResultStatus. Anything that isn't a recognised 404
-// or auth failure (including 5xx and unclassified 4xx such as 429) falls through to "server",
-// which callers treat as retryable.
+// statusForHttp maps an HTTP status code to a ResultStatus; unrecognised codes (including 5xx and
+// stray 4xx such as 429) fall through to "server", which callers treat as retryable.
 export function statusForHttp(code: number): ResultStatus {
   if (code === 404) {
     return "not_found";

--- a/src/utils/storage/errors.ts
+++ b/src/utils/storage/errors.ts
@@ -8,16 +8,15 @@ export function messageFor(err: unknown): string {
   return "Network error";
 }
 
-// statusForHttp maps an HTTP status code to a ResultStatus.
+// statusForHttp maps an HTTP status code to a ResultStatus. Anything that isn't a recognised 404
+// or auth failure (including 5xx and unclassified 4xx such as 429) falls through to "server",
+// which callers treat as retryable.
 export function statusForHttp(code: number): ResultStatus {
   if (code === 404) {
     return "not_found";
   }
   if (code === 403 || code === 401) {
     return "auth";
-  }
-  if (code >= 500) {
-    return "server";
   }
   return "server";
 }


### PR DESCRIPTION
## Problem

- `statusForHttp` carried a `code >= 500` branch returning `"server"`, identical to the fallback below it, so the guard could never change the outcome
- The redundant branch was flagged independently by two reviewers on the parent change

## Changes

- Remove the dead `code >= 500` guard and let the fallback handle those codes
- Document that unclassified codes, including `5xx` and stray `4xx` such as `429`, deliberately map to `"server"` and are treated as retryable

## Why

- Dead code that reviewers keep noticing is cheaper to delete once than to re-explain
- The fallback was silently load bearing, so naming the intent stops someone re-adding the guard as a well meaning fix

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes the dead `if (code >= 500) return "server"` branch from `statusForHttp`, whose return value was always shadowed by the identical unconditional fallback on the line after it. The updated doc comment now explicitly names the fallback's intent so no one re-adds the guard as a well-meaning fix.

- The only runtime behavior is the deletion of three unreachable lines; callers see no change.
- The revised comment documents that unrecognised codes — `5xx`, `429`, and any other stray `4xx` — deliberately resolve to `"server"` and are treated as retryable.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the deletion is unreachable code and the fallback behaviour is identical before and after.

The removed branch and the fallback both returned "server" unconditionally, so no code path through `statusForHttp` can produce a different result after this change. The doc comment expansion is the only substantive addition, and it accurately reflects the existing behaviour.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/utils/storage/errors.ts | Removes dead `code >= 500` guard whose return value was identical to the unconditional fallback; expands the doc comment to document the fallback's intent. Behavior is completely unchanged. |

<sub>Reviews (2): Last reviewed commit: ["Update comment"](https://github.com/8thpark/geode/commit/81d9164425f11e5b01a31065a2e89e5636e89c27) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45340721)</sub>

<!-- /greptile_comment -->