### PR TITLE
Storage → Page past the 1,000 key list cap

### DIFF
--- a/src/storage.itest.ts
+++ b/src/storage.itest.ts
@@ -114,6 +114,16 @@ test("listObjects pages past the 1,000 key response cap", async () => {
   assert.equal(result.ok, true);
   assert.equal(result.status, "ok");
   assert.equal(result.objects.length, total);
+
+  // Leave the bucket as we found it. Same bounded fan-out as the setup so cleanup does not open
+  // 1,001 concurrent sockets.
+  for (let start = 0; start < total; start += limit) {
+    const batch: Promise<unknown>[] = [];
+    for (let i = start; i < Math.min(start + limit, total); i++) {
+      batch.push(client.deleteObject(`${prefix}${String(i).padStart(4, "0")}.md`));
+    }
+    await Promise.all(batch);
+  }
 });
 
 test("putObject/getObject round-trips a key containing a space and ampersand", async () => {

--- a/src/storage.itest.ts
+++ b/src/storage.itest.ts
@@ -93,6 +93,29 @@ test("listObjects with no prefix returns everything", async () => {
   assert.ok(found);
 });
 
+test("listObjects pages past the 1,000 key response cap", async () => {
+  const client = createS3Client(liveSettings, SECRET_ACCESS_KEY);
+  const prefix = "paging-test/";
+  const total = 1001;
+
+  // One PUT per key would serialise 1,001 round trips; bound the fan-out instead so the setup
+  // stays quick without hammering MinIO with unlimited concurrent sockets.
+  const body = new TextEncoder().encode("p");
+  const limit = 32;
+  for (let start = 0; start < total; start += limit) {
+    const batch: Promise<unknown>[] = [];
+    for (let i = start; i < Math.min(start + limit, total); i++) {
+      batch.push(client.putObject(`${prefix}${String(i).padStart(4, "0")}.md`, body));
+    }
+    await Promise.all(batch);
+  }
+
+  const result = await client.listObjects(prefix);
+  assert.equal(result.ok, true);
+  assert.equal(result.status, "ok");
+  assert.equal(result.objects.length, total);
+});
+
 test("putObject/getObject round-trips a key containing a space and ampersand", async () => {
   const client = createS3Client(liveSettings, SECRET_ACCESS_KEY);
   const body = new TextEncoder().encode("special chars");

--- a/src/storage.test.ts
+++ b/src/storage.test.ts
@@ -54,8 +54,42 @@ test("parseListObjectsXml decodes XML entities in object keys", () => {
   </Contents>
 </ListBucketResult>`;
 
-  assert.deepEqual(parseListObjectsXml(xml), [
-    { key: "notes/Foo & Bar (draft).md", size: 12, lastModified: "2026-07-13T00:00:00.000Z" },
-    { key: "notes/2 < 3 😀.md", size: 34, lastModified: "2026-07-13T00:01:00.000Z" },
-  ]);
+  assert.deepEqual(parseListObjectsXml(xml), {
+    objects: [
+      { key: "notes/Foo & Bar (draft).md", size: 12, lastModified: "2026-07-13T00:00:00.000Z" },
+      { key: "notes/2 < 3 😀.md", size: 34, lastModified: "2026-07-13T00:01:00.000Z" },
+    ],
+    nextContinuationToken: undefined,
+  });
+});
+
+test("parseListObjectsXml surfaces the continuation token when the listing is truncated", () => {
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult>
+  <Contents>
+    <Key>notes/a.md</Key>
+    <LastModified>2026-07-13T00:00:00.000Z</LastModified>
+    <Size>1</Size>
+  </Contents>
+  <IsTruncated>true</IsTruncated>
+  <NextContinuationToken>1ueGcxLPRx1Tr/XYExHnhbYLgveDs2J/wm36Hy4vbOwM=</NextContinuationToken>
+</ListBucketResult>`;
+
+  const page = parseListObjectsXml(xml);
+  assert.equal(page.nextContinuationToken, "1ueGcxLPRx1Tr/XYExHnhbYLgveDs2J/wm36Hy4vbOwM=");
+  assert.equal(page.objects.length, 1);
+});
+
+test("parseListObjectsXml ignores the token on the final page", () => {
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult>
+  <Contents>
+    <Key>notes/a.md</Key>
+    <LastModified>2026-07-13T00:00:00.000Z</LastModified>
+    <Size>1</Size>
+  </Contents>
+  <IsTruncated>false</IsTruncated>
+</ListBucketResult>`;
+
+  assert.equal(parseListObjectsXml(xml).nextContinuationToken, undefined);
 });

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -188,34 +188,48 @@ async function s3DeleteObject(
   return { ok: true, status: "ok", message: "" };
 }
 
-// s3ListObjects lists objects in the bucket, optionally restricted to a key prefix.
+// s3ListObjects lists objects in the bucket, optionally restricted to a key prefix. S3 caps a
+// single response at 1,000 keys, so it follows NextContinuationToken until the listing is complete
+// and returns every key. Stopping early would make unlisted keys look like remote deletions.
 async function s3ListObjects(
   client: AwsClient,
   baseUrl: string,
   prefix: string | undefined,
 ): Promise<ListResult> {
-  let url = `${baseUrl}?list-type=2`;
-  if (prefix !== undefined && prefix !== "") {
-    url += `&prefix=${encodeURIComponent(prefix)}`;
-  }
+  const objects: ObjectMeta[] = [];
+  let continuationToken: string | undefined;
 
-  let response: Response;
-  try {
-    response = await client.fetch(url, { method: "GET" });
-  } catch (err) {
-    return { ok: false, status: "network", message: messageFor(err), objects: [] };
-  }
+  do {
+    let url = `${baseUrl}?list-type=2`;
+    if (prefix !== undefined && prefix !== "") {
+      url += `&prefix=${encodeURIComponent(prefix)}`;
+    }
+    if (continuationToken !== undefined) {
+      url += `&continuation-token=${encodeURIComponent(continuationToken)}`;
+    }
 
-  if (!response.ok) {
-    return {
-      ok: false,
-      status: statusForHttp(response.status),
-      message: `Storage rejected the list (${response.status})`,
-      objects: [],
-    };
-  }
-  const xml = await response.text();
-  return { ok: true, status: "ok", message: "", objects: parseListObjectsXml(xml) };
+    let response: Response;
+    try {
+      response = await client.fetch(url, { method: "GET" });
+    } catch (err) {
+      return { ok: false, status: "network", message: messageFor(err), objects: [] };
+    }
+
+    if (!response.ok) {
+      return {
+        ok: false,
+        status: statusForHttp(response.status),
+        message: `Storage rejected the list (${response.status})`,
+        objects: [],
+      };
+    }
+
+    const page = parseListObjectsXml(await response.text());
+    objects.push(...page.objects);
+    continuationToken = page.nextContinuationToken;
+  } while (continuationToken !== undefined);
+
+  return { ok: true, status: "ok", message: "", objects };
 }
 
 // createS3Client returns a StorageClient backed by the S3 compatible endpoint in settings.

--- a/src/utils/storage/xml.ts
+++ b/src/utils/storage/xml.ts
@@ -1,5 +1,13 @@
 import type { ObjectMeta } from "../../storage.ts";
 
+// ListPage is one page of a ListObjectsV2 response: the objects it carries and, when the listing
+// is truncated, the token that fetches the next page. nextContinuationToken is undefined once the
+// listing is complete.
+export type ListPage = {
+  objects: ObjectMeta[];
+  nextContinuationToken: string | undefined;
+};
+
 // fieldFrom returns the text content of the first <tag>...</tag> found in an XML fragment, or
 // "" if it isn't present.
 function fieldFrom(block: string, tag: string): string {
@@ -50,10 +58,10 @@ function decodeXmlText(text: string): string {
 }
 
 // parseListObjectsXml extracts object keys, sizes, and last-modified timestamps from an S3
-// ListObjectsV2 XML response. Regex rather than a DOM parser: the schema is narrow and stable,
-// and DOMParser isn't available outside a browser-like runtime, which would make this untestable
-// under node:test.
-export function parseListObjectsXml(xml: string): ObjectMeta[] {
+// ListObjectsV2 XML response, along with the continuation token when the listing is truncated.
+// Regex rather than a DOM parser: the schema is narrow and stable, and DOMParser isn't available
+// outside a browser-like runtime, which would make this untestable under node:test.
+export function parseListObjectsXml(xml: string): ListPage {
   const objects: ObjectMeta[] = [];
   const contentsPattern = /<Contents>([\s\S]*?)<\/Contents>/g;
   let match = contentsPattern.exec(xml);
@@ -68,5 +76,12 @@ export function parseListObjectsXml(xml: string): ObjectMeta[] {
     match = contentsPattern.exec(xml);
   }
 
-  return objects;
+  // A token is only meaningful when IsTruncated is true. Guarding on both avoids looping forever
+  // if a provider echoes a stale token on the final page.
+  const truncated = fieldFrom(xml, "IsTruncated") === "true";
+  const token = decodeXmlText(fieldFrom(xml, "NextContinuationToken"));
+  return {
+    objects,
+    nextContinuationToken: truncated && token !== "" ? token : undefined,
+  };
 }

--- a/src/utils/storage/xml.ts
+++ b/src/utils/storage/xml.ts
@@ -80,8 +80,12 @@ export function parseListObjectsXml(xml: string): ListPage {
   // if a provider echoes a stale token on the final page.
   const truncated = fieldFrom(xml, "IsTruncated") === "true";
   const token = decodeXmlText(fieldFrom(xml, "NextContinuationToken"));
+  let nextContinuationToken: string | undefined;
+  if (truncated && token !== "") {
+    nextContinuationToken = token;
+  }
   return {
     objects,
-    nextContinuationToken: truncated && token !== "" ? token : undefined,
+    nextContinuationToken,
   };
 }


### PR DESCRIPTION
Resolves [#35](https://github.com/8thpark/geode/issues/35)

## Problem

- `listObjects` sent a single `ListObjectsV2` request and ignored `IsTruncated` and `NextContinuationToken`, so any vault over 1,000 files listed short
- Sync read the missing keys as remote deletions, breaching the "no edit is ever silently lost" bar and tripping the large vault release gate

## Changes

- Paginated `listObjects` so it follows the continuation token until the listing is complete, returning every key
- Reworked the XML parser to surface the continuation token, only when the response is genuinely truncated so a stale token cannot loop forever
- Added unit coverage for the truncated and final page branches, plus an integration test that lists past 1,000 keys

## Why

- Correctness for large vaults is a release gate, and silent data loss is the exact failure this bar exists to prevent

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes silent data loss in large vaults by paginating `listObjects` through S3's 1,000-key response cap. Previously, any vault with more than 1,000 objects would have unlisted keys treated as remote deletions during sync.

- `parseListObjectsXml` now returns a `ListPage` struct containing both the object list and the continuation token; the token is only surfaced when `IsTruncated` is `true` and the token is non-empty, preventing stale-token loops on misbehaving providers.
- `s3ListObjects` follows the continuation token in a `do-while` loop until the listing is complete, accumulating all pages before returning.
- Unit tests cover the truncated-page and final-page branches; a new integration test writes 1,001 objects, asserts all are returned, and cleans up in bounded batches.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the pagination loop is correct, error handling is consistent with the existing ListResult contract, and both unit and integration tests exercise the new paths.

The change is a self-contained correctness fix: the do-while loop exits cleanly on any undefined token, mid-pagination errors return ok:false with an empty objects array matching the pre-existing contract, and the XML parser guards on both IsTruncated and token presence so a broken provider cannot produce an infinite loop.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/utils/storage/xml.ts | Added ListPage type and extended parseListObjectsXml to return the continuation token alongside objects; guards correctly on both IsTruncated and token presence to prevent stale-token loops |
| src/storage.ts | s3ListObjects reworked to follow NextContinuationToken in a do-while loop; error handling returns ok:false with objects:[] consistent with ListResult contract on any page failure |
| src/storage.test.ts | Updated existing XML entity test to match new ListPage shape; added unit tests for the truncated-page (token present) and final-page (token absent) branches |
| src/storage.itest.ts | Integration test writes 1,001 objects in batches of 32, asserts listObjects returns all of them, and cleans up with the same bounded fan-out pattern |

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into revett/list-obj..."](https://github.com/8thpark/geode/commit/e4237fdec93d17b04c3c0e43f1879a8bce85832c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45341128)</sub>

<!-- /greptile_comment -->