### PR TITLE
Agents → Adopt typescript-as-go skill

### DIFF
--- a/.agents/skills/typescript-as-go/SKILL.md
+++ b/.agents/skills/typescript-as-go/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: typescript-as-go
+description: Enforce agents to write TypeScript as if it were Go; simple, explicit, boring
+license: MIT
+compatibility: Designed for Claude Code (or similar products)
+metadata:
+  author: revett
+  repo: https://github.com/revett/typescript-as-go
+  version: 0.3.0
+---
+
+# TypeScript As Go
+
+## Task
+
+Write TypeScript as if it were Go: simple, explicit, boring. When you are unsure how to write
+something, ask what the dullest Go programmer would do, and do that. The goal is code that is fast
+to read and review, not clever to write. No magic.
+
+## Rules
+
+As an agent working in this project, you must follow the following allowed and banned rules when
+writing Typescript.
+
+### Allowed
+
+1. Pure functions first, reaching for a class only where a framework contract demands one and
+   keeping it a shell whose methods delegate immediately to module level functions; prefer
+   composition over inheritance
+2. Named exports only, using a default export solely when a framework requires it
+3. Small files with one concern each and kebab-case file names (`settings-tab.ts`), graduating to
+   package folders (`settings/tab.ts`) only once a concern outgrows a single file
+4. Framework code stays thin glue, with logic living in pure modules that never import the framework
+5. Names short and evocative, scaled to scope (terse for locals, descriptive for exports), never
+   prefixing a getter with `get` (`owner()`, not `getOwner()`), always camelCase or PascalCase and
+   never snake_case
+6. `type` over `interface` for data shapes, since they are structs not contracts and a `type` cannot
+   be reopened by declaration merging; use `interface` only when a framework contract leaves no
+   choice
+7. String literal unions for closed sets of values (`type Status = "open" | "closed"`), keeping the
+   syntax erasable at build time
+8. Keep types small (one or two members) and accept the narrowest shape a function actually uses,
+   since structural typing means callers need not name the type
+9. Model variant data as a discriminated union with a shared literal tag, branching on the tag with
+   a `switch` that ends in a `default` asserting the union is exhausted (`assertNever(x)`)
+10. Use `satisfies` to check a value conforms to a type at compile time without widening it, the
+    equivalent of Go's compile time interface check
+11. Explicit zero values, where every type ships a complete default (a `DEFAULT_X` constant) usable
+    as is without further initialization, never undefined shaped holes
+12. Distinguish absent from zero with an explicit presence check (`map.has(k)`, `k in obj`,
+    `x === undefined`), never reading a falsy default as "missing"
+13. Errors are values, so domain logic returns a result the caller inspects (a tuple or
+    `{ ok, value }`), never a sentinel like `-1`, `NaN`, `null`, or `""` folded into the normal
+    return
+14. Give a modeled error structure rather than just a string, carrying the operation, offending
+    input, and any cause as fields, with lowercase messages that have no trailing period and are
+    prefixed with their origin (`settings: unknown theme "$name"`)
+15. Guard clauses and early returns, since flat beats nested
+16. Braces on every `if`, even a one line body
+17. Release resources with `try/finally` or a `using` declaration placed right where the resource is
+    acquired, so cleanup sits beside setup and cannot be forgotten on an early return
+18. One sentence `//` doc comment above every exported symbol, Go style
+    (`// normalizeSettings returns ...`)
+19. Table driven tests with `node:test` and `node:assert/strict` and no test framework dependency,
+    each test sitting beside the code it covers as `name.test.ts`, mirroring Go's `_test.go` pattern
+20. Reach for a small, focused dependency when hand rolling something fiddly to get right (request
+    signing, a mock server), but hand roll the moment it drags in a framework or SDK you do not need
+21. Separate a trailing `return` from the block above it with a blank line, so the final result of a
+    function reads as its own beat rather than crowding the guard or loop that precedes it
+22. The formatter, if there is one configured (e.g. Biome), is law, it decides and nobody debates
+    the output
+
+### Banned
+
+1. No enums, use string literal unions instead
+2. No ternary expressions, and no defaulting through `??` or `||`; write the `if`, or reach for a
+   file local helper such as `stringOr(v, fallback)` or `numberOr(v, fallback)`, so the fallback is
+   an explicit branch and not folded into an operator (`||` stays fine inside a boolean condition)
+3. No `else` after a `return`
+4. No `switch` case fallthrough, every case ending in `return` or `break`, with stacked labels to
+   share a branch
+5. No throwing for expected failures, returning the error as a value and converting to a result at
+   the framework boundary, reserving `throw` (Go's `panic`) for impossible states and programmer
+   errors and never exposing it across a module boundary as an API
+6. No swallowed errors and no floating promises, never discarding an error or unhandled rejection
+   you could handle
+7. No sentinel or in band return values (`-1`, `null`, `NaN`, `""`) to signal failure or absence
+8. No `interface` for plain data shapes
+9. No JSDoc `/** */` blocks, use `//` comments
+10. No barrel files and no `utils.ts` (or any grab bag dumping ground)
+11. No inheritance for code reuse (`extends` chains), compose instead
+12. No clever generics
+13. No decorators
+14. No magic
+15. No chained array pipelines (`.filter().map()`, `.map().filter()`) and no `.reduce`; Go has no
+    map or filter, so write an explicit `for...of` that guards with `continue` and pushes into a
+    result, one readable loop over a pipeline (a single `.map` on an already clean list is fine)

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,4 @@ main.js
 *.swp
 
 # Agent skills
-.agents/
 plans/
-skills-lock.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,33 +26,28 @@ to update the private
 [Working Document](https://claude.ai/code/artifact/fa8682d6-0677-4d6c-a32d-c91e51411d8f) artifact as
 we make decisions together about the project, and to track progress.
 
-## Competitors
+## Similar Projects
 
-Risk is out of 5. Activity last checked 2026-07.
-
-- [Obsidian Sync](https://obsidian.md/sync) → risk 5/5 → first party, E2E encrypted, excellent on
-  mobile, very much alive; the existential scenario is Obsidian shipping an official API/MCP on
-  top of it
-- [Remotely Save](https://github.com/remotely-save/remotely-save) → risk 2/5 → 7.8k stars but no
+- [Obsidian Sync](https://obsidian.md/sync) (Risk 5/5) → First party, E2E encrypted, excellent on
+  mobile, very much alive; the existential scenario is Obsidian shipping an official API/MCP on top
+  of it
+- [Remotely Save](https://github.com/remotely-save/remotely-save) (Risk 2/5) → 7.8k stars but no
   push since Nov 2024 and 215 open issues; the leading BYO storage sync plugin is effectively
   unmaintained, and its users are our first audience
-- [Self-hosted LiveSync](https://github.com/vrtmrz/obsidian-livesync) → risk 3/5 → 11.5k stars and
+- [Self-hosted LiveSync](https://github.com/vrtmrz/obsidian-livesync) (Risk 3/5) → 11.5k stars and
   very active; real time CouchDB sync for self hosters, same job, more demanding setup
-- Folder syncers ([obsidian-git](https://github.com/Vinzent03/obsidian-git) 11.5k stars and very
-  active, iCloud, Syncthing) → risk 2/5 → free and good enough for simple setups; they cap the
-  sync market, not the agent access market
-- [Local REST API](https://github.com/coddingtonbear/obsidian-local-rest-api) → risk 2/5 → 2.6k
+- [obsidian-git](https://github.com/Vinzent03/obsidian-git) (Risk 2/5) → 11.5k stars and very active
+- [Local REST API](https://github.com/coddingtonbear/obsidian-local-rest-api) (Risk 2/5) → 2.6k
   stars, active, ships a built-in MCP server; strong locally but requires Obsidian running on an
   awake machine
 - Remote MCP via tunnels and hosted connectors
   ([obsidian-web-mcp](https://github.com/jimprosser/obsidian-web-mcp), 146 stars and young, and
-  [MCPBundles](https://www.mcpbundles.com)) → risk 4/5 → early movers on our paid layer; all still
+  [MCPBundles](https://www.mcpbundles.com)) (Risk 4/5) → Early movers on our paid layer; all still
   need a live device or a tunnel to the vault, whereas Geode reads from storage with nothing awake
-- Desktop agents reading vault files directly (Claude Desktop, Claude Code, etc) → risk 4/5 → the
-  good enough default whenever the laptop is on; always on access is the differentiation to
-  protect
+- Desktop agents reading vault files directly (Claude Desktop, Claude Code, etc) (Risk 4/5) → The
+  good enough default whenever the laptop is on; always on access is the differentiation to protect
 - Hosted PKM with native AI ([Notion](https://notion.com), [Anytype](https://anytype.io),
-  [Capacities](https://capacities.io)) → risk 3/5 → the long game threat is users leaving Obsidian
+  [Capacities](https://capacities.io)) (Risk 3/5) → The long game threat is users leaving Obsidian
   entirely, not picking a rival plugin
 
 ## Remember
@@ -60,48 +55,16 @@ Risk is out of 5. Activity last checked 2026-07.
 - Less is always more, simple is always better, boring is best, to avoid the magic!
 - Whilst still meeting requirements, being secure, and delivering value for our users
 
-## Development
-
-- Line length is set to 100 characters for all project files
-
 ## Code Style
 
-Write TypeScript as if it were Go: simple, explicit, boring. When unsure, ask what the dullest Go
-programmer would do.
+It is critically important that you abide by all the rules set out in the `typescript-as-go` skill
+when writing Typescript, no exceptions.
 
-- The formatter is law; Biome decides and nobody debates the output
-- Pure functions first; classes only where the Obsidian API demands them (`Plugin`,
-  `PluginSettingTab`), and those classes are shells: methods delegate immediately to module level
-  functions, no logic lives on the class
-- Named exports only, except the plugin class Obsidian requires as a default export
-- String literal unions over enums; `erasableSyntaxOnly` in tsconfig enforces strippable syntax
-- `type` over `interface`: data shapes are structs, not contracts, and `type` can't be reopened
-  by declaration merging; `interface` only if implementing a framework contract demands it
-- Errors are values: domain logic returns results rather than throwing; exceptions stay at the
-  framework boundary
-- Explicit zero values: every type has a complete default (see `DEFAULT_SETTINGS`), never
-  undefined shaped holes
-- Guard clauses and early returns; flat beats nested; no `else` after a `return`
-- No ternary expressions; Go doesn't have one and neither do we, write the `if` (file local
-  helpers like `stringOr(v, fallback)` cover the defaulting cases)
-- Braces on every `if`, even a one line body; Go's formatter won't let you drop them and neither
-  do we
-- Every exported symbol gets a one sentence `//` doc comment above it, Go style
-  ("normalizeSettings returns..."); no JSDoc `/** */` blocks
-- Table driven tests with `node:test` and `node:assert/strict`; no test framework dependencies
-- Small files with one concern; no barrel files, no `utils.ts` dumping ground
-- File names are kebab-case (`settings-tab.ts`); tests sit beside the code they test as
-  `name.test.ts`, Go's `_test.go` pattern; graduate to package folders (`settings/tab.ts`) only
-  when a concern outgrows single files
-- Framework code stays thin glue; logic lives in pure modules that never import `obsidian`
-- No clever generics, no decorators, no magic
-- A small, focused dependency beats hand rolling something fiddly to get right (request signing,
-  a mock server); it loses to hand rolling the moment it drags in a framework or an SDK we don't
-  need
+Additional rules for the project:
 
-## Priorities
-
-- When stuck, the blocker is usually priorities, not missing information → Decide and move
-- One thing done exceptionally beats five things done adequately → Depth over breadth
-- Not every rough edge needs fixing now → Some fires are allowed to burn; triage ruthlessly
-- Users want value per second, not seconds of value → Optimize for speed and density, not features
+1. Line length is set to 100 characters for all project files
+2. Classes only where the Obsidian API demands them (`Plugin`, `PluginSettingTab`), and those
+   classes are shells: methods delegate immediately to module level functions, no logic lives on the
+   class; the plugin class is the one default export Obsidian requires
+3. Framework code stays thin glue; logic lives in pure modules that never import `obsidian`
+4. `erasableSyntaxOnly` in tsconfig enforces strippable syntax

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ we make decisions together about the project, and to track progress.
 ## Code Style
 
 It is critically important that you abide by all the rules set out in the `typescript-as-go` skill
-when writing Typescript, no exceptions.
+(`.agents/skills/typescript-as-go/SKILL.md`) when writing TypeScript, no exceptions.
 
 Additional rules for the project:
 

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "typescript-as-go": {
+      "source": "revett/typescript-as-go",
+      "sourceType": "github",
+      "skillPath": "skills/typescript-as-go/SKILL.md",
+      "computedHash": "ed955730b40914c46d8c55ea8cc5e47b1c442ce9295301fdd2a79712db93fb98"
+    }
+  }
+}

--- a/src/log.ts
+++ b/src/log.ts
@@ -125,7 +125,12 @@ export function createLogger(sink: LogSink, minLevel: LogLevel): Logger {
       return;
     }
     consoleFor(level)(`geode: ${message}`);
-    void sink.append({ time: Date.now(), level, message });
+    // Fire and forget: the Logger API is synchronous, so append can't be awaited. Report a
+    // failed persist to the console rather than leaving it as an unhandled rejection, and never
+    // back into sink, which would recurse if the sink itself is what's failing.
+    sink.append({ time: Date.now(), level, message }).catch((err) => {
+      console.error(`geode: log sink append failed: ${err}`);
+    });
   };
 
   return {

--- a/src/main.ts
+++ b/src/main.ts
@@ -134,11 +134,18 @@ export default class GeodePlugin extends Plugin {
     const store = createObsidianStateStore(this.app.vault.adapter, `${dir}/state.json`);
     const reader = createObsidianVaultReader(this.app.vault);
 
-    const previous = await store.read();
-    const current = await takeSnapshot(reader, previous);
-    const changes = diffSnapshots(previous, current);
+    // Both callers fire this and forget (void), so a rejection here would surface as an
+    // unhandled promise rejection. takeSnapshot can throw when a file vanishes mid-snapshot
+    // (a live vault race), so convert any failure to a logged result at this boundary.
+    try {
+      const previous = await store.read();
+      const current = await takeSnapshot(reader, previous);
+      const changes = diffSnapshots(previous, current);
 
-    this.logger.info(`vault state refreshed (${changes.length} change(s) since last run)`);
-    await store.write(current);
+      this.logger.info(`vault state refreshed (${changes.length} change(s) since last run)`);
+      await store.write(current);
+    } catch (err) {
+      this.logger.error(`vault state refresh failed: ${err}`);
+    }
   }
 }

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -468,7 +468,11 @@ export class GeodeSettingTab extends PluginSettingTab {
     this.connectionMessage = "";
     this.refreshActionsUI();
 
-    const secretAccessKey = this.app.secretStorage.getSecret(this.draft.secretId) ?? "";
+    const rawSecret = this.app.secretStorage.getSecret(this.draft.secretId);
+    let secretAccessKey = "";
+    if (rawSecret !== null) {
+      secretAccessKey = rawSecret;
+    }
     if (secretAccessKey === "") {
       this.plugin.logger.warn(`no secret found for ID "${this.draft.secretId}"`);
     }


### PR DESCRIPTION
Resolves #72 

## Problem

- Our `AGENTS.md` `Code Style` section hand duplicated a full set of TypeScript conventions, drifting from the upstream `typescript-as-go` skill and needing manual upkeep

## Changes

- Vendored the `typescript-as-go` skill into `.agents/skills` and pinned it with `skills-lock.json`
- Trimmed the `Code Style` section to defer to the skill, keeping only the project specific rules
- Tidied the competitors list, renamed it `Similar Projects`, and dropped the stale `Development` and `Priorities` sections

## Why

- One source of truth for the universal rules, refreshed with `npx skills update` rather than edited by hand
- Less duplication means less drift, so `AGENTS.md` keeps only what is genuinely Obsidian specific

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR vendors the `typescript-as-go` skill into `.agents/skills/` and slims `AGENTS.md` so the Code Style section defers to that single source of truth, eliminating the previously hand-maintained duplicate rule set. Three source files are updated to comply with the newly authoritative skill rules.

- **`AGENTS.md`**: Code Style trimmed to four project-specific addenda; Competitors renamed to Similar Projects; Development and Priorities sections removed.
- **`src/log.ts` / `src/main.ts`**: Floating-promise issues fixed — `void sink.append()` replaced with `.catch()` error reporting, and `refreshVaultState` wrapped in `try/catch` to prevent unhandled rejections from a live-vault race.
- **`src/settings-tab.ts`**: Banned `??` operator replaced with an explicit `if` block per the skill's no-nullish-coalescing rule.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are documentation cleanup, tooling additions, and targeted bug fixes with no new logic or API surface.

The code changes are straightforward correctness fixes (unhandled rejection handling, banned-operator removal) that make the codebase safer. The documentation changes reduce drift without removing any information that agents rely on. No new behaviour is introduced.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .agents/skills/typescript-as-go/SKILL.md | Vendored upstream typescript-as-go skill (v0.3.0) with 22 allowed and 15 banned rules; file is read-only reference content. |
| AGENTS.md | Code Style section trimmed to defer to the vendored skill; Competitors renamed to Similar Projects; stale Development/Priorities sections removed. Clean, no issues. |
| skills-lock.json | New lock file pinning typescript-as-go at a specific GitHub source and SHA-256 hash; format looks correct. |
| .gitignore | Removed .agents/ and skills-lock.json from gitignore so the vendored skill and lock file are tracked; correct companion change. |
| src/log.ts | Replaced void sink.append(...) with .catch() to surface sink failures to console instead of silently swallowing the rejection; correct and well-commented. |
| src/main.ts | Wrapped refreshVaultState body in try/catch to catch mid-snapshot errors (live vault race) that would otherwise surface as unhandled promise rejections; correct fix. |
| src/settings-tab.ts | Replaced the banned ?? "" with an explicit if (rawSecret !== null) block to comply with the typescript-as-go skill; semantically equivalent given Obsidian's string | null return type. |

<sub>Reviews (2): Last reviewed commit: ["Address comments from GT"](https://github.com/8thpark/geode/commit/fe1cbe84ab0f24a216aaa7870bac38451958c4ba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45344418)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/8thpark/github/8thpark/geode/-/custom-context?memory=ba501fa0-8d60-456e-b668-85f0f2abace3))

<!-- /greptile_comment -->