### PR TITLE
Prevent concurrent refreshVaultState from racing on state.json

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -256,15 +256,17 @@ export default class GeodePlugin extends Plugin {
       return this.refreshInFlight;
     }
 
+    let runQueued = false;
     this.refreshInFlight = this.doRefresh();
     try {
       await this.refreshInFlight;
+      runQueued = this.refreshQueued;
     } finally {
       this.refreshInFlight = null;
+      this.refreshQueued = false;
     }
 
-    if (this.refreshQueued) {
-      this.refreshQueued = false;
+    if (runQueued) {
       return this.refreshVaultState();
     }
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -71,6 +71,8 @@ export default class GeodePlugin extends Plugin {
   private logSink!: LogSink;
   private statusBarEl!: HTMLElement;
   private refreshTimer: number | undefined;
+  private refreshInFlight: Promise<void> | null = null;
+  private refreshQueued = false;
   private syncing = false;
 
   async onload() {
@@ -245,7 +247,31 @@ export default class GeodePlugin extends Plugin {
   // common ancestor sync diffs both sides against, and only a completed sync may write it. Writing
   // the live vault here would poison that ancestor, so a brand new local file would look like a
   // remote deletion on the next sync and get wiped.
-  async refreshVaultState() {
+  //
+  // While a refresh is already running, subsequent calls are coalesced: at most one extra refresh
+  // runs after the in-flight one finishes, catching any changes that arrived mid-snapshot.
+  async refreshVaultState(): Promise<void> {
+    if (this.refreshInFlight !== null) {
+      this.refreshQueued = true;
+      return this.refreshInFlight;
+    }
+
+    this.refreshInFlight = this.doRefresh();
+    try {
+      await this.refreshInFlight;
+    } finally {
+      this.refreshInFlight = null;
+    }
+
+    if (this.refreshQueued) {
+      this.refreshQueued = false;
+      return this.refreshVaultState();
+    }
+  }
+
+  // doRefresh does the actual snapshot and diff work, split out so refreshVaultState can own the
+  // in flight guard without this getting lost in indentation.
+  private async doRefresh(): Promise<void> {
     const dir = this.manifest.dir;
     if (dir === undefined) {
       return;


### PR DESCRIPTION
resolves #39 

# Problem
There is no in flight guard on refreshVaultState in src/main.ts. The layout ready run and a debounce fired run can overlap, and any snapshot taking longer than the 2s debounce lets a second run start mid first. Both read the same previous state and both write state.json; last writer wins with potentially stale data. Becomes a real correctness bug once sync reads this state.

# Changes
refreshVaultState had no in-flight guard. The onLayoutReady call and a debounce-fired run can overlap, and any snapshot taking longer than the 2s debounce lets a second run start mid-first. Both read the same previous state; once sync depends on this state, last writer wins with potentially stale data.

Add a `refreshInFlight` promise tracker and `refreshQueued` boolean. When a refresh is already running, subsequent calls flip the flag and return the existing promise. When the in-flight refresh finishes, it checks the flag and runs one more pass to catch changes that arrived mid-snapshot.
The body is extracted to doRefresh unchanged.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes the race condition on `refreshVaultState` where overlapping invocations (from `onLayoutReady` and the 2-second debounce) could each read the same previous state and clobber each other's write to `state.json`. The fix adds a `refreshInFlight` promise tracker and a `refreshQueued` boolean to coalesce concurrent calls into at most one queued follow-up run, and extracts the snapshot/diff body into a private `doRefresh` for clarity.

- `refreshVaultState` now acts as an in-flight guard: concurrent callers get the existing promise back, and at most one extra pass is triggered after the current run finishes to capture changes that arrived mid-snapshot.
- `doRefresh` is the extracted body of the old `refreshVaultState`, unchanged in behavior — it owns the internal `try/catch` that converts filesystem errors into logged results.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the guard logic is correct, both state fields are reset in the `finally` block on all exit paths, and the change is narrowly scoped to `refreshVaultState` and its new `doRefresh` helper.

The coalescing mechanism is correct: concurrent callers return the same in-flight promise, `refreshQueued` and `refreshInFlight` are both cleared unconditionally in `finally` (covering the reject path as well as the success path), and the recursive queued-run call happens synchronously after cleanup with no window for a new caller to observe stale state.

No files require special attention beyond the comment cleanup in `src/main.ts`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/main.ts | Adds `refreshInFlight`/`refreshQueued` guard to `refreshVaultState`, extracts body to private `doRefresh`; logic is sound for the happy path but a stale comment in `doRefresh` now misdescribes its caller relationship |

<sub>Reviews (2): Last reviewed commit: ["refactor: capture queued state so finall..."](https://github.com/8thpark/geode/commit/b4af3a48c1cc7eea39df263baa664655389ab2e7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45614297)</sub>

<!-- /greptile_comment -->