### PR TITLE
[#86] Sync → Refuse to overwrite local edits made mid sync

### DIFF
--- a/src/sync/execute.test.ts
+++ b/src/sync/execute.test.ts
@@ -164,6 +164,32 @@ test("executeSyncPlan: pullDelete of a file edited after the snapshot is refused
   assert.equal(files.get("a.md"), "edited after snapshot");
 });
 
+test("executeSyncPlan: pullDelete of a file that exists but cannot be read is refused, never treated as absent", async () => {
+  // A read failing on a file that is still present (a permission error, say) must not read as
+  // "nothing to discard": the delete could succeed against content the drift check never
+  // verified. The action must fail with the read's own error and leave the file alone.
+  const reader = fakeReader({ "a.md": "hello" });
+  reader.readFile = async () => {
+    throw new Error("EACCES: permission denied");
+  };
+  const { writer, files } = fakeLocalWriter();
+  files.set("a.md", "hello");
+  const local = snapshot(file("a.md", await hashOf("hello")));
+  const { storage } = fakeStorage();
+
+  const failures = await executeSyncPlan(
+    [{ kind: "pullDelete", path: "a.md" }],
+    local,
+    reader,
+    writer,
+    storage,
+    1,
+  );
+
+  assert.deepEqual(failures, [{ path: "a.md", message: "EACCES: permission denied" }]);
+  assert.equal(files.get("a.md"), "hello");
+});
+
 test("executeSyncPlan: a conflict renames the local copy, pushes it to storage, and pulls the remote version clean", async () => {
   const reader = fakeReader({ "a.md": "local edit" });
   const { writer, files } = fakeLocalWriter();

--- a/src/sync/execute.test.ts
+++ b/src/sync/execute.test.ts
@@ -1,8 +1,15 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
+import { hashBytes } from "../vault/vault.ts";
 import { executeSyncPlan } from "./execute.ts";
-import { fakeLocalWriter, fakeReader, fakeStorage } from "./fake.ts";
+import { empty, fakeLocalWriter, fakeReader, fakeStorage, file, snapshot } from "./fake.ts";
 import { conflictCopyPath, type SyncAction } from "./plan.ts";
+
+// hashOf returns the real content hash of text, for building local snapshots whose entries
+// executeSyncPlan's drift check can verify against a fake reader's live bytes.
+async function hashOf(text: string): Promise<string> {
+  return hashBytes(new TextEncoder().encode(text));
+}
 
 test("executeSyncPlan: push reads the local file and puts it remotely", async () => {
   const reader = fakeReader({ "a.md": "hello" });
@@ -11,6 +18,7 @@ test("executeSyncPlan: push reads the local file and puts it remotely", async ()
 
   const failures = await executeSyncPlan(
     [{ kind: "push", path: "a.md" }],
+    empty,
     reader,
     writer,
     storage,
@@ -27,7 +35,7 @@ test("executeSyncPlan: pushDelete removes the remote object", async () => {
   const { writer } = fakeLocalWriter();
   const { storage, objects } = fakeStorage({ "a.md": "hello" });
 
-  await executeSyncPlan([{ kind: "pushDelete", path: "a.md" }], reader, writer, storage, 1);
+  await executeSyncPlan([{ kind: "pushDelete", path: "a.md" }], empty, reader, writer, storage, 1);
 
   assert.equal(objects.has("a.md"), false);
 });
@@ -39,6 +47,7 @@ test("executeSyncPlan: pull fetches the remote object and writes it locally", as
 
   const failures = await executeSyncPlan(
     [{ kind: "pull", path: "a.md" }],
+    empty,
     reader,
     writer,
     storage,
@@ -49,15 +58,110 @@ test("executeSyncPlan: pull fetches the remote object and writes it locally", as
   assert.equal(files.get("a.md"), "hello");
 });
 
-test("executeSyncPlan: pullDelete removes the local file", async () => {
-  const reader = fakeReader({});
+test("executeSyncPlan: pull overwrites a local file that still matches the snapshot", async () => {
+  const reader = fakeReader({ "a.md": "unchanged" });
+  const { writer, files } = fakeLocalWriter();
+  files.set("a.md", "unchanged");
+  const local = snapshot(file("a.md", await hashOf("unchanged")));
+  const { storage } = fakeStorage({ "a.md": "remote edit" });
+
+  const failures = await executeSyncPlan(
+    [{ kind: "pull", path: "a.md" }],
+    local,
+    reader,
+    writer,
+    storage,
+    1,
+  );
+
+  assert.deepEqual(failures, []);
+  assert.equal(files.get("a.md"), "remote edit");
+});
+
+test("executeSyncPlan: pull onto a file edited after the snapshot is refused and the edit survives", async () => {
+  // Reproduces #86. The pull was planned from a snapshot in which a.md was unchanged, but the
+  // user edited it before the plan reached this action. Overwriting it now would silently discard
+  // that edit, so the action must fail instead (the next sync replans it as a conflict) and the
+  // rest of the plan must still run.
+  const reader = fakeReader({ "a.md": "edited after snapshot" });
+  const { writer, files } = fakeLocalWriter();
+  files.set("a.md", "edited after snapshot");
+  const local = snapshot(file("a.md", await hashOf("as snapshotted")));
+  const { storage } = fakeStorage({ "a.md": "remote edit", "b.md": "remote b" });
+
+  const actions: SyncAction[] = [
+    { kind: "pull", path: "a.md" },
+    { kind: "pull", path: "b.md" },
+  ];
+  const failures = await executeSyncPlan(actions, local, reader, writer, storage, 1);
+
+  assert.deepEqual(failures, [
+    { path: "a.md", message: "changed locally mid sync; sync again to reconcile" },
+  ]);
+  assert.equal(files.get("a.md"), "edited after snapshot");
+  // The following action still ran.
+  assert.equal(files.get("b.md"), "remote b");
+});
+
+test("executeSyncPlan: pull onto a file created after the snapshot is refused", async () => {
+  // The snapshot saw nothing at this path (the pull was planned for a remote-only file), but the
+  // user created a file there before the plan reached this action. Writing the remote version
+  // over it would discard a file the plan never knew existed.
+  const reader = fakeReader({ "a.md": "created after snapshot" });
+  const { writer, files } = fakeLocalWriter();
+  files.set("a.md", "created after snapshot");
+  const { storage } = fakeStorage({ "a.md": "remote edit" });
+
+  const failures = await executeSyncPlan(
+    [{ kind: "pull", path: "a.md" }],
+    empty,
+    reader,
+    writer,
+    storage,
+    1,
+  );
+
+  assert.deepEqual(failures, [
+    { path: "a.md", message: "changed locally mid sync; sync again to reconcile" },
+  ]);
+  assert.equal(files.get("a.md"), "created after snapshot");
+});
+
+test("executeSyncPlan: pullDelete removes a local file that still matches the snapshot", async () => {
+  const reader = fakeReader({ "a.md": "hello" });
   const { writer, files } = fakeLocalWriter();
   files.set("a.md", "hello");
+  const local = snapshot(file("a.md", await hashOf("hello")));
   const { storage } = fakeStorage();
 
-  await executeSyncPlan([{ kind: "pullDelete", path: "a.md" }], reader, writer, storage, 1);
+  await executeSyncPlan([{ kind: "pullDelete", path: "a.md" }], local, reader, writer, storage, 1);
 
   assert.equal(files.has("a.md"), false);
+});
+
+test("executeSyncPlan: pullDelete of a file edited after the snapshot is refused and the edit survives", async () => {
+  // Reproduces #86 for the delete side: the remote deletion was planned against a snapshot in
+  // which a.md was unchanged, but the user edited it in the window since. Deleting it now would
+  // silently discard the edit; the next sync replans this as a conflict instead.
+  const reader = fakeReader({ "a.md": "edited after snapshot" });
+  const { writer, files } = fakeLocalWriter();
+  files.set("a.md", "edited after snapshot");
+  const local = snapshot(file("a.md", await hashOf("as snapshotted")));
+  const { storage } = fakeStorage();
+
+  const failures = await executeSyncPlan(
+    [{ kind: "pullDelete", path: "a.md" }],
+    local,
+    reader,
+    writer,
+    storage,
+    1,
+  );
+
+  assert.deepEqual(failures, [
+    { path: "a.md", message: "changed locally mid sync; sync again to reconcile" },
+  ]);
+  assert.equal(files.get("a.md"), "edited after snapshot");
 });
 
 test("executeSyncPlan: a conflict renames the local copy, pushes it to storage, and pulls the remote version clean", async () => {
@@ -69,6 +173,7 @@ test("executeSyncPlan: a conflict renames the local copy, pushes it to storage, 
 
   const failures = await executeSyncPlan(
     [{ kind: "conflict", path: "a.md", deletedSide: "none" }],
+    empty,
     reader,
     writer,
     storage,
@@ -92,6 +197,7 @@ test("executeSyncPlan: a conflict with nothing local to preserve just pulls the 
 
   const failures = await executeSyncPlan(
     [{ kind: "conflict", path: "a.md", deletedSide: "local" }],
+    empty,
     reader,
     writer,
     storage,
@@ -103,6 +209,31 @@ test("executeSyncPlan: a conflict with nothing local to preserve just pulls the 
   assert.equal(files.has(conflictCopyPath("a.md", now)), false);
 });
 
+test("executeSyncPlan: a conflict restore onto a path recreated after the snapshot is refused", async () => {
+  // The snapshot saw this path as locally deleted, so the plan decided the remote edit could be
+  // restored with nothing to preserve. The user then recreated the file before the plan reached
+  // this action; overwriting it now would discard content the plan never saw (#86).
+  const reader = fakeReader({ "a.md": "recreated after snapshot" });
+  const { writer, files } = fakeLocalWriter();
+  files.set("a.md", "recreated after snapshot");
+  const { storage } = fakeStorage({ "a.md": "remote edit" });
+  const now = Date.parse("2026-07-14T10:00:00.000Z");
+
+  const failures = await executeSyncPlan(
+    [{ kind: "conflict", path: "a.md", deletedSide: "local" }],
+    empty,
+    reader,
+    writer,
+    storage,
+    now,
+  );
+
+  assert.deepEqual(failures, [
+    { path: "a.md", message: "changed locally mid sync; sync again to reconcile" },
+  ]);
+  assert.equal(files.get("a.md"), "recreated after snapshot");
+});
+
 test("executeSyncPlan: a conflict with nothing remote to pull preserves the local edit as a copy and reports no failure", async () => {
   const reader = fakeReader({ "a.md": "local edit" });
   const { writer, files } = fakeLocalWriter();
@@ -112,6 +243,7 @@ test("executeSyncPlan: a conflict with nothing remote to pull preserves the loca
 
   const failures = await executeSyncPlan(
     [{ kind: "conflict", path: "a.md", deletedSide: "remote" }],
+    empty,
     reader,
     writer,
     storage,
@@ -136,7 +268,7 @@ test("executeSyncPlan: a push whose local file vanished is reported and doesn't 
     { kind: "push", path: "a.md" },
     { kind: "push", path: "b.md" },
   ];
-  const failures = await executeSyncPlan(actions, reader, writer, storage, 1);
+  const failures = await executeSyncPlan(actions, empty, reader, writer, storage, 1);
 
   assert.deepEqual(failures, [{ path: "a.md", message: "no such file: a.md" }]);
   assert.equal(objects.get("b.md"), "world");
@@ -156,7 +288,7 @@ test("executeSyncPlan: a conflict whose local file vanished is reported, nothing
     { kind: "conflict", path: "a.md", deletedSide: "none" },
     { kind: "push", path: "b.md" },
   ];
-  const failures = await executeSyncPlan(actions, reader, writer, storage, now);
+  const failures = await executeSyncPlan(actions, empty, reader, writer, storage, now);
 
   assert.deepEqual(failures, [{ path: "a.md", message: "no such file: a.md" }]);
   // No conflict copy was created locally or remotely from a file that wasn't there to preserve.
@@ -182,7 +314,7 @@ test("executeSyncPlan: a failed push is reported and doesn't stop the rest of th
     { kind: "push", path: "a.md" },
     { kind: "push", path: "b.md" },
   ];
-  const failures = await executeSyncPlan(actions, reader, writer, storage, 1);
+  const failures = await executeSyncPlan(actions, empty, reader, writer, storage, 1);
 
   assert.deepEqual(failures, [{ path: "a.md", message: "Storage rejected the write (500)" }]);
   assert.equal(objects.get("b.md"), "world");
@@ -206,7 +338,7 @@ test("executeSyncPlan: a pull whose local write throws is reported and doesn't s
     { kind: "pull", path: "a.md" },
     { kind: "pull", path: "b.md" },
   ];
-  const failures = await executeSyncPlan(actions, reader, writer, storage, 1);
+  const failures = await executeSyncPlan(actions, empty, reader, writer, storage, 1);
 
   assert.deepEqual(failures, [{ path: "a.md", message: "EACCES: permission denied" }]);
   assert.equal(files.get("b.md"), "pulled");
@@ -227,6 +359,7 @@ test("executeSyncPlan: a conflict whose rename throws is reported and the local 
 
   const failures = await executeSyncPlan(
     [{ kind: "conflict", path: "a.md", deletedSide: "none" }],
+    empty,
     reader,
     writer,
     storage,

--- a/src/sync/execute.ts
+++ b/src/sync/execute.ts
@@ -1,6 +1,10 @@
 import type { StorageClient } from "../storage/storage.ts";
-import type { Reader } from "../vault/vault.ts";
+import { byPath, type FileState, hashBytes, type Reader, type Snapshot } from "../vault/vault.ts";
 import { conflictCopyPath, type SyncAction } from "./plan.ts";
+
+// DRIFT_MESSAGE is the failure reported when a local file changed after the snapshot an action
+// was planned from; the next sync re-snapshots and replans the path as a conflict.
+const DRIFT_MESSAGE = "changed locally mid sync; sync again to reconcile";
 
 // LocalWriter applies changes decided by a sync to the local vault. The real implementation
 // writes through the vault adapter (see vault/obsidian.ts); tests use an in-memory fake.
@@ -17,16 +21,20 @@ export type SyncFailure = {
 };
 
 // executeSyncPlan carries out every action against reader/localWriter (the local vault) and
-// storage (the remote bucket), and reports whatever couldn't be completed. now is passed in
-// rather than read internally so a conflict's copy name is deterministic under test.
+// storage (the remote bucket), and reports whatever couldn't be completed. local is the snapshot
+// the plan was made from, so each destructive local write can first check the file hasn't changed
+// since (#86). now is passed in rather than read internally so a conflict's copy name is
+// deterministic under test.
 export async function executeSyncPlan(
   actions: SyncAction[],
+  local: Snapshot,
   reader: Reader,
   localWriter: LocalWriter,
   storage: StorageClient,
   now: number,
 ): Promise<SyncFailure[]> {
   const failures: SyncFailure[] = [];
+  const localByPath = byPath(local.files);
 
   for (const action of actions) {
     if (action.kind === "push") {
@@ -53,6 +61,10 @@ export async function executeSyncPlan(
     }
 
     if (action.kind === "pull") {
+      if (await localDrifted(reader, action.path, localByPath.get(action.path))) {
+        failures.push({ path: action.path, message: DRIFT_MESSAGE });
+        continue;
+      }
       const result = await storage.getObject(action.path);
       if (!result.ok || result.body === null) {
         failures.push({ path: action.path, message: result.message });
@@ -69,6 +81,10 @@ export async function executeSyncPlan(
     }
 
     if (action.kind === "pullDelete") {
+      if (await localDrifted(reader, action.path, localByPath.get(action.path))) {
+        failures.push({ path: action.path, message: DRIFT_MESSAGE });
+        continue;
+      }
       const failure = await applyLocalWrite(action.path, () => localWriter.deleteFile(action.path));
       if (failure !== null) {
         failures.push(failure);
@@ -77,8 +93,13 @@ export async function executeSyncPlan(
     }
 
     // conflict, deletedSide "local": the user deleted their copy, so there is no local edit to
-    // preserve; the remote edit simply wins and is restored onto the local path.
+    // preserve; the remote edit simply wins and is restored onto the local path. The snapshot has
+    // no entry here, so any file found now was recreated after it and must not be overwritten.
     if (action.deletedSide === "local") {
+      if (await localDrifted(reader, action.path, localByPath.get(action.path))) {
+        failures.push({ path: action.path, message: DRIFT_MESSAGE });
+        continue;
+      }
       const result = await storage.getObject(action.path);
       if (!result.ok || result.body === null) {
         failures.push({ path: action.path, message: result.message });
@@ -154,6 +175,34 @@ async function applyLocalWrite(path: string, op: () => Promise<void>): Promise<S
   } catch (err) {
     return { path, message: localFailureMessage(err) };
   }
+}
+
+// localDrifted reports whether the file at path now holds content the local snapshot never saw:
+// an edit or creation made in the window between the snapshot and this action running (#86).
+// Overwriting or deleting such a file would silently discard that edit, so the caller fails the
+// action instead; the next sync re-snapshots, sees both sides changed, and replans the path as a
+// conflict, which is where the conflict copy machinery lives. A path with nothing on disk, or
+// whose content still hashes to the snapshot's entry, is safe to write over. Reading right before
+// the destructive write shrinks the unguardable race to the moment between this read and the
+// write itself, rather than the whole plan execution.
+async function localDrifted(
+  reader: Reader,
+  path: string,
+  expected: FileState | undefined,
+): Promise<boolean> {
+  let bytes: Uint8Array;
+  try {
+    bytes = await reader.readFile(path);
+  } catch {
+    // Nothing on disk means nothing to discard; a read failing for any other reason resurfaces
+    // on the destructive write that follows, where it is reported.
+    return false;
+  }
+  if (expected === undefined) {
+    return true;
+  }
+
+  return (await hashBytes(bytes)) !== expected.hash;
 }
 
 // localFailureMessage turns whatever a local vault operation threw into a SyncFailure message.

--- a/src/sync/execute.ts
+++ b/src/sync/execute.ts
@@ -61,8 +61,9 @@ export async function executeSyncPlan(
     }
 
     if (action.kind === "pull") {
-      if (await localDrifted(reader, action.path, localByPath.get(action.path))) {
-        failures.push({ path: action.path, message: DRIFT_MESSAGE });
+      const drift = await checkLocalDrift(reader, action.path, localByPath.get(action.path));
+      if (drift !== null) {
+        failures.push(drift);
         continue;
       }
       const result = await storage.getObject(action.path);
@@ -81,8 +82,9 @@ export async function executeSyncPlan(
     }
 
     if (action.kind === "pullDelete") {
-      if (await localDrifted(reader, action.path, localByPath.get(action.path))) {
-        failures.push({ path: action.path, message: DRIFT_MESSAGE });
+      const drift = await checkLocalDrift(reader, action.path, localByPath.get(action.path));
+      if (drift !== null) {
+        failures.push(drift);
         continue;
       }
       const failure = await applyLocalWrite(action.path, () => localWriter.deleteFile(action.path));
@@ -96,8 +98,9 @@ export async function executeSyncPlan(
     // preserve; the remote edit simply wins and is restored onto the local path. The snapshot has
     // no entry here, so any file found now was recreated after it and must not be overwritten.
     if (action.deletedSide === "local") {
-      if (await localDrifted(reader, action.path, localByPath.get(action.path))) {
-        failures.push({ path: action.path, message: DRIFT_MESSAGE });
+      const drift = await checkLocalDrift(reader, action.path, localByPath.get(action.path));
+      if (drift !== null) {
+        failures.push(drift);
         continue;
       }
       const result = await storage.getObject(action.path);
@@ -177,32 +180,40 @@ async function applyLocalWrite(path: string, op: () => Promise<void>): Promise<S
   }
 }
 
-// localDrifted reports whether the file at path now holds content the local snapshot never saw:
-// an edit or creation made in the window between the snapshot and this action running (#86).
+// checkLocalDrift returns the failure to report before a destructive local write at path, or null
+// when the write is safe. Drift means the file now holds content the local snapshot never saw: an
+// edit or creation made in the window between the snapshot and this action running (#86).
 // Overwriting or deleting such a file would silently discard that edit, so the caller fails the
 // action instead; the next sync re-snapshots, sees both sides changed, and replans the path as a
-// conflict, which is where the conflict copy machinery lives. A path with nothing on disk, or
-// whose content still hashes to the snapshot's entry, is safe to write over. Reading right before
-// the destructive write shrinks the unguardable race to the moment between this read and the
-// write itself, rather than the whole plan execution.
-async function localDrifted(
+// conflict, which is where the conflict copy machinery lives. Only a confirmed absent path, or
+// content that still hashes to the snapshot's entry, is safe to write over: a file that exists
+// but cannot be read is refused with the read's own error, never treated as absent, since
+// deleting content that was never verified is the exact hole this check closes. Checking right
+// before the destructive write shrinks the unguardable race to the moment between this check and
+// the write itself, rather than the whole plan execution.
+async function checkLocalDrift(
   reader: Reader,
   path: string,
   expected: FileState | undefined,
-): Promise<boolean> {
+): Promise<SyncFailure | null> {
+  const exists = await reader.fileExists(path);
+  if (!exists) {
+    return null;
+  }
   let bytes: Uint8Array;
   try {
     bytes = await reader.readFile(path);
-  } catch {
-    // Nothing on disk means nothing to discard; a read failing for any other reason resurfaces
-    // on the destructive write that follows, where it is reported.
-    return false;
+  } catch (err) {
+    return { path, message: localFailureMessage(err) };
   }
   if (expected === undefined) {
-    return true;
+    return { path, message: DRIFT_MESSAGE };
+  }
+  if ((await hashBytes(bytes)) !== expected.hash) {
+    return { path, message: DRIFT_MESSAGE };
   }
 
-  return (await hashBytes(bytes)) !== expected.hash;
+  return null;
 }
 
 // localFailureMessage turns whatever a local vault operation threw into a SyncFailure message.

--- a/src/sync/fake.ts
+++ b/src/sync/fake.ts
@@ -36,6 +36,9 @@ export function fakeLocalWriter(): { writer: LocalWriter; files: Map<string, str
 // fakeReader returns a Reader backed by an in-memory map of path to content.
 export function fakeReader(files: Record<string, string>): Reader {
   return {
+    fileExists: async (path) => {
+      return files[path] !== undefined;
+    },
     listFiles: async () => {
       const list = [];
       for (const [path, content] of Object.entries(files)) {

--- a/src/sync/sync.test.ts
+++ b/src/sync/sync.test.ts
@@ -1,9 +1,15 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import type { Snapshot } from "../vault/vault.ts";
+import { hashBytes, type Snapshot } from "../vault/vault.ts";
 import { empty, fakeLocalWriter, fakeReader, fakeStorage, file, snapshot } from "./fake.ts";
-import { MANIFEST_KEY } from "./plan.ts";
+import { conflictCopyPath, MANIFEST_KEY } from "./plan.ts";
 import { adoptLiveStats, readRemoteManifest, syncOnce } from "./sync.ts";
+
+// hashOf returns the real content hash of text, for snapshots whose entries executeSyncPlan's
+// drift check will verify against live bytes.
+async function hashOf(text: string): Promise<string> {
+  return hashBytes(new TextEncoder().encode(text));
+}
 
 test("readRemoteManifest: a 404 is treated as an empty snapshot", async () => {
   const { storage } = fakeStorage();
@@ -87,8 +93,9 @@ test("syncOnce: a present but empty manifest still trusts the ancestor and pulls
   // really did produce an empty remote. A file the ancestor knew about, unchanged locally, was
   // deleted remotely, and pullDelete is the correct result that must NOT be suppressed. The reader
   // reports the file at the same size and mtime as the ancestor so takeSnapshot reuses its hash and
-  // sees no local change.
-  const previous = snapshot(file("a.md", "h1"));
+  // sees no local change; the hash is the real content hash so the pullDelete's drift check also
+  // sees the file as unchanged.
+  const previous = snapshot({ path: "a.md", size: 2, mtime: 1, hash: await hashOf("xy") });
   const reader = fakeReader({ "a.md": "xy" });
   const { writer, files } = fakeLocalWriter();
   files.set("a.md", "xy");
@@ -211,6 +218,60 @@ test("syncOnce: a file changed mid sync is not recorded in the manifest and is p
   assert.equal(retry.ok, true);
   assert.equal(objects.get("a.md"), "edited mid sync");
   assert.equal(objects.get("c.md"), "created mid sync");
+});
+
+test("syncOnce: a file edited mid sync is never overwritten by a pull, and the retry preserves it as a conflict copy", async () => {
+  // Reproduces #86. Both files are in sync locally and edited remotely, so the pass plans a pull
+  // for each. While a.md's pull is fetching, the user edits b.md; before the fix the pull planned
+  // for b.md then overwrote that edit with the remote version, silently discarding it. The pass
+  // must refuse that pull and fail instead, and because state.json never advances, the retry sees
+  // b.md changed on both sides and preserves the edit as a conflict copy.
+  const ancestor = snapshot(
+    { path: "a.md", size: 4, mtime: 1, hash: await hashOf("a v1") },
+    { path: "b.md", size: 4, mtime: 1, hash: await hashOf("b v1") },
+  );
+  const remoteManifest = JSON.stringify(
+    snapshot(file("a.md", await hashOf("a v2")), file("b.md", await hashOf("b v2"))),
+  );
+  const { storage, objects } = fakeStorage({
+    [MANIFEST_KEY]: remoteManifest,
+    "a.md": "a v2",
+    "b.md": "b v2",
+  });
+  const readerFiles: Record<string, string> = { "a.md": "a v1", "b.md": "b v1" };
+  const reader = fakeReader(readerFiles);
+  const { writer, files } = fakeLocalWriter();
+  files.set("a.md", "a v1");
+  files.set("b.md", "b v1");
+  const inner = storage.getObject;
+  let edited = false;
+  storage.getObject = async (key) => {
+    if (key === "a.md" && !edited) {
+      edited = true;
+      readerFiles["b.md"] = "edited mid sync";
+      files.set("b.md", "edited mid sync");
+    }
+    return inner(key);
+  };
+  const now = Date.parse("2026-07-14T10:00:00.000Z");
+
+  const outcome = await syncOnce(ancestor, reader, writer, storage, now);
+
+  assert.equal(outcome.ok, false);
+  // The edit survived, a.md's pull still landed, and no manifest was uploaded.
+  assert.equal(files.get("b.md"), "edited mid sync");
+  assert.equal(files.get("a.md"), "a v2");
+  assert.equal(objects.get(MANIFEST_KEY), remoteManifest);
+
+  // The retry diffs against the same ancestor: b.md changed locally and remotely, a genuine
+  // conflict, so the edit is renamed to a conflict copy, pushed, and the remote version pulled.
+  const retry = await syncOnce(ancestor, reader, writer, storage, now);
+
+  assert.equal(retry.ok, true);
+  const copyPath = conflictCopyPath("b.md", now);
+  assert.equal(files.get(copyPath), "edited mid sync");
+  assert.equal(objects.get(copyPath), "edited mid sync");
+  assert.equal(files.get("b.md"), "b v2");
 });
 
 test("syncOnce: two first syncs racing for an empty bucket, the loser fails instead of clobbering", async () => {

--- a/src/sync/sync.ts
+++ b/src/sync/sync.ts
@@ -121,7 +121,7 @@ export async function syncOnce(
   const local = await takeSnapshot(reader, ancestor);
 
   const actions = planSync(ancestor, local, remote.snapshot);
-  const failures = await executeSyncPlan(actions, reader, localWriter, storage, now);
+  const failures = await executeSyncPlan(actions, local, reader, localWriter, storage, now);
   if (failures.length > 0) {
     return { ok: false, message: `${failures.length} file(s) failed to sync`, failures };
   }

--- a/src/vault/obsidian.ts
+++ b/src/vault/obsidian.ts
@@ -31,6 +31,9 @@ export function createObsidianLocalWriter(adapter: DataAdapter): LocalWriter {
 // lives inside .obsidian/plugins/geode/) never shows up as a vault file to snapshot.
 export function createObsidianReader(vault: Vault): Reader {
   return {
+    fileExists: async (path) => {
+      return vault.getFileByPath(path) !== null;
+    },
     listFiles: async () => {
       const files: FileInfo[] = [];
       for (const file of vault.getFiles()) {

--- a/src/vault/vault.test.ts
+++ b/src/vault/vault.test.ts
@@ -17,6 +17,9 @@ function fakeReader(files: Record<string, { content: string; mtime: number }>): 
 } {
   let reads = 0;
   const reader: Reader = {
+    fileExists: async (path) => {
+      return files[path] !== undefined;
+    },
     listFiles: async () => {
       const list: FileInfo[] = [];
       for (const [path, file] of Object.entries(files)) {
@@ -116,6 +119,9 @@ test("takeSnapshot: concurrency is bounded by the limit", async () => {
   let inflight = 0;
   let peakInflight = 0;
   const reader: Reader = {
+    fileExists: async (path) => {
+      return files[path] !== undefined;
+    },
     listFiles: async () => {
       const list: FileInfo[] = [];
       for (const [path, file] of Object.entries(files)) {

--- a/src/vault/vault.ts
+++ b/src/vault/vault.ts
@@ -75,6 +75,18 @@ export function diffSnapshots(previous: Snapshot, current: Snapshot): Change[] {
   return changes;
 }
 
+// hashBytes returns the lowercase hex SHA-256 digest of data.
+export async function hashBytes(data: Uint8Array): Promise<string> {
+  // Same TS/DOM lib generic mismatch as storage.ts's BodyInit cast: Uint8Array<ArrayBufferLike>
+  // vs BufferSource's stricter ArrayBuffer expectation. Not a real runtime issue.
+  const digest = await crypto.subtle.digest("SHA-256", data as BufferSource);
+  let hex = "";
+  for (const byte of new Uint8Array(digest)) {
+    hex += byte.toString(16).padStart(2, "0");
+  }
+  return hex;
+}
+
 // isSnapshot reports whether a value parsed from untrusted JSON (a remote manifest, a local
 // state.json) is shaped like a snapshot: a non-null object with a files array. Callers use this
 // instead of a blind `as Snapshot` cast, so a body that parses but is the wrong shape becomes
@@ -113,18 +125,6 @@ export async function takeSnapshot(
   });
 
   return { files };
-}
-
-// hashBytes returns the lowercase hex SHA-256 digest of data.
-async function hashBytes(data: Uint8Array): Promise<string> {
-  // Same TS/DOM lib generic mismatch as storage.ts's BodyInit cast: Uint8Array<ArrayBufferLike>
-  // vs BufferSource's stricter ArrayBuffer expectation. Not a real runtime issue.
-  const digest = await crypto.subtle.digest("SHA-256", data as BufferSource);
-  let hex = "";
-  for (const byte of new Uint8Array(digest)) {
-    hex += byte.toString(16).padStart(2, "0");
-  }
-  return hex;
 }
 
 // mapWithConcurrency runs fn over each item with at most limit concurrent invocations, preserving

--- a/src/vault/vault.ts
+++ b/src/vault/vault.ts
@@ -19,9 +19,11 @@ export type FileState = {
   hash: string;
 };
 
-// Reader lists files present in the vault right now and reads their bytes. The real
-// implementation wraps Obsidian's Vault API (see obsidian.ts); tests use an in-memory fake.
+// Reader lists files present in the vault right now, reads their bytes, and answers whether a
+// path currently exists, so a failed read on a present file is never mistaken for absence. The
+// real implementation wraps Obsidian's Vault API (see obsidian.ts); tests use an in-memory fake.
 export type Reader = {
+  fileExists: (path: string) => Promise<boolean>;
   listFiles: () => Promise<FileInfo[]>;
   readFile: (path: string) => Promise<Uint8Array>;
 };


### PR DESCRIPTION
Resolves [#86](https://github.com/8thpark/geode/issues/86)

## Problem

- A sync plans its actions from a snapshot taken at the start of the pass but executes them later, so the vault can change in the window between
- A `pull` or `pullDelete` wrote over or deleted the local file without re checking it, silently discarding any edit made in that window, exactly the loss the conflict copy machinery exists to prevent
- The same hole existed when restoring a remote edit onto a locally deleted path that the user had since recreated

## Changes

- Every destructive local write now re reads the file just before acting and verifies it still matches the snapshot the plan was made from
- A file that drifted fails that action with `changed locally mid sync; sync again to reconcile`, the pass fails, and `state.json` never advances
- The next pass sees the path changed on both sides and routes it through the existing conflict copy machinery, so the edit survives as a conflicted copy
- Added regression tests at the execute level plus an end to end test reproducing the mid sync edit and the retry that preserves it

## Why

- No edit is ever silently lost is the core promise of the plugin; overwriting a fresh edit without a copy breaks it
- Failing loudly and replanning on the next pass reuses the existing planner and conflict machinery rather than inventing a second reconciliation path at execution time
- The unguardable race shrinks from the whole plan execution to the instant between the check and the write

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes the silent-data-loss window in #86: a sync pass snapshot was taken once at the start but destructive local writes (`pull`, `pullDelete`, and conflict restores onto locally-deleted paths) executed later without re-verifying the file hadn't changed in the interim. The fix adds `checkLocalDrift` — a pre-write guard that re-reads and hashes the live file, failing the action when the content no longer matches the snapshot baseline, so the next pass sees both sides changed and routes the path through the existing conflict-copy machinery instead of discarding the edit silently.

- **`checkLocalDrift`** correctly distinguishes four states: absent (safe to proceed), unreadable-but-present (fail with the read's own error, never treat as absent), in snapshot with matching hash (safe), and anything else (DRIFT_MESSAGE); the previously flagged hole where a `pullDelete` could silently delete an unreadable file is closed.
- **Snapshot passed by reference** from `takeSnapshot` into `executeSyncPlan` via `sync.ts`; the same stat-gated-hash baseline the planner uses now drives the drift check, so no extra hashing work is needed for files that haven't changed.
- **No drift check on `conflict` with `deletedSide "none"/"remote"`** — intentionally omitted because those branches read and preserve whatever local content is currently present before overwriting, so no data can be lost even if the file was edited mid-sync.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the change only adds conservative guards that fail actions rather than silently discard data, and the previously flagged read-error hole in `pullDelete` is explicitly tested and closed.

Every destructive local write now re-verifies the file against the snapshot baseline before proceeding. The logic correctly separates the four states (absent, unreadable, hash-matched, drifted), the E2E retry test confirms the conflict-copy machinery takes over on the next pass, and the specific read-error scenario that was flagged in a prior review now has a dedicated regression test.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/sync/execute.ts | Core change: adds `checkLocalDrift` guard before every destructive local write (`pull`, `pullDelete`, `conflict` with `deletedSide: "local"`). Logic correctly distinguishes absent (safe), unreadable (fail with read error), unknown (DRIFT_MESSAGE), and hash-matched (safe) cases. |
| src/sync/execute.test.ts | Comprehensive regression coverage: drift on `pull`, `pullDelete`, `conflict` restore; read-error-on-present-file is refused; passing snapshot hash matches proceed; previously-flagged `pullDelete` read-error hole is explicitly exercised. |
| src/vault/vault.ts | Adds `fileExists` to the `Reader` interface and exports `hashBytes`, giving `checkLocalDrift` the two primitives it needs. `fileExists` separates "absent" from "unreadable" so read failures on present files are never treated as safe. |
| src/vault/obsidian.ts | Implements `fileExists` via `vault.getFileByPath(path) !== null`, consistent with how `readFile` already resolves files; correctly returns `false` for paths outside the vault index. |
| src/sync/sync.ts | One-line change: passes the freshly-taken `local` snapshot into `executeSyncPlan` so the drift check has a baseline to compare against. |
| src/sync/sync.test.ts | Adds the end-to-end mid-sync-edit scenario: first pass refuses the clobbering pull and leaves state.json unadvanced; retry sees a genuine conflict and produces a conflict copy, preserving the edit. |
| src/sync/fake.ts | Adds `fileExists` to `fakeReader` closing over the same mutable `files` object as `readFile`, so mid-sync mutations in tests are visible to both methods — correctly mirroring a live filesystem. |
| src/vault/vault.test.ts | Updates inline `fakeReader` fixtures to satisfy the expanded `Reader` interface; no logic changes. |

<sub>Reviews (2): Last reviewed commit: ["Address"](https://github.com/8thpark/geode/commit/ea45c55ee4e3dbe3746f7c472b857696d112ad4e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46074299)</sub>

<!-- /greptile_comment -->