### PR TITLE
Vault → Invalidate state on sync settings change

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -211,7 +211,7 @@ export default class GeodePlugin extends Plugin {
     }
 
     const storage = createS3Client(this.settings, secretAccessKey);
-    const stateStore = createObsidianStore(this.app.vault.adapter, `${dir}/state.json`);
+    const stateStore = createObsidianStore(this.app.vault.adapter, `${dir}/state.json`, this.settings);
     const reader = createObsidianReader(this.app.vault);
     const localWriter = createObsidianLocalWriter(this.app.vault.adapter);
 
@@ -294,7 +294,7 @@ export default class GeodePlugin extends Plugin {
       return;
     }
 
-    const store = createObsidianStore(this.app.vault.adapter, `${dir}/state.json`);
+    const store = createObsidianStore(this.app.vault.adapter, `${dir}/state.json`, this.settings);
     const reader = createObsidianReader(this.app.vault);
 
     // Both callers fire this and forget (void), so a rejection here would surface as an

--- a/src/main.ts
+++ b/src/main.ts
@@ -211,7 +211,11 @@ export default class GeodePlugin extends Plugin {
     }
 
     const storage = createS3Client(this.settings, secretAccessKey);
-    const stateStore = createObsidianStore(this.app.vault.adapter, `${dir}/state.json`, this.settings);
+    const stateStore = createObsidianStore(
+      this.app.vault.adapter,
+      `${dir}/state.json`,
+      this.settings,
+    );
     const reader = createObsidianReader(this.app.vault);
     const localWriter = createObsidianLocalWriter(this.app.vault.adapter);
 

--- a/src/sync/sync.itest.ts
+++ b/src/sync/sync.itest.ts
@@ -53,7 +53,7 @@ function newDevice(): Device {
     root,
     reader: createObsidianReader(vault),
     writer: createObsidianLocalWriter(adapter),
-    stateStore: createObsidianStore(adapter, STATE_PATH),
+    stateStore: createObsidianStore(adapter, STATE_PATH, liveSettings),
   };
 }
 

--- a/src/vault/obsidian.test.ts
+++ b/src/vault/obsidian.test.ts
@@ -1,8 +1,9 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import type { DataAdapter } from "obsidian";
+import { DEFAULT_SETTINGS } from "../settings/settings.ts";
 import { createObsidianLocalWriter, createObsidianStore } from "./obsidian.ts";
-import type { Snapshot } from "./vault.ts";
+import { fingerprintSettings, type Snapshot } from "./vault.ts";
 
 // fakeAdapter returns a DataAdapter whose exists/read/write operate over one in-memory file map,
 // enough to drive the state store. Only the methods the state store touches are implemented; the
@@ -182,13 +183,13 @@ test("createObsidianLocalWriter: a failed write of the staged bytes leaves the d
 });
 
 test("createObsidianStore: a missing state file reads back as empty", async () => {
-  const store = createObsidianStore(fakeAdapter(), STATE_PATH);
+  const store = createObsidianStore(fakeAdapter(), STATE_PATH, DEFAULT_SETTINGS);
 
   assert.deepEqual(await store.read(), empty);
 });
 
 test("createObsidianStore: unparseable state reads back as empty, never throwing", async () => {
-  const store = createObsidianStore(fakeAdapter({ [STATE_PATH]: "not json" }), STATE_PATH);
+  const store = createObsidianStore(fakeAdapter({ [STATE_PATH]: "not json" }), STATE_PATH, DEFAULT_SETTINGS);
 
   assert.deepEqual(await store.read(), empty);
 });
@@ -198,7 +199,7 @@ test("createObsidianStore: state that parses but is the wrong shape reads back a
   // array, and before the shape check it flowed into takeSnapshot where byPath(previous.files)
   // threw on the next sync. It must instead fall back to empty and start fresh.
   for (const body of ["{}", "[]", "null", "42"]) {
-    const store = createObsidianStore(fakeAdapter({ [STATE_PATH]: body }), STATE_PATH);
+    const store = createObsidianStore(fakeAdapter({ [STATE_PATH]: body }), STATE_PATH, DEFAULT_SETTINGS);
 
     assert.deepEqual(await store.read(), empty, body);
   }
@@ -206,30 +207,49 @@ test("createObsidianStore: state that parses but is the wrong shape reads back a
 
 test("createObsidianStore: a well shaped snapshot round-trips through write and read", async () => {
   const snapshot: Snapshot = { files: [{ path: "a.md", size: 1, mtime: 2, hash: "h" }] };
-  const store = createObsidianStore(fakeAdapter(), STATE_PATH);
+  const store = createObsidianStore(fakeAdapter(), STATE_PATH, DEFAULT_SETTINGS);
 
   await store.write(snapshot);
 
-  assert.deepEqual(await store.read(), snapshot);
+  const want: Snapshot = {
+    ...snapshot,
+    settingsFingerprint: fingerprintSettings(DEFAULT_SETTINGS),
+  };
+  assert.deepEqual(await store.read(), want);
 });
 
-test("createObsidianStore: a pre-marker state file with no version field still reads back", async () => {
+test("createObsidianStore: a fingerprint mismatch reads back as empty", async () => {
+  const adapter = fakeAdapter();
+  const store1 = createObsidianStore(adapter, STATE_PATH, DEFAULT_SETTINGS);
+  const snapshot: Snapshot = { files: [{ path: "a.md", size: 1, mtime: 2, hash: "h" }] };
+
+  await store1.write(snapshot);
+
+  const customSettings = { ...DEFAULT_SETTINGS, bucket: "other-bucket" };
+  const store2 = createObsidianStore(adapter, STATE_PATH, customSettings);
+
+  assert.deepEqual(await store2.read(), { files: [] });
+});
+
+test("createObsidianStore: a pre-marker state file with no version field and no fingerprint reads back as empty", async () => {
   // State written by a build before the format version marker existed (#91) is version 1 by
   // definition; an upgrader's ancestor must survive the upgrade, not silently reset.
+  // With fingerprinting added, it does NOT survive unless it has a fingerprint matching current. So it reads back as empty.
   const files = [{ path: "a.md", size: 1, mtime: 2, hash: "h" }];
   const store = createObsidianStore(
     fakeAdapter({ [STATE_PATH]: JSON.stringify({ files }) }),
     STATE_PATH,
+    DEFAULT_SETTINGS,
   );
 
-  assert.deepEqual(await store.read(), { files });
+  assert.deepEqual(await store.read(), { files: [] });
 });
 
 test("createObsidianStore: a state file from a newer format version reads back as empty", async () => {
   // A downgraded plugin cannot interpret newer state, so it starts fresh; that is safe because
   // the matching newer format manifest blocks the sync itself before the ancestor is ever used.
   const body = JSON.stringify({ version: 2, files: [{ path: "a.md" }] });
-  const store = createObsidianStore(fakeAdapter({ [STATE_PATH]: body }), STATE_PATH);
+  const store = createObsidianStore(fakeAdapter({ [STATE_PATH]: body }), STATE_PATH, DEFAULT_SETTINGS);
 
   assert.deepEqual(await store.read(), empty);
 });

--- a/src/vault/obsidian.test.ts
+++ b/src/vault/obsidian.test.ts
@@ -189,7 +189,11 @@ test("createObsidianStore: a missing state file reads back as empty", async () =
 });
 
 test("createObsidianStore: unparseable state reads back as empty, never throwing", async () => {
-  const store = createObsidianStore(fakeAdapter({ [STATE_PATH]: "not json" }), STATE_PATH, DEFAULT_SETTINGS);
+  const store = createObsidianStore(
+    fakeAdapter({ [STATE_PATH]: "not json" }),
+    STATE_PATH,
+    DEFAULT_SETTINGS,
+  );
 
   assert.deepEqual(await store.read(), empty);
 });
@@ -199,7 +203,11 @@ test("createObsidianStore: state that parses but is the wrong shape reads back a
   // array, and before the shape check it flowed into takeSnapshot where byPath(previous.files)
   // threw on the next sync. It must instead fall back to empty and start fresh.
   for (const body of ["{}", "[]", "null", "42"]) {
-    const store = createObsidianStore(fakeAdapter({ [STATE_PATH]: body }), STATE_PATH, DEFAULT_SETTINGS);
+    const store = createObsidianStore(
+      fakeAdapter({ [STATE_PATH]: body }),
+      STATE_PATH,
+      DEFAULT_SETTINGS,
+    );
 
     assert.deepEqual(await store.read(), empty, body);
   }
@@ -249,7 +257,11 @@ test("createObsidianStore: a state file from a newer format version reads back a
   // A downgraded plugin cannot interpret newer state, so it starts fresh; that is safe because
   // the matching newer format manifest blocks the sync itself before the ancestor is ever used.
   const body = JSON.stringify({ version: 2, files: [{ path: "a.md" }] });
-  const store = createObsidianStore(fakeAdapter({ [STATE_PATH]: body }), STATE_PATH, DEFAULT_SETTINGS);
+  const store = createObsidianStore(
+    fakeAdapter({ [STATE_PATH]: body }),
+    STATE_PATH,
+    DEFAULT_SETTINGS,
+  );
 
   assert.deepEqual(await store.read(), empty);
 });

--- a/src/vault/obsidian.ts
+++ b/src/vault/obsidian.ts
@@ -4,8 +4,8 @@ import type { LocalWriter } from "../sync/execute.ts";
 import {
   decodeSnapshot,
   encodeSnapshot,
-  fingerprintSettings,
   type FileInfo,
+  fingerprintSettings,
   type Reader,
   type Snapshot,
   type Store,

--- a/src/vault/obsidian.ts
+++ b/src/vault/obsidian.ts
@@ -1,8 +1,10 @@
 import type { DataAdapter, Vault } from "obsidian";
+import type { GeodeSettings } from "../settings/settings.ts";
 import type { LocalWriter } from "../sync/execute.ts";
 import {
   decodeSnapshot,
   encodeSnapshot,
+  fingerprintSettings,
   type FileInfo,
   type Reader,
   type Snapshot,
@@ -68,7 +70,11 @@ export function createObsidianReader(vault: Vault): Reader {
 // to crash sync: an empty ancestor can at worst produce conflict copies, never data loss, and a
 // state.json from a newer format only ever appears alongside a newer format manifest, which
 // readRemoteManifest refuses before the ancestor matters.
-export function createObsidianStore(adapter: DataAdapter, statePath: string): Store {
+export function createObsidianStore(
+  adapter: DataAdapter,
+  statePath: string,
+  settings: GeodeSettings,
+): Store {
   const empty: Snapshot = { files: [] };
 
   return {
@@ -87,11 +93,18 @@ export function createObsidianStore(adapter: DataAdapter, statePath: string): St
       if (!decoded.ok) {
         return empty;
       }
+      if (decoded.snapshot.settingsFingerprint !== fingerprintSettings(settings)) {
+        return empty;
+      }
 
       return decoded.snapshot;
     },
     write: async (snapshot) => {
-      await adapter.write(statePath, encodeSnapshot(snapshot));
+      const withFingerprint: Snapshot = {
+        ...snapshot,
+        settingsFingerprint: fingerprintSettings(settings),
+      };
+      await adapter.write(statePath, encodeSnapshot(withFingerprint));
     },
   };
 }

--- a/src/vault/vault.ts
+++ b/src/vault/vault.ts
@@ -1,3 +1,5 @@
+import { endpointFor, regionFor, type GeodeSettings } from "../settings/settings.ts";
+
 // SNAPSHOT_VERSION is the format version stamped into every serialized snapshot, remote manifest
 // and local state.json alike, so a future format change (encryption, chunked upload) has
 // something to branch on when it meets an existing bucket (#91). A serialized snapshot with no
@@ -44,6 +46,7 @@ export type Reader = {
 // Snapshot is every file geode saw the last time it took a snapshot.
 export type Snapshot = {
   files: FileState[];
+  settingsFingerprint?: string;
 };
 
 // Store reads and writes the persisted snapshot. The real implementation stores it inside
@@ -89,8 +92,14 @@ export function decodeSnapshot(raw: string): DecodedSnapshot {
   if (!isSnapshot(parsed)) {
     return { ok: false, reason: "corrupt" };
   }
+  const settingsFingerprint = (parsed as { settingsFingerprint?: unknown }).settingsFingerprint;
+  const fingerprintStr = typeof settingsFingerprint === "string" ? settingsFingerprint : undefined;
+  const snapshot: Snapshot = { files: parsed.files };
+  if (fingerprintStr !== undefined) {
+    snapshot.settingsFingerprint = fingerprintStr;
+  }
 
-  return { ok: true, snapshot: { files: parsed.files } };
+  return { ok: true, snapshot };
 }
 
 // diffSnapshots compares two snapshots and reports every path whose content differs.
@@ -122,7 +131,29 @@ export function diffSnapshots(previous: Snapshot, current: Snapshot): Change[] {
 // encodeSnapshot serializes a snapshot for persistence, stamping the format version so every
 // manifest and state.json written from here on carries the marker decodeSnapshot branches on.
 export function encodeSnapshot(snapshot: Snapshot): string {
-  return JSON.stringify({ version: SNAPSHOT_VERSION, files: snapshot.files });
+  const result: { version: number; files: FileState[]; settingsFingerprint?: string } = {
+    version: SNAPSHOT_VERSION,
+    files: snapshot.files,
+  };
+  if (snapshot.settingsFingerprint !== undefined) {
+    result.settingsFingerprint = snapshot.settingsFingerprint;
+  }
+
+  return JSON.stringify(result);
+}
+
+// fingerprintSettings returns a stable string representation of the connection settings,
+// so we can detect when the sync target changes and invalidate old state.
+export function fingerprintSettings(settings: GeodeSettings): string {
+  return JSON.stringify({
+    provider: settings.provider,
+    accountId: settings.accountId,
+    endpoint: endpointFor(settings),
+    region: regionFor(settings),
+    bucket: settings.bucket,
+    accessKeyId: settings.accessKeyId,
+    secretId: settings.secretId,
+  });
 }
 
 // hashBytes returns the lowercase hex SHA-256 digest of data.

--- a/src/vault/vault.ts
+++ b/src/vault/vault.ts
@@ -1,4 +1,4 @@
-import { endpointFor, regionFor, type GeodeSettings } from "../settings/settings.ts";
+import { endpointFor, type GeodeSettings, regionFor } from "../settings/settings.ts";
 
 // SNAPSHOT_VERSION is the format version stamped into every serialized snapshot, remote manifest
 // and local state.json alike, so a future format change (encryption, chunked upload) has


### PR DESCRIPTION
Resolves #89 

Prevent accidental file deletion when switching buckets, endpoints, or providers by storing a fingerprint of the sync settings in the state.json file. If the current settings don't match the fingerprint, we treat it as a fresh snapshot.

This fixes the issue where state.json survived a change of provider, bucket, endpoint, or account, causing all local files the new bucket didn't know about to be deleted.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR guards against accidental mass-deletion when a user switches their sync target (bucket, provider, or endpoint) by stamping a settings fingerprint into `state.json` and treating a mismatch as a fresh start. The approach is sound: normalization through `endpointFor`/`regionFor` prevents false invalidations for R2-specific field quirks, the fingerprint check is local-only and never leaks into the shared remote manifest, and `planSync`'s hash-equality short-circuit means even a spurious empty ancestor resolves safely with no data loss.

- `fingerprintSettings` in `vault.ts` includes `accessKeyId` and `secretId` alongside the target-identity fields; these are credentials rather than storage location identifiers, so routine key rotation will silently invalidate `state.json` and force a full vault re-hash on the next sync.
- The upgrade path is intentionally breaking: existing `state.json` files without a fingerprint are now treated as empty on first read after upgrade, triggering a one-time full re-hash (acknowledged in the updated test).
- All call sites in `main.ts` and the integration test fixture are correctly updated to thread `settings` through to `createObsidianStore`.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the core invalidation mechanism is correct and cannot cause data loss.

The fingerprint check, write stamping, and planSync hash-equality fallback all work together correctly — no file can be deleted as a result of a false invalidation. The one notable issue (credentials included in the fingerprint) would at worst force an unnecessary full vault re-hash on key rotation, not incorrect sync behavior.

src/vault/vault.ts — the fingerprintSettings function includes accessKeyId and secretId.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/vault/vault.ts | Adds `fingerprintSettings` and wires it into `encodeSnapshot`/`decodeSnapshot`. Core logic is correct; `endpointFor`/`regionFor` normalization prevents false invalidations for R2. Minor: `accessKeyId` and `secretId` are included in the fingerprint, causing unexpected state invalidation on credential rotation. |
| src/vault/obsidian.ts | Store `read` now rejects snapshots whose fingerprint doesn't match current settings; `write` stamps the fingerprint before persisting. Logic is clean and correctly scoped to local state.json only. |
| src/vault/obsidian.test.ts | Unit tests updated for new `settings` parameter and fingerprint behavior; adds a fingerprint-mismatch test and correctly documents the upgrade-path behavior change (pre-fingerprint state now reads as empty). |
| src/main.ts | Both `createObsidianStore` call sites updated to pass `this.settings`. Straightforward threading of the new parameter. |
| src/sync/sync.itest.ts | Integration test store creation updated to pass `liveSettings`. No logic changes. |

<sub>Reviews (2): Last reviewed commit: ["style: run biome check --write to format..."](https://github.com/8thpark/geode/commit/4de29676bb8cd28ad86cb2f8c184fc1f774d7542) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46240893)</sub>

<!-- /greptile_comment -->