### PR TITLE
Logs →  fix messages containing new lines corrupting format

### DIFF
--- a/src/log/log.test.ts
+++ b/src/log/log.test.ts
@@ -34,6 +34,64 @@ test("parseLogLine preserves tabs inside the message", () => {
   assert.deepEqual(parsed, entry);
 });
 
+const messageRoundTripCases: { message: string; label: string }[] = [
+  { label: "embedded newline", message: "error\nstacktrace" },
+  { label: "embedded CR", message: "line1\rline2" },
+  { label: "literal backslash-n", message: "path\\nother" },
+  { label: "both literal backslash-n and real newline", message: "path\\nother\nand more" },
+  { label: "multiple newlines", message: "a\nb\nc" },
+  { label: "CRLF", message: "line1\r\nline2" },
+];
+
+for (const { message, label } of messageRoundTripCases) {
+  test(`formatLogLine/parseLogLine round trip: ${label}`, () => {
+    const entry: LogEntry = {
+      time: Date.parse("2026-07-14T10:00:00.000Z"),
+      level: "error",
+      message,
+    };
+
+    const parsed = parseLogLine(formatLogLine(entry));
+
+    assert.deepEqual(parsed, entry);
+  });
+}
+
+test("formatLogLine produces a single physical line for a message with newlines", () => {
+  const entry: LogEntry = {
+    time: Date.parse("2026-07-14T10:00:00.000Z"),
+    level: "error",
+    message: "ENOENT\n  at readFileSync",
+  };
+
+  const line = formatLogLine(entry);
+
+  assert.equal(line.includes("\n"), false);
+});
+
+test("parseLogLine survives the adapter's split-on-newline path", () => {
+  const entry: LogEntry = {
+    time: Date.parse("2026-07-14T10:00:00.000Z"),
+    level: "error",
+    message: "sync: ENOENT\n  at readFileSync\n  at load",
+  };
+
+  const persisted = `${formatLogLine(entry)}\n`;
+
+  const entries: LogEntry[] = [];
+  for (const line of persisted.split("\n")) {
+    if (line !== "") {
+      const parsed = parseLogLine(line);
+      if (parsed !== undefined) {
+        entries.push(parsed);
+      }
+    }
+  }
+
+  assert.equal(entries.length, 1);
+  assert.deepEqual(entries[0], entry);
+});
+
 const malformedLines = [
   "",
   "not a log line",

--- a/src/log/log.ts
+++ b/src/log/log.ts
@@ -1,4 +1,9 @@
-const LEVEL_ORDER: Record<LogLevel, number> = { debug: 0, info: 1, warn: 2, error: 3 };
+const LEVEL_ORDER: Record<LogLevel, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+};
 
 // LogEntry is one line of geode's log.
 export type LogEntry = {
@@ -70,11 +75,24 @@ export function createMemorySink(maxLines: number): LogSink {
   };
 }
 
+// escapeMessage encodes control characters in a log message so the result is a single physical
+// line. Backslashes are escaped first so a pre-existing literal "\n" (two characters) is not
+// misinterpreted when newlines are escaped next.
+export function escapeMessage(msg: string): string {
+  return msg
+    .split("\\")
+    .join("\\\\")
+    .split("\n")
+    .join("\\n")
+    .split("\r")
+    .join("\\r");
+}
+
 // formatLogLine renders one entry as a single persisted line: an ISO timestamp, the level, then
 // the message, tab separated so parseLogLine can split on the same delimiter without tripping
 // over spaces in either the level or the message.
 export function formatLogLine(entry: LogEntry): string {
-  return `${new Date(entry.time).toISOString()}\t${entry.level}\t${entry.message}`;
+  return `${new Date(entry.time).toISOString()}\t${entry.level}\t${escapeMessage(entry.message)}`;
 }
 
 // levelEnabled reports whether a message at level should be logged when the minimum is minLevel.
@@ -93,7 +111,34 @@ export function parseLogLine(line: string): LogEntry | undefined {
   if (Number.isNaN(time) || !isLogLevel(rawLevel)) {
     return undefined;
   }
-  return { time, level: rawLevel, message: rest.join("\t") };
+  return { time, level: rawLevel, message: unescapeMessage(rest.join("\t")) };
+}
+
+// unescapeMessage reverses escapeMessage. Unlike escape, unescape must
+// scan character by character to avoid matching "\n" inside the stored "\\" sequence.
+export function unescapeMessage(msg: string): string {
+  let result = "";
+  for (let i = 0; i < msg.length; i++) {
+    if (msg[i] === "\\" && i + 1 < msg.length) {
+      const next = msg[i + 1];
+      if (next === "n") {
+        result += "\n";
+        i++;
+      } else if (next === "r") {
+        result += "\r";
+        i++;
+      } else if (next === "\\") {
+        result += "\\";
+        i++;
+      } else {
+        result += msg[i];
+      }
+    } else {
+      result += msg[i];
+    }
+  }
+
+  return result;
 }
 
 // trimLogLines keeps only the last maxLines lines of a log, dropping the oldest. The result keeps
@@ -124,7 +169,12 @@ function consoleFor(level: LogLevel): (message: string) => void {
 }
 
 function isLogLevel(value: string): value is LogLevel {
-  return value === "debug" || value === "info" || value === "warn" || value === "error";
+  return (
+    value === "debug" ||
+    value === "info" ||
+    value === "warn" ||
+    value === "error"
+  );
 }
 
 // linesOf splits a log's text into its lines. Every persisted line ends in "\n", so a naive split

--- a/src/log/log.ts
+++ b/src/log/log.ts
@@ -79,13 +79,7 @@ export function createMemorySink(maxLines: number): LogSink {
 // line. Backslashes are escaped first so a pre-existing literal "\n" (two characters) is not
 // misinterpreted when newlines are escaped next.
 export function escapeMessage(msg: string): string {
-  return msg
-    .split("\\")
-    .join("\\\\")
-    .split("\n")
-    .join("\\n")
-    .split("\r")
-    .join("\\r");
+  return msg.split("\\").join("\\\\").split("\n").join("\\n").split("\r").join("\\r");
 }
 
 // formatLogLine renders one entry as a single persisted line: an ISO timestamp, the level, then
@@ -169,12 +163,7 @@ function consoleFor(level: LogLevel): (message: string) => void {
 }
 
 function isLogLevel(value: string): value is LogLevel {
-  return (
-    value === "debug" ||
-    value === "info" ||
-    value === "warn" ||
-    value === "error"
-  );
+  return value === "debug" || value === "info" || value === "warn" || value === "error";
 }
 
 // linesOf splits a log's text into its lines. Every persisted line ends in "\n", so a naive split

--- a/src/sync/sync.ts
+++ b/src/sync/sync.ts
@@ -7,17 +7,8 @@ import {
   type Snapshot,
   takeSnapshot,
 } from "../vault/vault.ts";
-import {
-  executeSyncPlan,
-  type LocalWriter,
-  type SyncFailure,
-} from "./execute.ts";
-import {
-  MANIFEST_KEY,
-  manifestAfterSync,
-  planSync,
-  type SyncAction,
-} from "./plan.ts";
+import { executeSyncPlan, type LocalWriter, type SyncFailure } from "./execute.ts";
+import { MANIFEST_KEY, manifestAfterSync, planSync, type SyncAction } from "./plan.ts";
 
 // SyncOutcome is the result of a single sync pass. On success it carries the new snapshot to
 // persist as the next sync's starting point and how many actions were applied; on failure it
@@ -163,14 +154,7 @@ export async function syncOnce(
   const local = await takeSnapshot(reader, ancestor);
 
   const actions = planSync(ancestor, local, remote.snapshot);
-  const executed = await executeSyncPlan(
-    actions,
-    local,
-    reader,
-    localWriter,
-    storage,
-    now,
-  );
+  const executed = await executeSyncPlan(actions, local, reader, localWriter, storage, now);
 
   // The manifest is derived from what the plan just did to the bucket, never from a fresh disk
   // snapshot: a file edited while the plan ran would land in a re-snapshot claiming content the
@@ -181,12 +165,7 @@ export async function syncOnce(
   // keeps the entry the bucket really holds; the manifest is uploaded even when some actions
   // failed, so one bad file never leaves the rest of the pass's pushes invisible to every other
   // device (#87).
-  const manifest = manifestAfterSync(
-    local,
-    remote.snapshot,
-    executed.completed,
-    now,
-  );
+  const manifest = manifestAfterSync(local, remote.snapshot, executed.completed, now);
   const final = adoptLiveStats(manifest, await takeSnapshot(reader, local));
   const manifestBody = new TextEncoder().encode(JSON.stringify(final));
 
@@ -200,11 +179,7 @@ export async function syncOnce(
   if (!remote.firstSync) {
     condition = { kind: "ifMatch", etag: remote.etag };
   }
-  const uploaded = await storage.putObject(
-    MANIFEST_KEY,
-    manifestBody,
-    condition,
-  );
+  const uploaded = await storage.putObject(MANIFEST_KEY, manifestBody, condition);
   if (!uploaded.ok) {
     if (uploaded.status === "conflict") {
       return {

--- a/src/sync/sync.ts
+++ b/src/sync/sync.ts
@@ -7,8 +7,17 @@ import {
   type Snapshot,
   takeSnapshot,
 } from "../vault/vault.ts";
-import { executeSyncPlan, type LocalWriter, type SyncFailure } from "./execute.ts";
-import { MANIFEST_KEY, manifestAfterSync, planSync, type SyncAction } from "./plan.ts";
+import {
+  executeSyncPlan,
+  type LocalWriter,
+  type SyncFailure,
+} from "./execute.ts";
+import {
+  MANIFEST_KEY,
+  manifestAfterSync,
+  planSync,
+  type SyncAction,
+} from "./plan.ts";
 
 // SyncOutcome is the result of a single sync pass. On success it carries the new snapshot to
 // persist as the next sync's starting point and how many actions were applied; on failure it
@@ -19,7 +28,12 @@ import { MANIFEST_KEY, manifestAfterSync, planSync, type SyncAction } from "./pl
 // manifest never uploaded, or never got that far).
 export type SyncOutcome =
   | { ok: true; snapshot: Snapshot; changeCount: number }
-  | { ok: false; message: string; failures: SyncFailure[]; snapshot: Snapshot | null };
+  | {
+      ok: false;
+      message: string;
+      failures: SyncFailure[];
+      snapshot: Snapshot | null;
+    };
 
 // adoptLiveStats returns manifest with each entry swapped for the live vault's entry at the same
 // path wherever the content hashes match, so state.json carries local size and mtime and the next
@@ -85,9 +99,7 @@ export async function readRemoteManifest(
     return { ok: true, snapshot: parsed, firstSync: false, etag: fetched.etag };
   }
 
-  // TODO(#41): GetResult conflates 404 with every other failure; swap this for a real status
-  // once that's fixed, rather than sniffing the message text for a status code.
-  if (fetched.message.includes("(404)")) {
+  if (fetched.status === "not_found") {
     return { ok: true, snapshot: { files: [] }, firstSync: true };
   }
   return { ok: false, message: fetched.message };
@@ -151,7 +163,14 @@ export async function syncOnce(
   const local = await takeSnapshot(reader, ancestor);
 
   const actions = planSync(ancestor, local, remote.snapshot);
-  const executed = await executeSyncPlan(actions, local, reader, localWriter, storage, now);
+  const executed = await executeSyncPlan(
+    actions,
+    local,
+    reader,
+    localWriter,
+    storage,
+    now,
+  );
 
   // The manifest is derived from what the plan just did to the bucket, never from a fresh disk
   // snapshot: a file edited while the plan ran would land in a re-snapshot claiming content the
@@ -162,7 +181,12 @@ export async function syncOnce(
   // keeps the entry the bucket really holds; the manifest is uploaded even when some actions
   // failed, so one bad file never leaves the rest of the pass's pushes invisible to every other
   // device (#87).
-  const manifest = manifestAfterSync(local, remote.snapshot, executed.completed, now);
+  const manifest = manifestAfterSync(
+    local,
+    remote.snapshot,
+    executed.completed,
+    now,
+  );
   const final = adoptLiveStats(manifest, await takeSnapshot(reader, local));
   const manifestBody = new TextEncoder().encode(JSON.stringify(final));
 
@@ -176,7 +200,11 @@ export async function syncOnce(
   if (!remote.firstSync) {
     condition = { kind: "ifMatch", etag: remote.etag };
   }
-  const uploaded = await storage.putObject(MANIFEST_KEY, manifestBody, condition);
+  const uploaded = await storage.putObject(
+    MANIFEST_KEY,
+    manifestBody,
+    condition,
+  );
   if (!uploaded.ok) {
     if (uploaded.status === "conflict") {
       return {
@@ -186,7 +214,12 @@ export async function syncOnce(
         snapshot: null,
       };
     }
-    return { ok: false, message: uploaded.message, failures: executed.failures, snapshot: null };
+    return {
+      ok: false,
+      message: uploaded.message,
+      failures: executed.failures,
+      snapshot: null,
+    };
   }
 
   // The count comes from failed (one entry per planned path), not failures: a conflict can report


### PR DESCRIPTION
resolves #97

## Problem
Persisted log lines are newline delimited and messages are written verbatim. An error message containing a newline (common in thrown I/O and provider errors) splits into one valid line plus malformed continuation lines that the parser silently drops, so the most interesting half of an error never appears in the log view.  

`formatLogLine` wrote messages verbatim; any \n in the message broke the line delimiter and parseLogLine silently dropped the continuation lines.

## Changes
Added `escapeMessage` / `unescapeMessage` at the serialization boundary. formatLogLine escapes \, \n, \r before writing; parseLogLine unescapes them after reading. Unescape uses character-by-character scanning to avoid matching \n inside the stored \\ sequence.

## Tests
Eight new cases, round-trips for embedded newline, CR, literal backslash-n, both together, multiple newlines, CRLF; a single-line guarantee check; and an adapter split-and-parse simulation.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes log corruption caused by error messages containing newlines being written verbatim into a newline-delimited log file, causing the parser to silently drop the continuation lines. It also upgrades the 404 check in `readRemoteManifest` from message-text sniffing to the proper `status` field.

- Adds `escapeMessage` (escape `\` → `\\`, `\n` → `\n`, `\r` → `\r`) and `unescapeMessage` (character-by-character scanner) at the `formatLogLine`/`parseLogLine` boundary in `log.ts`. The escape ordering (backslash first) correctly prevents literal `\n` sequences from being misread, and the scanner correctly handles `\\n` without consuming the `n` as an escape target.
- Replaces the `fetched.message.includes("(404)")` sniff in `sync.ts` with `fetched.status === "not_found"`, closing the TODO added in #41 now that `ResultStatus` carries a proper discriminant.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the escape/unescape logic is correct in all tested and edge cases, and the sync status check is a straightforward improvement.

The escape ordering (backslash before newline) and the character-by-character unescape scanner are both implemented correctly and verified across eight round-trip cases including the tricky \
 ambiguity. The sync.ts change removes a fragile string-sniff in favour of the typed status discriminant that already existed on GetResult.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/log/log.ts | Adds escapeMessage/unescapeMessage at the format/parse boundary; escape ordering (backslash first, then newline, then CR) and char-by-char unescape are both correct; no issues found. |
| src/log/log.test.ts | Eight new test cases covering all escape combinations (embedded newline, CR, literal backslash-n, CRLF, multiple newlines, both together), a single-line guarantee, and an adapter split-and-parse simulation; coverage is thorough. |
| src/sync/sync.ts | Replaces fragile message.includes("(404)") sniffing with status === "not_found" (closing the TODO referencing #41), and reformats two multi-field union arms for line-length compliance; both changes are correct. |

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/log-format"](https://github.com/8thpark/geode/commit/b42d34fa52b165ae61b9d762fcccbc4fadddd6d2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46654327)</sub>

<!-- /greptile_comment -->