### PR TITLE
Sync → Fix test connection required fields

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -35,11 +35,7 @@ const VAULT_STATE_DEBOUNCE_MS = 2000;
 // equivalent) so the Settings command can jump straight to Geode's tab, and opening the log view
 // can close the settings modal out from under itself.
 type AppWithSetting = App & {
-  setting: {
-    open: () => void;
-    close: () => void;
-    openTabById: (id: string) => void;
-  };
+  setting: { open: () => void; close: () => void; openTabById: (id: string) => void };
 };
 
 // SyncStatus is the state the status bar item reflects.
@@ -203,14 +199,8 @@ export default class GeodePlugin extends Plugin {
   // runSync does the actual work of syncNow, split out so syncNow can own the in flight guard
   // and status bar bookkeeping around it without this getting lost in indentation.
   private async runSync(dir: string): Promise<void> {
-    const secretAccessKey = this.app.secretStorage.getSecret(this.settings.secretId);
-    if (secretAccessKey === null) {
-      this.logger.error(`sync: secret access key not found for ID "${this.settings.secretId}"`);
-      this.setSyncStatus("error", "secret access key not found; open settings to reconfigure");
-      return;
-    }
-
-    const storage = createS3Client(this.settings, rawSecret);
+    const secretAccessKey = this.app.secretStorage.getSecret(this.settings.secretId) ?? "";
+    const storage = createS3Client(this.settings, secretAccessKey);
     const stateStore = createObsidianStore(this.app.vault.adapter, `${dir}/state.json`);
     const reader = createObsidianReader(this.app.vault);
     const localWriter = createObsidianLocalWriter(this.app.vault.adapter);

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,7 +35,11 @@ const VAULT_STATE_DEBOUNCE_MS = 2000;
 // equivalent) so the Settings command can jump straight to Geode's tab, and opening the log view
 // can close the settings modal out from under itself.
 type AppWithSetting = App & {
-  setting: { open: () => void; close: () => void; openTabById: (id: string) => void };
+  setting: {
+    open: () => void;
+    close: () => void;
+    openTabById: (id: string) => void;
+  };
 };
 
 // SyncStatus is the state the status bar item reflects.
@@ -199,8 +203,14 @@ export default class GeodePlugin extends Plugin {
   // runSync does the actual work of syncNow, split out so syncNow can own the in flight guard
   // and status bar bookkeeping around it without this getting lost in indentation.
   private async runSync(dir: string): Promise<void> {
-    const secretAccessKey = this.app.secretStorage.getSecret(this.settings.secretId) ?? "";
-    const storage = createS3Client(this.settings, secretAccessKey);
+    const secretAccessKey = this.app.secretStorage.getSecret(this.settings.secretId);
+    if (secretAccessKey === null) {
+      this.logger.error(`sync: secret access key not found for ID "${this.settings.secretId}"`);
+      this.setSyncStatus("error", "secret access key not found; open settings to reconfigure");
+      return;
+    }
+
+    const storage = createS3Client(this.settings, rawSecret);
     const stateStore = createObsidianStore(this.app.vault.adapter, `${dir}/state.json`);
     const reader = createObsidianReader(this.app.vault);
     const localWriter = createObsidianLocalWriter(this.app.vault.adapter);

--- a/src/storage/storage.test.ts
+++ b/src/storage/storage.test.ts
@@ -84,7 +84,7 @@ test("testConnection: R2 with empty endpoint and region passes field check", asy
   const result = await testConnection(settings, "shh");
 
   assert.equal(result.ok, false);
-  assert.notEqual(result.status, "auth");
+  assert.ok(!result.message.startsWith("Fill in"));
 });
 
 test("parseListObjectsXml decodes XML entities in object keys", () => {

--- a/src/storage/storage.test.ts
+++ b/src/storage/storage.test.ts
@@ -28,6 +28,40 @@ const missingFieldCases: {
     secretAccessKey: "",
     want: "Fill in secret access key first",
   },
+  {
+    name: "missing account ID for R2",
+    settings: {
+      ...DEFAULT_SETTINGS,
+      bucket: "my-vault",
+      accessKeyId: "AKIA123",
+    },
+    secretAccessKey: "shh",
+    want: "Fill in account ID first",
+  },
+  {
+    name: "missing endpoint for custom",
+    settings: {
+      ...DEFAULT_SETTINGS,
+      provider: "custom",
+      region: "us-east-1",
+      bucket: "my-vault",
+      accessKeyId: "AKIA123",
+    },
+    secretAccessKey: "shh",
+    want: "Fill in endpoint first",
+  },
+  {
+    name: "missing region for custom",
+    settings: {
+      ...DEFAULT_SETTINGS,
+      provider: "custom",
+      endpoint: "https://s3.example.com",
+      bucket: "my-vault",
+      accessKeyId: "AKIA123",
+    },
+    secretAccessKey: "shh",
+    want: "Fill in region first",
+  },
 ];
 
 for (const { name, settings, secretAccessKey, want } of missingFieldCases) {
@@ -38,6 +72,20 @@ for (const { name, settings, secretAccessKey, want } of missingFieldCases) {
     assert.equal(result.message, want);
   });
 }
+
+test("testConnection: R2 with empty endpoint and region passes field check", async () => {
+  const settings: GeodeSettings = {
+    ...DEFAULT_SETTINGS,
+    bucket: "my-vault",
+    accessKeyId: "AKIA123",
+    accountId: "acc123",
+  };
+
+  const result = await testConnection(settings, "shh");
+
+  assert.equal(result.ok, false);
+  assert.notEqual(result.status, "auth");
+});
 
 test("parseListObjectsXml decodes XML entities in object keys", () => {
   const xml = `<?xml version="1.0" encoding="UTF-8"?>

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -1,9 +1,5 @@
 import { AwsClient } from "aws4fetch";
-import {
-  endpointFor,
-  type GeodeSettings,
-  regionFor,
-} from "../settings/settings.ts";
+import { endpointFor, type GeodeSettings, regionFor } from "../settings/settings.ts";
 import { encodeKey } from "./encode.ts";
 import { messageFor, statusForHttp } from "./errors.ts";
 import { parseListObjectsXml } from "./xml.ts";
@@ -54,9 +50,7 @@ export type ObjectMeta = {
 // equals etag, "ifAbsent" only while no object exists at the key. A failed precondition comes
 // back as a "conflict" status, how a caller detects a concurrent writer instead of silently
 // overwriting what that writer just stored.
-export type PutCondition =
-  | { kind: "ifMatch"; etag: string }
-  | { kind: "ifAbsent" };
+export type PutCondition = { kind: "ifMatch"; etag: string } | { kind: "ifAbsent" };
 
 // PutResult reports whether an object was written. Message is the empty string when ok is true.
 export type PutResult = {
@@ -68,33 +62,20 @@ export type PutResult = {
 // ResultStatus classifies the outcome of a storage operation so callers can distinguish absent
 // objects and failed put preconditions from transient failures without parsing the message
 // string.
-export type ResultStatus =
-  | "ok"
-  | "not_found"
-  | "conflict"
-  | "auth"
-  | "server"
-  | "network";
+export type ResultStatus = "ok" | "not_found" | "conflict" | "auth" | "server" | "network";
 
 // StorageClient reads, writes, deletes, and lists objects in a bucket. Every method takes and
 // returns plain data, never provider credentials or settings, so a future WebDAV or Dropbox
 // client can satisfy this same shape without changing anything that depends on it.
 export type StorageClient = {
-  putObject: (
-    key: string,
-    body: Uint8Array,
-    condition?: PutCondition,
-  ) => Promise<PutResult>;
+  putObject: (key: string, body: Uint8Array, condition?: PutCondition) => Promise<PutResult>;
   getObject: (key: string) => Promise<GetResult>;
   deleteObject: (key: string) => Promise<DeleteResult>;
   listObjects: (prefix?: string) => Promise<ListResult>;
 };
 
 // createS3Client returns a StorageClient backed by the S3 compatible endpoint in settings.
-export function createS3Client(
-  settings: GeodeSettings,
-  secretAccessKey: string,
-): StorageClient {
+export function createS3Client(settings: GeodeSettings, secretAccessKey: string): StorageClient {
   const client = new AwsClient({
     accessKeyId: settings.accessKeyId,
     secretAccessKey,
@@ -104,8 +85,7 @@ export function createS3Client(
   const baseUrl = `${endpointFor(settings)}/${settings.bucket}`;
 
   return {
-    putObject: (key, body, condition) =>
-      s3PutObject(client, baseUrl, key, body, condition),
+    putObject: (key, body, condition) => s3PutObject(client, baseUrl, key, body, condition),
     getObject: (key) => s3GetObject(client, baseUrl, key),
     deleteObject: (key) => s3DeleteObject(client, baseUrl, key),
     listObjects: (prefix) => s3ListObjects(client, baseUrl, prefix),
@@ -150,9 +130,7 @@ export async function testConnection(
 
 // conditionHeaders converts a PutCondition into the HTTP precondition headers an S3 compatible
 // server evaluates before accepting a write.
-function conditionHeaders(
-  condition: PutCondition | undefined,
-): Record<string, string> {
+function conditionHeaders(condition: PutCondition | undefined): Record<string, string> {
   if (condition === undefined) {
     return {};
   }
@@ -167,10 +145,7 @@ function conditionHeaders(
 // "" if everything required is present. The requirements mirror hasConnectionConfig: all providers
 // need bucket, access key, and secret; R2 derives endpoint and region from the account ID, so
 // only custom needs them explicitly.
-function missingFieldFor(
-  settings: GeodeSettings,
-  secretAccessKey: string,
-): string {
+function missingFieldFor(settings: GeodeSettings, secretAccessKey: string): string {
   if (settings.bucket === "") {
     return "bucket";
   }
@@ -223,11 +198,7 @@ async function s3DeleteObject(
 }
 
 // s3GetObject reads the bytes stored at key.
-async function s3GetObject(
-  client: AwsClient,
-  baseUrl: string,
-  key: string,
-): Promise<GetResult> {
+async function s3GetObject(client: AwsClient, baseUrl: string, key: string): Promise<GetResult> {
   let response: Response;
   try {
     response = await client.fetch(`${baseUrl}/${encodeKey(key)}`, {

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -1,5 +1,9 @@
 import { AwsClient } from "aws4fetch";
-import { endpointFor, type GeodeSettings, regionFor } from "../settings/settings.ts";
+import {
+  endpointFor,
+  type GeodeSettings,
+  regionFor,
+} from "../settings/settings.ts";
 import { encodeKey } from "./encode.ts";
 import { messageFor, statusForHttp } from "./errors.ts";
 import { parseListObjectsXml } from "./xml.ts";
@@ -50,7 +54,9 @@ export type ObjectMeta = {
 // equals etag, "ifAbsent" only while no object exists at the key. A failed precondition comes
 // back as a "conflict" status, how a caller detects a concurrent writer instead of silently
 // overwriting what that writer just stored.
-export type PutCondition = { kind: "ifMatch"; etag: string } | { kind: "ifAbsent" };
+export type PutCondition =
+  | { kind: "ifMatch"; etag: string }
+  | { kind: "ifAbsent" };
 
 // PutResult reports whether an object was written. Message is the empty string when ok is true.
 export type PutResult = {
@@ -62,20 +68,33 @@ export type PutResult = {
 // ResultStatus classifies the outcome of a storage operation so callers can distinguish absent
 // objects and failed put preconditions from transient failures without parsing the message
 // string.
-export type ResultStatus = "ok" | "not_found" | "conflict" | "auth" | "server" | "network";
+export type ResultStatus =
+  | "ok"
+  | "not_found"
+  | "conflict"
+  | "auth"
+  | "server"
+  | "network";
 
 // StorageClient reads, writes, deletes, and lists objects in a bucket. Every method takes and
 // returns plain data, never provider credentials or settings, so a future WebDAV or Dropbox
 // client can satisfy this same shape without changing anything that depends on it.
 export type StorageClient = {
-  putObject: (key: string, body: Uint8Array, condition?: PutCondition) => Promise<PutResult>;
+  putObject: (
+    key: string,
+    body: Uint8Array,
+    condition?: PutCondition,
+  ) => Promise<PutResult>;
   getObject: (key: string) => Promise<GetResult>;
   deleteObject: (key: string) => Promise<DeleteResult>;
   listObjects: (prefix?: string) => Promise<ListResult>;
 };
 
 // createS3Client returns a StorageClient backed by the S3 compatible endpoint in settings.
-export function createS3Client(settings: GeodeSettings, secretAccessKey: string): StorageClient {
+export function createS3Client(
+  settings: GeodeSettings,
+  secretAccessKey: string,
+): StorageClient {
   const client = new AwsClient({
     accessKeyId: settings.accessKeyId,
     secretAccessKey,
@@ -85,7 +104,8 @@ export function createS3Client(settings: GeodeSettings, secretAccessKey: string)
   const baseUrl = `${endpointFor(settings)}/${settings.bucket}`;
 
   return {
-    putObject: (key, body, condition) => s3PutObject(client, baseUrl, key, body, condition),
+    putObject: (key, body, condition) =>
+      s3PutObject(client, baseUrl, key, body, condition),
     getObject: (key) => s3GetObject(client, baseUrl, key),
     deleteObject: (key) => s3DeleteObject(client, baseUrl, key),
     listObjects: (prefix) => s3ListObjects(client, baseUrl, prefix),
@@ -130,7 +150,9 @@ export async function testConnection(
 
 // conditionHeaders converts a PutCondition into the HTTP precondition headers an S3 compatible
 // server evaluates before accepting a write.
-function conditionHeaders(condition: PutCondition | undefined): Record<string, string> {
+function conditionHeaders(
+  condition: PutCondition | undefined,
+): Record<string, string> {
   if (condition === undefined) {
     return {};
   }
@@ -142,8 +164,13 @@ function conditionHeaders(condition: PutCondition | undefined): Record<string, s
 }
 
 // missingFieldFor returns the name of the first field testConnection needs but doesn't have, or
-// "" if everything required is present.
-function missingFieldFor(settings: GeodeSettings, secretAccessKey: string): string {
+// "" if everything required is present. The requirements mirror hasConnectionConfig: all providers
+// need bucket, access key, and secret; R2 derives endpoint and region from the account ID, so
+// only custom needs them explicitly.
+function missingFieldFor(
+  settings: GeodeSettings,
+  secretAccessKey: string,
+): string {
   if (settings.bucket === "") {
     return "bucket";
   }
@@ -153,6 +180,20 @@ function missingFieldFor(settings: GeodeSettings, secretAccessKey: string): stri
   if (secretAccessKey === "") {
     return "secret access key";
   }
+
+  if (settings.provider === "r2") {
+    if (settings.accountId === "") {
+      return "account ID";
+    }
+  } else {
+    if (settings.endpoint === "") {
+      return "endpoint";
+    }
+    if (settings.region === "") {
+      return "region";
+    }
+  }
+
   return "";
 }
 
@@ -164,7 +205,9 @@ async function s3DeleteObject(
 ): Promise<DeleteResult> {
   let response: Response;
   try {
-    response = await client.fetch(`${baseUrl}/${encodeKey(key)}`, { method: "DELETE" });
+    response = await client.fetch(`${baseUrl}/${encodeKey(key)}`, {
+      method: "DELETE",
+    });
   } catch (err) {
     return { ok: false, status: "network", message: messageFor(err) };
   }
@@ -180,12 +223,24 @@ async function s3DeleteObject(
 }
 
 // s3GetObject reads the bytes stored at key.
-async function s3GetObject(client: AwsClient, baseUrl: string, key: string): Promise<GetResult> {
+async function s3GetObject(
+  client: AwsClient,
+  baseUrl: string,
+  key: string,
+): Promise<GetResult> {
   let response: Response;
   try {
-    response = await client.fetch(`${baseUrl}/${encodeKey(key)}`, { method: "GET" });
+    response = await client.fetch(`${baseUrl}/${encodeKey(key)}`, {
+      method: "GET",
+    });
   } catch (err) {
-    return { ok: false, status: "network", message: messageFor(err), body: null, etag: null };
+    return {
+      ok: false,
+      status: "network",
+      message: messageFor(err),
+      body: null,
+      etag: null,
+    };
   }
 
   if (!response.ok) {
@@ -231,7 +286,12 @@ async function s3ListObjects(
     try {
       response = await client.fetch(url, { method: "GET" });
     } catch (err) {
-      return { ok: false, status: "network", message: messageFor(err), objects: [] };
+      return {
+        ok: false,
+        status: "network",
+        message: messageFor(err),
+        objects: [],
+      };
     }
 
     if (!response.ok) {


### PR DESCRIPTION
Resolves #98 

## Problem

The missing field check before a connection test covers bucket, access key ID, and secret, but not endpoint or region for the custom provider. Testing with an empty endpoint builds a garbage URL and surfaces a raw network error instead of naming the field that needs filling in. 
`hasConnectionConfig` already knows the per provider requirements; the test path disagrees with it.

## Changes 

Added new checks in `missingFieldFor` to check for endpoint and region.

## Tests

Added four new test cases: missing account ID (R2), missing endpoint (custom), missing region (custom), and R2 with empty endpoint/region passing the field check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes the gap between `hasConnectionConfig` and `missingFieldFor` by adding the missing provider-specific field checks — `accountId` for R2 and `endpoint`/`region` for custom — so a test connection with an incomplete config returns a named-field error instead of falling through to a garbage URL and a raw network failure.

- `missingFieldFor` in `storage.ts` now branches on `provider`: R2 checks `accountId`; custom checks `endpoint` then `region`. The logic mirrors `hasConnectionConfig` exactly, and the function comment is updated to document the pairing.
- Four new unit test cases cover each newly-guarded field; a separate integration test verifies that a fully-populated R2 config clears the field-check gate and reaches an actual connection attempt, using a message-prefix assertion (`!result.message.startsWith("Fill in")`) that is resilient to real network responses.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted, well-tested addition to a pure validation helper with no side effects on the connection path itself.

The new `missingFieldFor` branches are a straightforward mirror of `hasConnectionConfig`, all four new test cases are mechanically correct, and the one integration test uses a message-prefix assertion that holds regardless of network conditions in CI.

**Files Needing Attention:** No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/storage/storage.ts | Extends `missingFieldFor` to check `accountId` for R2 and `endpoint`/`region` for custom providers, matching the logic already in `hasConnectionConfig`; also reformats some multi-line return objects. |
| src/storage/storage.test.ts | Adds four new test cases covering the new `missingFieldFor` paths; the integration test uses a message-prefix assertion rather than a status check, making it resilient to real network responses. |

<sub>Reviews (8): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/test-connec..."](https://github.com/8thpark/geode/commit/cfc37b7c913f0ac8d2403d867e6e38279db6dcc8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46663407)</sub>

<!-- /greptile_comment -->