### PR TITLE
Classify HTTP 400 responses as client errors

### DIFF
--- a/src/storage/errors.test.ts
+++ b/src/storage/errors.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { statusForHttp } from "./errors.ts";
+import type { ResultStatus } from "./storage.ts";
+
+test("statusForHttp: classifies provider responses", () => {
+  const cases: { code: number; want: ResultStatus }[] = [
+    { code: 400, want: "client" },
+    { code: 401, want: "auth" },
+    { code: 403, want: "auth" },
+    { code: 404, want: "not_found" },
+    { code: 412, want: "conflict" },
+    { code: 429, want: "server" },
+    { code: 500, want: "server" },
+  ];
+
+  for (const tc of cases) {
+    assert.equal(statusForHttp(tc.code), tc.want, `HTTP ${tc.code}`);
+  }
+});

--- a/src/storage/errors.ts
+++ b/src/storage/errors.ts
@@ -8,8 +8,8 @@ export function messageFor(err: unknown): string {
   return "Network error";
 }
 
-// statusForHttp maps an HTTP status code to a ResultStatus; unrecognised codes (including 5xx and
-// stray 4xx such as 429) fall through to "server", which callers treat as retryable.
+// statusForHttp maps HTTP 400 to the non-retryable client status and preserves known domain
+// statuses; unrecognised codes, including 5xx and 429, fall through to retryable server status.
 export function statusForHttp(code: number): ResultStatus {
   if (code === 400) {
     return "client";

--- a/src/storage/errors.ts
+++ b/src/storage/errors.ts
@@ -11,6 +11,9 @@ export function messageFor(err: unknown): string {
 // statusForHttp maps an HTTP status code to a ResultStatus; unrecognised codes (including 5xx and
 // stray 4xx such as 429) fall through to "server", which callers treat as retryable.
 export function statusForHttp(code: number): ResultStatus {
+  if (code === 400) {
+    return "client";
+  }
   if (code === 404) {
     return "not_found";
   }

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -62,7 +62,14 @@ export type PutResult = {
 // ResultStatus classifies the outcome of a storage operation so callers can distinguish absent
 // objects and failed put preconditions from transient failures without parsing the message
 // string.
-export type ResultStatus = "ok" | "not_found" | "conflict" | "auth" | "server" | "network";
+export type ResultStatus =
+  | "ok"
+  | "not_found"
+  | "conflict"
+  | "auth"
+  | "client"
+  | "server"
+  | "network";
 
 // StorageClient reads, writes, deletes, and lists objects in a bucket. Every method takes and
 // returns plain data, never provider credentials or settings, so a future WebDAV or Dropbox


### PR DESCRIPTION
## What changed

- add a `client` storage result status for non-retryable request failures
- classify HTTP 400 responses as `client` instead of retryable `server` failures
- add table-driven coverage for 400 and the existing auth, not-found, conflict, rate-limit, and server mappings

## Why

Providers use HTTP 400 for malformed requests and some credential problems. Retrying those
responses cannot succeed without changing the request, so treating them as transient server
failures would cause the retry work in #54 to loop unnecessarily.

Closes #100.

## Validation

- `npm test` (138 passed)
- targeted Biome check for the three changed files
- `npm run build`
- `npm run check-versions`
- `npm run audit` (0 production vulnerabilities)

`npm run lint` was also attempted on Windows, but the clone-wide check reports existing CRLF/LF
formatting differences across the checkout. The three changed files pass a targeted Biome check
after formatting.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a `"client"` variant to `ResultStatus` and routes HTTP 400 responses to it in `statusForHttp`, preventing the upcoming retry logic (#54) from looping on malformed-request errors that cannot succeed without a changed request. The function comment was also updated (per the prior review thread) and a new table-driven test file covers all six HTTP code mappings.

- `src/storage/storage.ts`: `"client"` is added to the `ResultStatus` union; no existing callers use exhaustive switches so the new variant flows through generic fallthrough paths without breaking anything.
- `src/storage/errors.ts`: The new `code === 400` branch is placed first and is mutually exclusive with all other checks; the mapping is correct.
- `src/storage/errors.test.ts`: New test file exercises every explicitly mapped code (400, 401, 403, 404, 412, 429, 500) using a table-driven pattern consistent with the rest of the test suite.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrow, well-tested, and existing callers handle the new status gracefully.

The three changed files make a small, self-contained addition: a new union member and a single new branch in a pure mapping function. All six HTTP code mappings are covered by the new test. No existing caller uses an exhaustive switch on ResultStatus, so the new variant does not break any dispatch logic.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/storage/storage.ts | Adds "client" to the ResultStatus union type; existing callers handle the new variant gracefully via generic fallthrough paths. |
| src/storage/errors.ts | Adds an early HTTP 400 → "client" branch before the existing status mappings; logic is correct and mutually exclusive with all other checks. |
| src/storage/errors.test.ts | New table-driven test file covering all mapped HTTP codes (400, 401, 403, 404, 412, 429, 500); complete and correct. |

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into agent/classify-..."](https://github.com/8thpark/geode/commit/404de09c5f2422812f2a3af1a0d94031aad5beb0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46673929)</sub>

<!-- /greptile_comment -->