### PR TITLE
Sync → add null guard for missing secret access key

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -204,7 +204,7 @@ export default class GeodePlugin extends Plugin {
   // and status bar bookkeeping around it without this getting lost in indentation.
   private async runSync(dir: string): Promise<void> {
     const secretAccessKey = this.app.secretStorage.getSecret(this.settings.secretId);
-    if (secretAccessKey === null) {
+    if (secretAccessKey === null || secretAccessKey === "") {
       this.logger.error(`sync: secret access key not found for ID "${this.settings.secretId}"`);
       this.setSyncStatus("error", "secret access key not found; open settings to reconfigure");
       return;

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,11 +35,7 @@ const VAULT_STATE_DEBOUNCE_MS = 2000;
 // equivalent) so the Settings command can jump straight to Geode's tab, and opening the log view
 // can close the settings modal out from under itself.
 type AppWithSetting = App & {
-  setting: {
-    open: () => void;
-    close: () => void;
-    openTabById: (id: string) => void;
-  };
+  setting: { open: () => void; close: () => void; openTabById: (id: string) => void };
 };
 
 // SyncStatus is the state the status bar item reflects.
@@ -203,14 +199,8 @@ export default class GeodePlugin extends Plugin {
   // runSync does the actual work of syncNow, split out so syncNow can own the in flight guard
   // and status bar bookkeeping around it without this getting lost in indentation.
   private async runSync(dir: string): Promise<void> {
-    const secretAccessKey = this.app.secretStorage.getSecret(this.settings.secretId);
-    if (secretAccessKey === null) {
-      this.logger.error(`sync: secret access key not found for ID "${this.settings.secretId}"`);
-      this.setSyncStatus("error", "secret access key not found; open settings to reconfigure");
-      return;
-    }
-
-    const storage = createS3Client(this.settings, rawSecret);
+    const secretAccessKey = this.app.secretStorage.getSecret(this.settings.secretId) ?? "";
+    const storage = createS3Client(this.settings, secretAccessKey);
     const stateStore = createObsidianStore(this.app.vault.adapter, `${dir}/state.json`);
     const reader = createObsidianReader(this.app.vault);
     const localWriter = createObsidianLocalWriter(this.app.vault.adapter);

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,7 +35,11 @@ const VAULT_STATE_DEBOUNCE_MS = 2000;
 // equivalent) so the Settings command can jump straight to Geode's tab, and opening the log view
 // can close the settings modal out from under itself.
 type AppWithSetting = App & {
-  setting: { open: () => void; close: () => void; openTabById: (id: string) => void };
+  setting: {
+    open: () => void;
+    close: () => void;
+    openTabById: (id: string) => void;
+  };
 };
 
 // SyncStatus is the state the status bar item reflects.
@@ -199,7 +203,13 @@ export default class GeodePlugin extends Plugin {
   // runSync does the actual work of syncNow, split out so syncNow can own the in flight guard
   // and status bar bookkeeping around it without this getting lost in indentation.
   private async runSync(dir: string): Promise<void> {
-    const secretAccessKey = this.app.secretStorage.getSecret(this.settings.secretId) ?? "";
+    const secretAccessKey = this.app.secretStorage.getSecret(this.settings.secretId);
+    if (secretAccessKey === null) {
+      this.logger.error(`sync: secret access key not found for ID "${this.settings.secretId}"`);
+      this.setSyncStatus("error", "secret access key not found; open settings to reconfigure");
+      return;
+    }
+
     const storage = createS3Client(this.settings, secretAccessKey);
     const stateStore = createObsidianStore(this.app.vault.adapter, `${dir}/state.json`);
     const reader = createObsidianReader(this.app.vault);

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,7 +35,11 @@ const VAULT_STATE_DEBOUNCE_MS = 2000;
 // equivalent) so the Settings command can jump straight to Geode's tab, and opening the log view
 // can close the settings modal out from under itself.
 type AppWithSetting = App & {
-  setting: { open: () => void; close: () => void; openTabById: (id: string) => void };
+  setting: {
+    open: () => void;
+    close: () => void;
+    openTabById: (id: string) => void;
+  };
 };
 
 // SyncStatus is the state the status bar item reflects.
@@ -199,8 +203,14 @@ export default class GeodePlugin extends Plugin {
   // runSync does the actual work of syncNow, split out so syncNow can own the in flight guard
   // and status bar bookkeeping around it without this getting lost in indentation.
   private async runSync(dir: string): Promise<void> {
-    const secretAccessKey = this.app.secretStorage.getSecret(this.settings.secretId) ?? "";
-    const storage = createS3Client(this.settings, secretAccessKey);
+    const secretAccessKey = this.app.secretStorage.getSecret(this.settings.secretId);
+    if (secretAccessKey === null) {
+      this.logger.error(`sync: secret access key not found for ID "${this.settings.secretId}"`);
+      this.setSyncStatus("error", "secret access key not found; open settings to reconfigure");
+      return;
+    }
+
+    const storage = createS3Client(this.settings, rawSecret);
     const stateStore = createObsidianStore(this.app.vault.adapter, `${dir}/state.json`);
     const reader = createObsidianReader(this.app.vault);
     const localWriter = createObsidianLocalWriter(this.app.vault.adapter);


### PR DESCRIPTION
resolves #99 

## Problem
When the stored secret ID resolves to nothing (deleted secret, restored device, renamed entry), sync proceeds with an empty secret access key and fails with a provider 403 that says nothing about the actual cause. The settings tab already detects and warns about an unresolvable secret; the sync path does not.

## Changes
In `runSync()`, resolve the secret and check for null before creating the S3 client. On failure, log the unresolvable ID and set a clear status message: "secret access key not found; open settings to reconfigure".

# P.S.
has 3 commits because I accidentally pushed to main on my fork, so had to revert it and create a new branch.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR guards the sync path against a missing or empty secret access key by resolving the secret before constructing the S3 client and returning early with a descriptive error status when it is absent.

- Replaces the silent `?? ""` fallback with an explicit `null | ""` check that logs the unresolvable secret ID and surfaces a clear "open settings to reconfigure" message to the user.
- Handles both the `null` case (deleted/renamed secret) and the empty-string case (e.g. a blank value saved by the user), keeping the guard consistent with the pattern `tab.ts` already uses before its connection test.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted early-return guard that can only cause sync to fail faster and more clearly than before, with no risk of silent data loss.

The guard covers both the null and empty-string paths, the error message and log are informative, the logic matches the existing pattern in `tab.ts`, and no existing behaviour is regressed — sync that previously reached the S3 client with an unusable key now exits early with a clear status instead.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/main.ts | Adds null/empty-string guard for the resolved secret access key before constructing the S3 client, with a clear error log and user-facing status message on failure; the `AppWithSetting` type is also reformatted for readability. |

<sub>Reviews (2): Last reviewed commit: ["refactor: add empty string check"](https://github.com/8thpark/geode/commit/877e5eaf5e89e831bc3d7eb845ad3bbd595b202e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46675081)</sub>

<!-- /greptile_comment -->