### PR TITLE
Sync → Add format version to manifest and state.json

### DIFF
--- a/src/sync/sync.test.ts
+++ b/src/sync/sync.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { hashBytes, type Snapshot } from "../vault/vault.ts";
+import { encodeSnapshot, hashBytes, type Snapshot } from "../vault/vault.ts";
 import type { LocalWriter } from "./execute.ts";
 import { empty, fakeLocalWriter, fakeReader, fakeStorage, file, snapshot } from "./fake.ts";
 import { conflictCopyPath, MANIFEST_KEY } from "./plan.ts";
@@ -22,7 +22,7 @@ test("readRemoteManifest: a 404 is treated as an empty snapshot", async () => {
 
 test("readRemoteManifest: valid JSON is parsed into a snapshot, with the manifest's etag", async () => {
   const want: Snapshot = snapshot(file("a.md", "h1"));
-  const { storage } = fakeStorage({ [MANIFEST_KEY]: JSON.stringify(want) });
+  const { storage } = fakeStorage({ [MANIFEST_KEY]: encodeSnapshot(want) });
 
   const result = await readRemoteManifest(storage);
 
@@ -32,7 +32,7 @@ test("readRemoteManifest: valid JSON is parsed into a snapshot, with the manifes
 test("readRemoteManifest: a manifest without an etag is refused, not synced unsafely", async () => {
   // Without an etag the manifest upload can't be conditional, and an unconditional upload is the
   // concurrent clobber #83 fixed; the pass must refuse rather than proceed.
-  const { storage } = fakeStorage({ [MANIFEST_KEY]: JSON.stringify(empty) });
+  const { storage } = fakeStorage({ [MANIFEST_KEY]: encodeSnapshot(empty) });
   const inner = storage.getObject;
   storage.getObject = async (key) => {
     const result = await inner(key);
@@ -63,6 +63,30 @@ test("readRemoteManifest: JSON of the wrong shape is corrupt, not a snapshot wit
 
     assert.deepEqual(result, { ok: false, message: "remote manifest is corrupt" }, body);
   }
+});
+
+test("readRemoteManifest: a pre-marker manifest with no version field is accepted as version 1", async () => {
+  // Buckets written before the format version marker existed (#91) are version 1 by definition;
+  // they must keep syncing, not read as corrupt.
+  const want: Snapshot = snapshot(file("a.md", "h1"));
+  const { storage } = fakeStorage({ [MANIFEST_KEY]: JSON.stringify(want) });
+
+  const result = await readRemoteManifest(storage);
+
+  assert.deepEqual(result, { ok: true, snapshot: want, firstSync: false, etag: '"v1"' });
+});
+
+test("readRemoteManifest: a manifest from a newer format version refuses the pass", async () => {
+  // A bucket written in a format this build does not know must not be synced against, and the
+  // message points at the actual fix (update the plugin) instead of claiming corruption.
+  const { storage } = fakeStorage({ [MANIFEST_KEY]: JSON.stringify({ version: 2, files: [] }) });
+
+  const result = await readRemoteManifest(storage);
+
+  assert.deepEqual(result, {
+    ok: false,
+    message: "remote manifest needs a newer version of geode",
+  });
 });
 
 test("syncOnce: a stale ancestor is ignored on a first sync, so a populated vault is pushed, not wiped", async () => {
@@ -100,7 +124,7 @@ test("syncOnce: a present but empty manifest still trusts the ancestor and pulls
   const reader = fakeReader({ "a.md": "xy" });
   const { writer, files } = fakeLocalWriter();
   files.set("a.md", "xy");
-  const { storage } = fakeStorage({ [MANIFEST_KEY]: JSON.stringify(empty) });
+  const { storage } = fakeStorage({ [MANIFEST_KEY]: encodeSnapshot(empty) });
 
   const outcome = await syncOnce(previous, reader, writer, storage, 1);
 
@@ -130,8 +154,8 @@ test("syncOnce: a manifest overwritten by another device mid sync fails the pass
   // clobbered B's manifest, so b.md read as a remote deletion on B's next sync and was silently
   // deleted. A's conditional upload must instead lose the race and fail the pass.
   const ancestor = snapshot(file("a.md", "h1"));
-  const { storage, objects } = fakeStorage({ [MANIFEST_KEY]: JSON.stringify(ancestor) });
-  const bManifest = JSON.stringify(snapshot(file("a.md", "h1"), file("b.md", "h2")));
+  const { storage, objects } = fakeStorage({ [MANIFEST_KEY]: encodeSnapshot(ancestor) });
+  const bManifest = encodeSnapshot(snapshot(file("a.md", "h1"), file("b.md", "h2")));
   const inner = storage.putObject;
   let raced = false;
   storage.putObject = async (key, body, condition) => {
@@ -176,7 +200,7 @@ test("syncOnce: a manifest overwritten by another device mid sync fails the pass
 test("syncOnce: retry adopts an identical orphaned upload without another file PUT", async () => {
   const ancestor = snapshot({ path: "a.md", size: 4, mtime: 1, hash: await hashOf("base") });
   const { storage, objects } = fakeStorage({
-    [MANIFEST_KEY]: JSON.stringify(ancestor),
+    [MANIFEST_KEY]: encodeSnapshot(ancestor),
     "a.md": "base",
   });
   const inner = storage.putObject;
@@ -188,7 +212,7 @@ test("syncOnce: retry adopts an identical orphaned upload without another file P
     }
     if (key === MANIFEST_KEY && raceManifest) {
       raceManifest = false;
-      await inner(MANIFEST_KEY, new TextEncoder().encode(JSON.stringify(ancestor)));
+      await inner(MANIFEST_KEY, new TextEncoder().encode(encodeSnapshot(ancestor)));
     }
     return inner(key, body, condition);
   };
@@ -218,7 +242,8 @@ test("syncOnce: retry adopts an identical orphaned upload without another file P
     changeCount: 1,
   });
   assert.equal(filePuts, 1, "retry replaced an identical orphaned upload");
-  assert.deepEqual(JSON.parse(objects.get(MANIFEST_KEY) ?? ""), retry.snapshot);
+  assert.ok(retry.ok);
+  assert.equal(objects.get(MANIFEST_KEY), encodeSnapshot(retry.snapshot));
 });
 
 test("syncOnce: losing the manifest race cannot overwrite the winner's file", async () => {
@@ -229,11 +254,11 @@ test("syncOnce: losing the manifest race cannot overwrite the winner's file", as
   const baseHash = await hashOf("base");
   const winnerHash = await hashOf("winner");
   const ancestor = snapshot({ path: "a.md", size: 4, mtime: 1, hash: baseHash });
-  const winnerManifest = JSON.stringify(
+  const winnerManifest = encodeSnapshot(
     snapshot({ path: "a.md", size: 6, mtime: 1, hash: winnerHash }),
   );
   const { storage, objects } = fakeStorage({
-    [MANIFEST_KEY]: JSON.stringify(ancestor),
+    [MANIFEST_KEY]: encodeSnapshot(ancestor),
     "a.md": "base",
   });
   const inner = storage.putObject;
@@ -271,7 +296,7 @@ test("syncOnce: a file changed mid sync is not recorded in the manifest and is p
   // as local changes for the next pass to push.
   const ancestor = snapshot({ path: "a.md", size: 2, mtime: 1, hash: await hashOf("xy") });
   const { storage, objects } = fakeStorage({
-    [MANIFEST_KEY]: JSON.stringify(ancestor),
+    [MANIFEST_KEY]: encodeSnapshot(ancestor),
     "a.md": "xy",
   });
   // a.md matches the ancestor's size and mtime so takeSnapshot reuses its hash and sees no local
@@ -323,7 +348,7 @@ test("syncOnce: a file edited mid sync is never overwritten by a pull, and the r
     { path: "a.md", size: 4, mtime: 1, hash: await hashOf("a v1") },
     { path: "b.md", size: 4, mtime: 1, hash: await hashOf("b v1") },
   );
-  const remoteManifest = JSON.stringify(
+  const remoteManifest = encodeSnapshot(
     snapshot(file("a.md", await hashOf("a v2")), file("b.md", await hashOf("b v2"))),
   );
   const { storage, objects } = fakeStorage({
@@ -445,7 +470,7 @@ test("syncOnce: the failure message counts files, not operation failures", async
   // A conflict whose copy push and pull both fail reports two operation failures for one vault
   // path. The user facing message must count the one file, not the two operations.
   const ancestor = snapshot({ path: "a.md", size: 4, mtime: 1, hash: await hashOf("a v1") });
-  const remoteManifest = JSON.stringify(
+  const remoteManifest = encodeSnapshot(
     snapshot({ path: "a.md", size: 4, mtime: 1, hash: await hashOf("a v2") }),
   );
   // The manifest claims a.md but the object is absent, so the conflict's pull 404s; the copy push
@@ -480,7 +505,7 @@ test("syncOnce: a failed pull records progress without the ancestor ever advanci
   // to the manifest's view the unchanged local copy would read as a fresh local edit on the next
   // pass and be pushed over the newer remote version, quietly undoing the remote edit.
   const ancestor = snapshot({ path: "a.md", size: 4, mtime: 1, hash: await hashOf("a v1") });
-  const remoteManifest = JSON.stringify(
+  const remoteManifest = encodeSnapshot(
     snapshot(
       { path: "a.md", size: 4, mtime: 1, hash: await hashOf("a v2") },
       { path: "b.md", size: 3, mtime: 1, hash: await hashOf("bee") },
@@ -543,7 +568,7 @@ test("syncOnce: two first syncs racing for an empty bucket, the loser fails inst
   // Both devices see no manifest and plan a first sync. The other device's manifest lands while
   // this one is mid pass; the "ifAbsent" conditional upload must lose rather than overwrite it.
   const { storage, objects } = fakeStorage();
-  const otherManifest = JSON.stringify(snapshot(file("b.md", "h2")));
+  const otherManifest = encodeSnapshot(snapshot(file("b.md", "h2")));
   const inner = storage.putObject;
   let raced = false;
   storage.putObject = async (key, body, condition) => {

--- a/src/sync/sync.ts
+++ b/src/sync/sync.ts
@@ -1,8 +1,9 @@
 import type { PutCondition, StorageClient } from "../storage/storage.ts";
 import {
   byPath,
+  decodeSnapshot,
+  encodeSnapshot,
   type FileState,
-  isSnapshot,
   type Reader,
   type Snapshot,
   takeSnapshot,
@@ -51,7 +52,10 @@ export function adoptLiveStats(manifest: Snapshot, live: Snapshot): Snapshot {
 // has ever been written, the safe assumption for a first sync against an empty bucket, so that's
 // treated as an empty snapshot flagged firstSync. Any other failure (network, auth, a real 5xx)
 // is reported as an error rather than ever guessed at as "remote is empty" — getting that guess
-// wrong would look exactly like every previously known remote file had just been deleted.
+// wrong would look exactly like every previously known remote file had just been deleted. A
+// manifest carrying a format version this build does not know (#91) also refuses the pass:
+// syncing against a bucket written in a newer format could mangle it, and the fix is updating
+// the plugin, not starting over.
 //
 // firstSync distinguishes "no manifest has ever been written" from "a manifest exists and is
 // genuinely empty": syncOnce must ignore the local ancestor in the former (nothing has ever been
@@ -71,13 +75,11 @@ export async function readRemoteManifest(
   const fetched = await storage.getObject(MANIFEST_KEY);
 
   if (fetched.ok && fetched.body !== null) {
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(new TextDecoder().decode(fetched.body));
-    } catch {
-      return { ok: false, message: "remote manifest is corrupt" };
-    }
-    if (!isSnapshot(parsed)) {
+    const decoded = decodeSnapshot(new TextDecoder().decode(fetched.body));
+    if (!decoded.ok) {
+      if (decoded.reason === "unsupportedVersion") {
+        return { ok: false, message: "remote manifest needs a newer version of geode" };
+      }
       return { ok: false, message: "remote manifest is corrupt" };
     }
     // Every S3 compatible server returns an ETag on a successful read; without one (a stripping
@@ -87,7 +89,7 @@ export async function readRemoteManifest(
     if (fetched.etag === null) {
       return { ok: false, message: "remote manifest has no etag" };
     }
-    return { ok: true, snapshot: parsed, firstSync: false, etag: fetched.etag };
+    return { ok: true, snapshot: decoded.snapshot, firstSync: false, etag: fetched.etag };
   }
 
   if (fetched.status === "not_found") {
@@ -187,7 +189,7 @@ export async function syncOnce(
   // device (#87).
   const manifest = manifestAfterSync(local, remote.snapshot, executed.completed, now);
   const final = adoptLiveStats(manifest, await takeSnapshot(reader, local));
-  const manifestBody = new TextEncoder().encode(JSON.stringify(final));
+  const manifestBody = new TextEncoder().encode(encodeSnapshot(final));
 
   // The upload is conditional on the remote manifest still being exactly what this pass read at
   // the start (or still absent, on a first sync). An unconditional put would last-writer-win

--- a/src/vault/obsidian.test.ts
+++ b/src/vault/obsidian.test.ts
@@ -212,3 +212,24 @@ test("createObsidianStore: a well shaped snapshot round-trips through write and 
 
   assert.deepEqual(await store.read(), snapshot);
 });
+
+test("createObsidianStore: a pre-marker state file with no version field still reads back", async () => {
+  // State written by a build before the format version marker existed (#91) is version 1 by
+  // definition; an upgrader's ancestor must survive the upgrade, not silently reset.
+  const files = [{ path: "a.md", size: 1, mtime: 2, hash: "h" }];
+  const store = createObsidianStore(
+    fakeAdapter({ [STATE_PATH]: JSON.stringify({ files }) }),
+    STATE_PATH,
+  );
+
+  assert.deepEqual(await store.read(), { files });
+});
+
+test("createObsidianStore: a state file from a newer format version reads back as empty", async () => {
+  // A downgraded plugin cannot interpret newer state, so it starts fresh; that is safe because
+  // the matching newer format manifest blocks the sync itself before the ancestor is ever used.
+  const body = JSON.stringify({ version: 2, files: [{ path: "a.md" }] });
+  const store = createObsidianStore(fakeAdapter({ [STATE_PATH]: body }), STATE_PATH);
+
+  assert.deepEqual(await store.read(), empty);
+});

--- a/src/vault/obsidian.ts
+++ b/src/vault/obsidian.ts
@@ -1,6 +1,13 @@
 import type { DataAdapter, Vault } from "obsidian";
 import type { LocalWriter } from "../sync/execute.ts";
-import { type FileInfo, isSnapshot, type Reader, type Snapshot, type Store } from "./vault.ts";
+import {
+  decodeSnapshot,
+  encodeSnapshot,
+  type FileInfo,
+  type Reader,
+  type Snapshot,
+  type Store,
+} from "./vault.ts";
 
 // createObsidianLocalWriter returns a LocalWriter that applies pulled remote changes straight
 // through the low level data adapter, rather than the Vault API, since a path pulled down for
@@ -56,8 +63,11 @@ export function createObsidianReader(vault: Vault): Reader {
 }
 
 // createObsidianStore returns a Store that persists the snapshot at statePath via the
-// vault adapter. A missing or unparseable file is treated as "no snapshot yet" rather than an
-// error, since the safest fallback for corrupt state is to start fresh, not to crash sync.
+// vault adapter. A missing, unparseable, or unsupported-version file is treated as "no snapshot
+// yet" rather than an error, since the safest fallback for unusable state is to start fresh, not
+// to crash sync: an empty ancestor can at worst produce conflict copies, never data loss, and a
+// state.json from a newer format only ever appears alongside a newer format manifest, which
+// readRemoteManifest refuses before the ancestor matters.
 export function createObsidianStore(adapter: DataAdapter, statePath: string): Store {
   const empty: Snapshot = { files: [] };
 
@@ -67,18 +77,21 @@ export function createObsidianStore(adapter: DataAdapter, statePath: string): St
       if (!exists) {
         return empty;
       }
+      let raw: string;
       try {
-        const parsed: unknown = JSON.parse(await adapter.read(statePath));
-        if (isSnapshot(parsed)) {
-          return parsed;
-        }
-        return empty;
+        raw = await adapter.read(statePath);
       } catch {
         return empty;
       }
+      const decoded = decodeSnapshot(raw);
+      if (!decoded.ok) {
+        return empty;
+      }
+
+      return decoded.snapshot;
     },
     write: async (snapshot) => {
-      await adapter.write(statePath, JSON.stringify(snapshot));
+      await adapter.write(statePath, encodeSnapshot(snapshot));
     },
   };
 }

--- a/src/vault/vault.test.ts
+++ b/src/vault/vault.test.ts
@@ -1,10 +1,14 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
+  type DecodedSnapshot,
+  decodeSnapshot,
   diffSnapshots,
+  encodeSnapshot,
   type FileInfo,
   isSnapshot,
   type Reader,
+  SNAPSHOT_VERSION,
   type Snapshot,
   takeSnapshot,
 } from "./vault.ts";
@@ -106,6 +110,51 @@ test("isSnapshot: only a non-null object with a files array is accepted", () => 
 
   for (const { name, value, want } of cases) {
     assert.equal(isSnapshot(value), want, name);
+  }
+});
+
+test("encodeSnapshot: the wire format carries the version marker and round-trips", () => {
+  const snapshot: Snapshot = { files: [{ path: "a.md", size: 1, mtime: 2, hash: "h" }] };
+
+  const raw = encodeSnapshot(snapshot);
+
+  assert.equal((JSON.parse(raw) as { version: number }).version, SNAPSHOT_VERSION);
+  assert.deepEqual(decodeSnapshot(raw), { ok: true, snapshot });
+});
+
+test("decodeSnapshot: version handling accepts the marker, treats absence as version 1, and refuses the unknown", () => {
+  const files = [{ path: "a.md", size: 1, mtime: 2, hash: "h" }];
+  const cases: { name: string; raw: string; want: DecodedSnapshot }[] = [
+    {
+      name: "the current versioned format",
+      raw: JSON.stringify({ version: 1, files }),
+      want: { ok: true, snapshot: { files } },
+    },
+    {
+      name: "a pre-marker snapshot with no version field, version 1 by definition",
+      raw: JSON.stringify({ files }),
+      want: { ok: true, snapshot: { files } },
+    },
+    {
+      name: "a version from a newer build",
+      raw: JSON.stringify({ version: 2, files }),
+      want: { ok: false, reason: "unsupportedVersion" },
+    },
+    {
+      name: "a version that isn't even a number",
+      raw: JSON.stringify({ version: "banana", files }),
+      want: { ok: false, reason: "unsupportedVersion" },
+    },
+    { name: "bytes that aren't JSON", raw: "not json", want: { ok: false, reason: "corrupt" } },
+    {
+      name: "JSON of the wrong shape",
+      raw: JSON.stringify({ version: 1 }),
+      want: { ok: false, reason: "corrupt" },
+    },
+  ];
+
+  for (const { name, raw, want } of cases) {
+    assert.deepEqual(decodeSnapshot(raw), want, name);
   }
 });
 

--- a/src/vault/vault.test.ts
+++ b/src/vault/vault.test.ts
@@ -141,6 +141,14 @@ test("decodeSnapshot: version handling accepts the marker, treats absence as ver
       want: { ok: false, reason: "unsupportedVersion" },
     },
     {
+      // The version check must win over the shape check: a future format may change the shape
+      // itself (files as an encrypted blob, say), and it must read as "needs a newer build",
+      // never as corrupt.
+      name: "a newer version whose shape this build does not understand",
+      raw: JSON.stringify({ version: 2, files: "ciphertext" }),
+      want: { ok: false, reason: "unsupportedVersion" },
+    },
+    {
       name: "a version that isn't even a number",
       raw: JSON.stringify({ version: "banana", files }),
       want: { ok: false, reason: "unsupportedVersion" },

--- a/src/vault/vault.ts
+++ b/src/vault/vault.ts
@@ -68,7 +68,9 @@ export function byPath(files: FileState[]): Map<string, FileState> {
 // its format version. A missing version is accepted as version 1, the format every build before
 // the marker existed wrote; any other unknown version is refused rather than guessed at, so this
 // build never misreads a bucket written in a newer format as garbage or, worse, as valid. The
-// returned snapshot carries only the in-memory shape; the version is a wire concern that
+// version check runs before the shape check on purpose: a future format is free to change the
+// shape itself, and its snapshots must still read as "needs a newer build", never as corrupt.
+// The returned snapshot carries only the in-memory shape; the version is a wire concern that
 // encodeSnapshot stamps back on at the next write.
 export function decodeSnapshot(raw: string): DecodedSnapshot {
   let parsed: unknown;
@@ -77,12 +79,15 @@ export function decodeSnapshot(raw: string): DecodedSnapshot {
   } catch {
     return { ok: false, reason: "corrupt" };
   }
-  if (!isSnapshot(parsed)) {
+  if (typeof parsed !== "object" || parsed === null) {
     return { ok: false, reason: "corrupt" };
   }
   const version = (parsed as { version?: unknown }).version;
   if (version !== undefined && version !== SNAPSHOT_VERSION) {
     return { ok: false, reason: "unsupportedVersion" };
+  }
+  if (!isSnapshot(parsed)) {
+    return { ok: false, reason: "corrupt" };
   }
 
   return { ok: true, snapshot: { files: parsed.files } };

--- a/src/vault/vault.ts
+++ b/src/vault/vault.ts
@@ -1,8 +1,21 @@
+// SNAPSHOT_VERSION is the format version stamped into every serialized snapshot, remote manifest
+// and local state.json alike, so a future format change (encryption, chunked upload) has
+// something to branch on when it meets an existing bucket (#91). A serialized snapshot with no
+// version field predates the marker and is this same format, version 1.
+export const SNAPSHOT_VERSION = 1;
+
 // Change describes one path whose state differs between two snapshots.
 export type Change = {
   path: string;
   kind: "added" | "modified" | "deleted";
 };
+
+// DecodedSnapshot is the result of parsing a serialized snapshot: the snapshot itself, or why it
+// cannot be used — bytes that don't parse into the expected shape, or a format version this
+// build does not know how to read.
+export type DecodedSnapshot =
+  | { ok: true; snapshot: Snapshot }
+  | { ok: false; reason: "corrupt" | "unsupportedVersion" };
 
 // FileInfo is one file as seen live in the vault, before hashing.
 export type FileInfo = {
@@ -51,6 +64,30 @@ export function byPath(files: FileState[]): Map<string, FileState> {
   return result;
 }
 
+// decodeSnapshot parses a serialized snapshot (a remote manifest, a local state.json) and checks
+// its format version. A missing version is accepted as version 1, the format every build before
+// the marker existed wrote; any other unknown version is refused rather than guessed at, so this
+// build never misreads a bucket written in a newer format as garbage or, worse, as valid. The
+// returned snapshot carries only the in-memory shape; the version is a wire concern that
+// encodeSnapshot stamps back on at the next write.
+export function decodeSnapshot(raw: string): DecodedSnapshot {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { ok: false, reason: "corrupt" };
+  }
+  if (!isSnapshot(parsed)) {
+    return { ok: false, reason: "corrupt" };
+  }
+  const version = (parsed as { version?: unknown }).version;
+  if (version !== undefined && version !== SNAPSHOT_VERSION) {
+    return { ok: false, reason: "unsupportedVersion" };
+  }
+
+  return { ok: true, snapshot: { files: parsed.files } };
+}
+
 // diffSnapshots compares two snapshots and reports every path whose content differs.
 export function diffSnapshots(previous: Snapshot, current: Snapshot): Change[] {
   const previousByPath = byPath(previous.files);
@@ -75,6 +112,12 @@ export function diffSnapshots(previous: Snapshot, current: Snapshot): Change[] {
   }
 
   return changes;
+}
+
+// encodeSnapshot serializes a snapshot for persistence, stamping the format version so every
+// manifest and state.json written from here on carries the marker decodeSnapshot branches on.
+export function encodeSnapshot(snapshot: Snapshot): string {
+  return JSON.stringify({ version: SNAPSHOT_VERSION, files: snapshot.files });
 }
 
 // hashBytes returns the lowercase hex SHA-256 digest of data.


### PR DESCRIPTION
Resolves [#91](https://github.com/8thpark/geode/issues/91)

## Problem

- The remote manifest and local `state.json` serialize as bare `{"files": []}` with no format marker, so a future format change (encryption, chunked upload) has nothing to branch on when it meets an existing bucket

## Changes

- Stamp `version: 1` into every serialized manifest and `state.json`
- Accept a snapshot with no version field as version 1, the format every earlier build wrote, so existing buckets and state files keep working without migration
- Refuse a manifest carrying an unknown version with a message pointing at updating the plugin, distinct from the corrupt manifest error
- Fall back to an empty ancestor when `state.json` carries an unknown version, matching the existing behaviour for corrupt state

## Why

- Adding the marker before the first release is a one liner; adding it after is a migration
- An old client must never sync against, and possibly mangle, a bucket written in a newer format

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR stamps a `version: 1` field into every serialized manifest and `state.json`, giving future format changes a marker to branch on before the first public release. The decode path correctly checks the version *before* the shape check, so a future `version: 2` payload with a changed structure returns `unsupportedVersion` rather than `corrupt` — exactly the distinct "update the plugin" path the PR description calls out.

- `decodeSnapshot` / `encodeSnapshot` are introduced in `vault.ts` as the single encode/decode boundary; all callers in `sync.ts` and `obsidian.ts` are migrated away from bare `JSON.stringify` / `JSON.parse` + `isSnapshot`.
- Missing version is accepted as v1 (backwards compatibility for existing buckets); any other unknown version refuses the pass with a user-readable message rather than silently misreading the data.
- Test coverage is thorough: table-driven cases in `vault.test.ts` exercise the versioned format, no-version round-trip, non-number version, newer version with changed shape, and corrupt bytes; `sync.test.ts` and `obsidian.test.ts` add integration-level tests for the pre-marker and newer-version paths.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrowly scoped to encode/decode boundaries, backwards-compatible for existing buckets, and comprehensively tested.

Every call site that previously used bare JSON.stringify/JSON.parse is migrated, the version-before-shape ordering is correct and verified by an explicit test case, old buckets (no version field) continue to work, and future format changes hitting an old build get the intended distinct error message rather than falling through to the corrupt branch.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/vault/vault.ts | Core logic: adds `SNAPSHOT_VERSION`, `DecodedSnapshot` type, `decodeSnapshot` (version check before shape check), and `encodeSnapshot`; ordering is correct and well-commented |
| src/vault/vault.test.ts | Comprehensive table-driven tests covering versioned format, no-version (backwards-compat), non-number version, newer version with changed shape, and corrupt bytes |
| src/sync/sync.ts | Replaces inline JSON.parse/isSnapshot with `decodeSnapshot`; adds distinct `unsupportedVersion` error path and switches manifest write to `encodeSnapshot` |
| src/sync/sync.test.ts | All manifest fixture strings migrated from `JSON.stringify` to `encodeSnapshot`; two new tests added for the pre-marker and newer-version cases |
| src/vault/obsidian.ts | Store updated to use `decodeSnapshot`/`encodeSnapshot`; updated comment correctly explains the downgrade-safety rationale |
| src/vault/obsidian.test.ts | Two new tests for pre-marker state file round-trip and newer-version state file fallback to empty |

<sub>Reviews (2): Last reviewed commit: ["Address comment"](https://github.com/8thpark/geode/commit/6e48fedaed823f872ce6d947d260b57e3dbc6ef8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46782952)</sub>

<!-- /greptile_comment -->