### PR TITLE
Vault → Exclude credentials from settings fingerprint

### DIFF
--- a/src/vault/obsidian.test.ts
+++ b/src/vault/obsidian.test.ts
@@ -239,6 +239,22 @@ test("createObsidianStore: a fingerprint mismatch reads back as empty", async ()
   assert.deepEqual(await store2.read(), { files: [] });
 });
 
+test("createObsidianStore: rotating credentials keeps state, it does not change the target", async () => {
+  const adapter = fakeAdapter();
+  const store1 = createObsidianStore(adapter, STATE_PATH, DEFAULT_SETTINGS);
+  const snapshot: Snapshot = { files: [{ path: "a.md", size: 1, mtime: 2, hash: "h" }] };
+
+  await store1.write(snapshot);
+
+  const rotated = { ...DEFAULT_SETTINGS, accessKeyId: "new-key", secretId: "new-secret-ref" };
+  const store2 = createObsidianStore(adapter, STATE_PATH, rotated);
+
+  assert.deepEqual(await store2.read(), {
+    ...snapshot,
+    settingsFingerprint: fingerprintSettings(DEFAULT_SETTINGS),
+  });
+});
+
 test("createObsidianStore: a pre-marker state file with no version field and no fingerprint reads back as empty", async () => {
   // State written by a build before the format version marker existed (#91) is version 1 by
   // definition; an upgrader's ancestor must survive the upgrade, not silently reset.

--- a/src/vault/obsidian.test.ts
+++ b/src/vault/obsidian.test.ts
@@ -247,11 +247,14 @@ test("createObsidianStore: rotating credentials keeps state, it does not change 
   await store1.write(snapshot);
 
   const rotated = { ...DEFAULT_SETTINGS, accessKeyId: "new-key", secretId: "new-secret-ref" };
+  // The invariant this test rests on: rotating credentials leaves the target fingerprint
+  // unchanged, which is the only reason store2 accepts the state store1 wrote.
+  assert.equal(fingerprintSettings(rotated), fingerprintSettings(DEFAULT_SETTINGS));
   const store2 = createObsidianStore(adapter, STATE_PATH, rotated);
 
   assert.deepEqual(await store2.read(), {
     ...snapshot,
-    settingsFingerprint: fingerprintSettings(DEFAULT_SETTINGS),
+    settingsFingerprint: fingerprintSettings(rotated),
   });
 });
 

--- a/src/vault/vault.ts
+++ b/src/vault/vault.ts
@@ -142,8 +142,12 @@ export function encodeSnapshot(snapshot: Snapshot): string {
   return JSON.stringify(result);
 }
 
-// fingerprintSettings returns a stable string representation of the connection settings,
-// so we can detect when the sync target changes and invalidate old state.
+// fingerprintSettings returns a stable string identifying the sync target, so we can detect when
+// that target changes and invalidate old state (#89). It covers only where the vault lives, the
+// fields normalized through endpointFor/regionFor to match what a connection actually uses.
+// Credentials (accessKeyId, secretId) are deliberately excluded: they authorize access to a
+// target, they do not identify one, so rotating a key must not invalidate state and force a full
+// re-hash. A genuine target change always moves one of the fields below.
 export function fingerprintSettings(settings: GeodeSettings): string {
   return JSON.stringify({
     provider: settings.provider,
@@ -151,8 +155,6 @@ export function fingerprintSettings(settings: GeodeSettings): string {
     endpoint: endpointFor(settings),
     region: regionFor(settings),
     bucket: settings.bucket,
-    accessKeyId: settings.accessKeyId,
-    secretId: settings.secretId,
   });
 }
 


### PR DESCRIPTION
## Problem

- The settings fingerprint stamped into `state.json` included `accessKeyId` and `secretId`, which authorize access to a target rather than identify one
- Rotating a key therefore invalidated the stored state and forced a full vault re-hash on the next sync, a heavy operation for a routine ops event

## Changes

- Reduce the fingerprint to target identity only: `provider`, `accountId`, `endpoint`, `region`, `bucket`
- Add a test proving credential rotation keeps state, while a genuine target change still invalidates it

## Why

- Key rotation is routine and should not trigger a full re-hash; sync stays quiet and boring
- Dropping credentials cannot reintroduce the switching-target data loss, the remaining fields already distinguish every real move of where the vault lives

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR narrows `fingerprintSettings` to the five fields that identify a sync target (`provider`, `accountId`, `endpoint`, `region`, `bucket`), explicitly dropping `accessKeyId` and `secretId` which authorize access but do not identify the target. A new test verifies the core invariant end-to-end.

- **`vault.ts`**: Removes the two credential fields from the JSON fingerprint; the updated comment explains the deliberate exclusion and confirms every genuine target change still moves at least one remaining field.
- **`obsidian.test.ts`**: Adds a credential-rotation test with an inline `assert.equal` precondition that makes the fingerprint equality invariant explicit before exercising `store2.read()`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a focused two-line removal with a clear rationale and a direct test covering the new invariant.

The fingerprint reduction is logically sound: every genuine target move still touches at least one of the five remaining fields, and rotating credentials against the same target no longer forces a full re-hash. The implementation is a straight deletion with no new branches or error paths, and the new test exercises the exact scenario the PR is designed to fix.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/vault/vault.ts | Removes `accessKeyId` and `secretId` from `fingerprintSettings`; comment clearly documents the deliberate exclusion and why target identity is still fully covered by the remaining fields. |
| src/vault/obsidian.test.ts | Adds a well-structured test that proves credential rotation keeps state intact; includes an inline precondition assertion to make the invariant explicit before exercising `store2.read()`. |

<sub>Reviews (2): Last reviewed commit: ["Address comment"](https://github.com/8thpark/geode/commit/8fc1c9f9257937addb42156cf294f4f7b532dfeb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46930360)</sub>

<!-- /greptile_comment -->