### PR TITLE
Sync → Fixed Pulled content to  now verify against its expected hash

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -35,11 +35,7 @@ const VAULT_STATE_DEBOUNCE_MS = 2000;
 // equivalent) so the Settings command can jump straight to Geode's tab, and opening the log view
 // can close the settings modal out from under itself.
 type AppWithSetting = App & {
-  setting: {
-    open: () => void;
-    close: () => void;
-    openTabById: (id: string) => void;
-  };
+  setting: { open: () => void; close: () => void; openTabById: (id: string) => void };
 };
 
 // SyncStatus is the state the status bar item reflects.
@@ -203,14 +199,8 @@ export default class GeodePlugin extends Plugin {
   // runSync does the actual work of syncNow, split out so syncNow can own the in flight guard
   // and status bar bookkeeping around it without this getting lost in indentation.
   private async runSync(dir: string): Promise<void> {
-    const secretAccessKey = this.app.secretStorage.getSecret(this.settings.secretId);
-    if (secretAccessKey === null) {
-      this.logger.error(`sync: secret access key not found for ID "${this.settings.secretId}"`);
-      this.setSyncStatus("error", "secret access key not found; open settings to reconfigure");
-      return;
-    }
-
-    const storage = createS3Client(this.settings, rawSecret);
+    const secretAccessKey = this.app.secretStorage.getSecret(this.settings.secretId) ?? "";
+    const storage = createS3Client(this.settings, secretAccessKey);
     const stateStore = createObsidianStore(this.app.vault.adapter, `${dir}/state.json`);
     const reader = createObsidianReader(this.app.vault);
     const localWriter = createObsidianLocalWriter(this.app.vault.adapter);

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,7 +35,11 @@ const VAULT_STATE_DEBOUNCE_MS = 2000;
 // equivalent) so the Settings command can jump straight to Geode's tab, and opening the log view
 // can close the settings modal out from under itself.
 type AppWithSetting = App & {
-  setting: { open: () => void; close: () => void; openTabById: (id: string) => void };
+  setting: {
+    open: () => void;
+    close: () => void;
+    openTabById: (id: string) => void;
+  };
 };
 
 // SyncStatus is the state the status bar item reflects.
@@ -199,8 +203,14 @@ export default class GeodePlugin extends Plugin {
   // runSync does the actual work of syncNow, split out so syncNow can own the in flight guard
   // and status bar bookkeeping around it without this getting lost in indentation.
   private async runSync(dir: string): Promise<void> {
-    const secretAccessKey = this.app.secretStorage.getSecret(this.settings.secretId) ?? "";
-    const storage = createS3Client(this.settings, secretAccessKey);
+    const secretAccessKey = this.app.secretStorage.getSecret(this.settings.secretId);
+    if (secretAccessKey === null) {
+      this.logger.error(`sync: secret access key not found for ID "${this.settings.secretId}"`);
+      this.setSyncStatus("error", "secret access key not found; open settings to reconfigure");
+      return;
+    }
+
+    const storage = createS3Client(this.settings, rawSecret);
     const stateStore = createObsidianStore(this.app.vault.adapter, `${dir}/state.json`);
     const reader = createObsidianReader(this.app.vault);
     const localWriter = createObsidianLocalWriter(this.app.vault.adapter);

--- a/src/sync/execute.test.ts
+++ b/src/sync/execute.test.ts
@@ -44,6 +44,7 @@ test("executeSyncPlan: pull fetches the remote object and writes it locally", as
   const reader = fakeReader({});
   const { writer, files } = fakeLocalWriter();
   const { storage } = fakeStorage({ "a.md": "hello" });
+  const remote = snapshot(file("a.md", await hashOf("hello")));
 
   const { failures } = await executeSyncPlan(
     [{ kind: "pull", path: "a.md" }],
@@ -52,6 +53,7 @@ test("executeSyncPlan: pull fetches the remote object and writes it locally", as
     writer,
     storage,
     1,
+    remote,
   );
 
   assert.deepEqual(failures, []);
@@ -64,6 +66,7 @@ test("executeSyncPlan: pull overwrites a local file that still matches the snaps
   files.set("a.md", "unchanged");
   const local = snapshot(file("a.md", await hashOf("unchanged")));
   const { storage } = fakeStorage({ "a.md": "remote edit" });
+  const remote = snapshot(file("a.md", await hashOf("remote edit")));
 
   const { failures } = await executeSyncPlan(
     [{ kind: "pull", path: "a.md" }],
@@ -72,6 +75,7 @@ test("executeSyncPlan: pull overwrites a local file that still matches the snaps
     writer,
     storage,
     1,
+    remote,
   );
 
   assert.deepEqual(failures, []);
@@ -88,12 +92,16 @@ test("executeSyncPlan: pull onto a file edited after the snapshot is refused and
   files.set("a.md", "edited after snapshot");
   const local = snapshot(file("a.md", await hashOf("as snapshotted")));
   const { storage } = fakeStorage({ "a.md": "remote edit", "b.md": "remote b" });
+  const remote = snapshot(
+    file("a.md", await hashOf("remote edit")),
+    file("b.md", await hashOf("remote b")),
+  );
 
   const actions: SyncAction[] = [
     { kind: "pull", path: "a.md" },
     { kind: "pull", path: "b.md" },
   ];
-  const { failures } = await executeSyncPlan(actions, local, reader, writer, storage, 1);
+  const { failures } = await executeSyncPlan(actions, local, reader, writer, storage, 1, remote);
 
   assert.deepEqual(failures, [
     { path: "a.md", message: "changed locally mid sync; sync again to reconcile" },
@@ -195,6 +203,7 @@ test("executeSyncPlan: a conflict renames the local copy, pushes it to storage, 
   const { writer, files } = fakeLocalWriter();
   files.set("a.md", "local edit");
   const { storage, objects } = fakeStorage({ "a.md": "remote edit" });
+  const remote = snapshot(file("a.md", await hashOf("remote edit")));
   const now = Date.parse("2026-07-14T10:00:00.000Z");
 
   const { failures } = await executeSyncPlan(
@@ -204,6 +213,7 @@ test("executeSyncPlan: a conflict renames the local copy, pushes it to storage, 
     writer,
     storage,
     now,
+    remote,
   );
 
   assert.deepEqual(failures, []);
@@ -219,6 +229,7 @@ test("executeSyncPlan: a conflict with nothing local to preserve just pulls the 
   const reader = fakeReader({});
   const { writer, files } = fakeLocalWriter();
   const { storage } = fakeStorage({ "a.md": "remote edit" });
+  const remote = snapshot(file("a.md", await hashOf("remote edit")));
   const now = Date.parse("2026-07-14T10:00:00.000Z");
 
   const { failures } = await executeSyncPlan(
@@ -228,6 +239,7 @@ test("executeSyncPlan: a conflict with nothing local to preserve just pulls the 
     writer,
     storage,
     now,
+    remote,
   );
 
   assert.deepEqual(failures, []);
@@ -366,6 +378,7 @@ test("executeSyncPlan: a conflict whose copy push fails is a failed action, even
   const { writer, files } = fakeLocalWriter();
   files.set("a.md", "local edit");
   const { storage, objects } = fakeStorage({ "a.md": "remote edit" });
+  const remote = snapshot(file("a.md", await hashOf("remote edit")));
   const inner = storage.putObject;
   storage.putObject = async (key, body, condition) => {
     if (key !== "a.md") {
@@ -383,6 +396,7 @@ test("executeSyncPlan: a conflict whose copy push fails is a failed action, even
     writer,
     storage,
     now,
+    remote,
   );
 
   assert.deepEqual(failures, [
@@ -409,12 +423,16 @@ test("executeSyncPlan: a pull whose local write throws is reported and doesn't s
     files.set(path, "pulled");
   };
   const { storage } = fakeStorage({ "a.md": "remote a", "b.md": "remote b" });
+  const remote = snapshot(
+    file("a.md", await hashOf("remote a")),
+    file("b.md", await hashOf("remote b")),
+  );
 
   const actions: SyncAction[] = [
     { kind: "pull", path: "a.md" },
     { kind: "pull", path: "b.md" },
   ];
-  const { failures } = await executeSyncPlan(actions, empty, reader, writer, storage, 1);
+  const { failures } = await executeSyncPlan(actions, empty, reader, writer, storage, 1, remote);
 
   assert.deepEqual(failures, [{ path: "a.md", message: "EACCES: permission denied" }]);
   assert.equal(files.get("b.md"), "pulled");
@@ -487,7 +505,7 @@ test("executeSyncPlan: pull with hash mismatch is refused and nothing is written
   assert.deepEqual(failures, [
     {
       path: "a.md",
-      message: "fetched bytes do not match manifest hash; data may be corrupt",
+      message: "fetched bytes do not match manifest hash; sync again to reconcile",
     },
   ]);
   assert.equal(files.has("a.md"), false);
@@ -512,7 +530,7 @@ test("executeSyncPlan: pull with truncated body is refused and nothing is writte
   assert.deepEqual(failures, [
     {
       path: "a.md",
-      message: "fetched bytes do not match manifest hash; data may be corrupt",
+      message: "fetched bytes do not match manifest hash; sync again to reconcile",
     },
   ]);
   assert.equal(files.has("a.md"), false);
@@ -538,7 +556,7 @@ test("executeSyncPlan: conflict restore with hash mismatch is refused and nothin
   assert.deepEqual(failures, [
     {
       path: "a.md",
-      message: "fetched bytes do not match manifest hash; data may be corrupt",
+      message: "fetched bytes do not match manifest hash; sync again to reconcile",
     },
   ]);
   assert.equal(files.has("a.md"), false);
@@ -565,7 +583,7 @@ test("executeSyncPlan: conflict with hash mismatch on remote restore is reported
   assert.deepEqual(failures, [
     {
       path: "a.md",
-      message: "fetched bytes do not match manifest hash; data may be corrupt",
+      message: "fetched bytes do not match manifest hash; sync again to reconcile",
     },
   ]);
   // The local edit was renamed to the conflict copy before the pull was attempted.

--- a/src/sync/execute.test.ts
+++ b/src/sync/execute.test.ts
@@ -447,3 +447,129 @@ test("executeSyncPlan: a conflict whose rename throws is reported and the local 
   assert.equal(files.get("a.md"), "local edit");
   assert.equal(objects.has(conflictCopyPath("a.md", now)), false);
 });
+
+test("executeSyncPlan: pull with matching hash writes the file to disk", async () => {
+  const reader = fakeReader({});
+  const { writer, files } = fakeLocalWriter();
+  const { storage } = fakeStorage({ "a.md": "hello" });
+  const remote = snapshot(file("a.md", await hashOf("hello")));
+
+  const { failures } = await executeSyncPlan(
+    [{ kind: "pull", path: "a.md" }],
+    empty,
+    reader,
+    writer,
+    storage,
+    1,
+    remote,
+  );
+
+  assert.deepEqual(failures, []);
+  assert.equal(files.get("a.md"), "hello");
+});
+
+test("executeSyncPlan: pull with hash mismatch is refused and nothing is written to disk", async () => {
+  const reader = fakeReader({});
+  const { writer, files } = fakeLocalWriter();
+  const { storage } = fakeStorage({ "a.md": "wrong content" });
+  const remote = snapshot(file("a.md", await hashOf("correct content")));
+
+  const { failures } = await executeSyncPlan(
+    [{ kind: "pull", path: "a.md" }],
+    empty,
+    reader,
+    writer,
+    storage,
+    1,
+    remote,
+  );
+
+  assert.deepEqual(failures, [
+    {
+      path: "a.md",
+      message: "fetched bytes do not match manifest hash; data may be corrupt",
+    },
+  ]);
+  assert.equal(files.has("a.md"), false);
+});
+
+test("executeSyncPlan: pull with truncated body is refused and nothing is written to disk", async () => {
+  const reader = fakeReader({});
+  const { writer, files } = fakeLocalWriter();
+  const { storage } = fakeStorage({ "a.md": "hel" });
+  const remote = snapshot(file("a.md", await hashOf("hello")));
+
+  const { failures } = await executeSyncPlan(
+    [{ kind: "pull", path: "a.md" }],
+    empty,
+    reader,
+    writer,
+    storage,
+    1,
+    remote,
+  );
+
+  assert.deepEqual(failures, [
+    {
+      path: "a.md",
+      message: "fetched bytes do not match manifest hash; data may be corrupt",
+    },
+  ]);
+  assert.equal(files.has("a.md"), false);
+});
+
+test("executeSyncPlan: conflict restore with hash mismatch is refused and nothing is written", async () => {
+  const reader = fakeReader({});
+  const { writer, files } = fakeLocalWriter();
+  const { storage } = fakeStorage({ "a.md": "wrong content" });
+  const remote = snapshot(file("a.md", await hashOf("correct content")));
+  const now = Date.parse("2026-07-14T10:00:00.000Z");
+
+  const { failures } = await executeSyncPlan(
+    [{ kind: "conflict", path: "a.md", deletedSide: "local" }],
+    empty,
+    reader,
+    writer,
+    storage,
+    now,
+    remote,
+  );
+
+  assert.deepEqual(failures, [
+    {
+      path: "a.md",
+      message: "fetched bytes do not match manifest hash; data may be corrupt",
+    },
+  ]);
+  assert.equal(files.has("a.md"), false);
+});
+
+test("executeSyncPlan: conflict with hash mismatch on remote restore is reported and local edit survives", async () => {
+  const reader = fakeReader({ "a.md": "local edit" });
+  const { writer, files } = fakeLocalWriter();
+  files.set("a.md", "local edit");
+  const { storage, objects } = fakeStorage({ "a.md": "wrong content" });
+  const remote = snapshot(file("a.md", await hashOf("correct content")));
+  const now = Date.parse("2026-07-14T10:00:00.000Z");
+
+  const { failures } = await executeSyncPlan(
+    [{ kind: "conflict", path: "a.md", deletedSide: "none" }],
+    empty,
+    reader,
+    writer,
+    storage,
+    now,
+    remote,
+  );
+
+  assert.deepEqual(failures, [
+    {
+      path: "a.md",
+      message: "fetched bytes do not match manifest hash; data may be corrupt",
+    },
+  ]);
+  // The local edit was renamed to the conflict copy before the pull was attempted.
+  assert.equal(files.get("a.md"), undefined);
+  assert.equal(files.get(conflictCopyPath("a.md", now)), "local edit");
+  assert.equal(objects.get(conflictCopyPath("a.md", now)), "local edit");
+});

--- a/src/sync/execute.ts
+++ b/src/sync/execute.ts
@@ -7,6 +7,7 @@ import { conflictCopyPath, type SyncAction } from "./plan.ts";
 const DRIFT_MESSAGE = "changed locally mid sync; sync again to reconcile";
 
 const REMOTE_DRIFT_MESSAGE = "changed remotely mid sync; sync again to reconcile";
+const HASH_MISMATCH_MESSAGE = "fetched bytes do not match manifest hash; data may be corrupt";
 const REMOTE_ETAG_MESSAGE = "remote object has no etag";
 
 // ExecuteResult reports what executeSyncPlan carried out: completed holds every action fully
@@ -206,6 +207,10 @@ async function executeAction(
       return failedAction(action.path, result.message, false);
     }
     const body = result.body;
+    const integrity = await verifyFetch(action.path, body, remoteByPath.get(action.path));
+    if (integrity !== null) {
+      return { concurrent: false, failures: [integrity] };
+    }
     const failure = await applyLocalWrite(action.path, () =>
       localWriter.writeFile(action.path, body),
     );
@@ -242,6 +247,10 @@ async function executeAction(
       return failedAction(action.path, result.message, false);
     }
     const body = result.body;
+    const integrity = await verifyFetch(action.path, body, remoteByPath.get(action.path));
+    if (integrity !== null) {
+      return { concurrent: false, failures: [integrity] };
+    }
     const failure = await applyLocalWrite(action.path, () =>
       localWriter.writeFile(action.path, body),
     );
@@ -292,6 +301,11 @@ async function executeAction(
     return { concurrent, failures };
   }
   const body = result.body;
+  const integrity = await verifyFetch(action.path, body, remoteByPath.get(action.path));
+  if (integrity !== null) {
+    failures.push(integrity);
+    return { concurrent, failures };
+  }
   const writeFailure = await applyLocalWrite(action.path, () =>
     localWriter.writeFile(action.path, body),
   );
@@ -384,4 +398,21 @@ function localFailureMessage(err: unknown): string {
     return err.message;
   }
   return "local file operation failed";
+}
+
+// verifyFetch hashes fetched bytes and compares against the expected hash from the remote
+// snapshot. A mismatch means the storage response was truncated, corrupted, or tampered with;
+// writing it to disk would silently propagate damage to every other device on the next sync.
+async function verifyFetch(
+  path: string,
+  body: Uint8Array,
+  expected: FileState | undefined,
+): Promise<SyncFailure | null> {
+  if (expected === undefined) {
+    return null;
+  }
+  if ((await hashBytes(body)) === expected.hash) {
+    return null;
+  }
+  return { path, message: HASH_MISMATCH_MESSAGE };
 }

--- a/src/sync/execute.ts
+++ b/src/sync/execute.ts
@@ -7,7 +7,8 @@ import { conflictCopyPath, type SyncAction } from "./plan.ts";
 const DRIFT_MESSAGE = "changed locally mid sync; sync again to reconcile";
 
 const REMOTE_DRIFT_MESSAGE = "changed remotely mid sync; sync again to reconcile";
-const HASH_MISMATCH_MESSAGE = "fetched bytes do not match manifest hash; data may be corrupt";
+const HASH_MISMATCH_MESSAGE = "fetched bytes do not match manifest hash; sync again to reconcile";
+const MANIFEST_MISSING_HASH_MESSAGE = "manifest missing expected hash for this path";
 const REMOTE_ETAG_MESSAGE = "remote object has no etag";
 
 // ExecuteResult reports what executeSyncPlan carried out: completed holds every action fully
@@ -402,14 +403,16 @@ function localFailureMessage(err: unknown): string {
 
 // verifyFetch hashes fetched bytes and compares against the expected hash from the remote
 // snapshot. A mismatch means the storage response was truncated, corrupted, or tampered with;
-// writing it to disk would silently propagate damage to every other device on the next sync.
+// writing it to disk would silently propagate damage to every other device on the next sync. A
+// missing expected hash is a programming error — the manifest should always carry an entry for a
+// path the plan decided to pull — surfaced rather than silently bypassed.
 async function verifyFetch(
   path: string,
   body: Uint8Array,
   expected: FileState | undefined,
 ): Promise<SyncFailure | null> {
   if (expected === undefined) {
-    return null;
+    return { path, message: MANIFEST_MISSING_HASH_MESSAGE };
   }
   if ((await hashBytes(body)) === expected.hash) {
     return null;

--- a/src/sync/sync.test.ts
+++ b/src/sync/sync.test.ts
@@ -155,7 +155,7 @@ test("syncOnce: a manifest overwritten by another device mid sync fails the pass
   // deleted. A's conditional upload must instead lose the race and fail the pass.
   const ancestor = snapshot(file("a.md", "h1"));
   const { storage, objects } = fakeStorage({ [MANIFEST_KEY]: encodeSnapshot(ancestor) });
-  const bManifest = encodeSnapshot(snapshot(file("a.md", "h1"), file("b.md", "h2")));
+  const bManifest = encodeSnapshot(snapshot(file("a.md", "h1"), file("b.md", await hashOf("bee"))));
   const inner = storage.putObject;
   let raced = false;
   storage.putObject = async (key, body, condition) => {


### PR DESCRIPTION
Resolves #95 

## Problem

Bytes fetched from storage are written to disk without being checked against the hash the manifest promised for that file. A truncated or corrupted response body becomes the local file, the next snapshot records the damage as truth, and the corruption propagates to every other device as an apparent edit.

Syncthing hash verifies every transferred block before it is accepted; Geode already computes content hashes but never uses them to validate a pull.

## Changes 

Adds `verifyFetch()`, a hash check against FileState.hash from the remote snapshot and guards all three pull sites in executeAction: the pull action, conflict restore (deletedSide: "local"), and conflict remote restore (deletedSide: "none"). A mismatch fails the action instead of writing corrupt bytes; the next sync replans the path as a conflict.

## Tests

- `src/sync/execute.test.ts`  5 new tests covering matching hash, mismatch, truncated body, and both conflict restore paths
- `src/sync/sync.test.ts`  fix pre-existing test that used placeholder hashes not matching stored bytes

All test pass

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes a silent data-corruption hole: bytes fetched from storage were written to disk without being checked against the hash the remote manifest promised, so a truncated or corrupted response would propagate to every other device on the next sync. `verifyFetch()` is introduced and guards all three fetch-and-write sites in `executeAction`.

- `verifyFetch(path, body, expected)` SHA-hashes the downloaded bytes and compares against `FileState.hash` from the remote snapshot; a missing manifest entry is a hard failure rather than a silent bypass, and a hash mismatch returns a `SyncFailure` before any local write occurs.
- Five new tests cover matching hash, mismatch, truncated body, and both conflict-restore paths; all pre-existing pull/conflict tests are updated to supply real-hash remote snapshots so the guard is exercised rather than short-circuited by the empty default.
- The `sync.test.ts` fix replaces a placeholder hash `"h2"` with the actual computed hash of the stored bytes, preventing the concurrent-manifest test from silently passing the new hash check with stale data.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change adds a defensive hash check before every local write and all pre-existing tests are updated to remain consistent with the new guard.

The three guarded write sites are correctly ordered (hash check fires after the fetch and before the write), `expected === undefined` is now a hard failure rather than a silent pass, and the test suite exercises the happy path, the mismatch path, and both conflict-restore paths end-to-end. The only production caller (`sync.ts`) always provides the remote snapshot, so the stronger default behaviour is safe.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/sync/execute.ts | Adds `verifyFetch()` that SHA-hashes downloaded bytes against the remote manifest entry and guards all three pull sites (plain pull, conflict `deletedSide:"local"`, conflict `deletedSide:"none"`) before any local write; returns a hard failure on both hash mismatch and missing manifest entry, never silently bypassing. |
| src/sync/execute.test.ts | Adds 5 new tests (matching hash, mismatch, truncated body, conflict `deletedSide:"local"` mismatch, conflict `deletedSide:"none"` mismatch); updates all pre-existing pull/conflict tests to pass real-hash remote snapshots so `verifyFetch` is exercised end-to-end rather than bypassed by an empty default. |
| src/sync/sync.test.ts | Fixes one pre-existing test that encoded a placeholder hash `"h2"` for `b.md`; replaces it with `await hashOf("bee")` so the manifest hash matches the actual stored bytes that would now be verified on pull. |

<sub>Reviews (2): Last reviewed commit: ["refactor: care for silent bypass and add..."](https://github.com/8thpark/geode/commit/51e4419b7404c043f0d5aadac8ac633175d6c004) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46944501)</sub>

<!-- /greptile_comment -->