### PR TITLE
Storage → Strictly encode object keys for SigV4

### DIFF
--- a/src/storage/encode.test.ts
+++ b/src/storage/encode.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { encodeComponent, encodeKey } from "./encode.ts";
+
+const encodeKeyCases: { name: string; key: string; want: string }[] = [
+  {
+    name: "plain key passes through",
+    key: "notes/hello.md",
+    want: "notes/hello.md",
+  },
+  {
+    name: "space and ampersand",
+    key: "notes/Foo & Bar.md",
+    want: "notes/Foo%20%26%20Bar.md",
+  },
+  {
+    name: "hash and percent",
+    key: "notes/100% #special.md",
+    want: "notes/100%25%20%23special.md",
+  },
+  {
+    name: "SigV4-sensitive characters ! ' ( ) * are percent encoded",
+    key: "notes/Don't forget! (draft) *.md",
+    want: "notes/Don%27t%20forget%21%20%28draft%29%20%2A.md",
+  },
+  {
+    name: "slashes separate segments and survive encoding",
+    key: "a b/c d/e.md",
+    want: "a%20b/c%20d/e.md",
+  },
+  {
+    name: "non-ASCII is UTF-8 percent encoded",
+    key: "notes/café 😀.md",
+    want: "notes/caf%C3%A9%20%F0%9F%98%80.md",
+  },
+];
+
+for (const { name, key, want } of encodeKeyCases) {
+  test(`encodeKey: ${name}`, () => {
+    assert.equal(encodeKey(key), want);
+  });
+}
+
+test("encodeComponent percent-encodes slashes, unlike encodeKey", () => {
+  assert.equal(encodeComponent("a/b!.md"), "a%2Fb%21.md");
+});

--- a/src/storage/encode.ts
+++ b/src/storage/encode.ts
@@ -1,8 +1,22 @@
+// encodeComponent percent-encodes a single URI component with SigV4's strict RFC 3986 rules:
+// on top of encodeURIComponent it also encodes ! ' ( ) *, so the bytes on the wire are byte for
+// byte the canonical form SigV4 signs and no provider's canonicalization choice can diverge.
+export function encodeComponent(component: string): string {
+  const encoded = encodeURIComponent(component);
+
+  return encoded.replace(/[!'()*]/g, percentEncode);
+}
+
 // encodeKey percent-encodes each path segment of an S3 object key individually, preserving "/" as
-// the separator so keys like "notes/Foo & Bar.md" become "notes/Foo%20%26%20Bar.md".
+// the separator so keys like "notes/Don't stop!.md" become "notes/Don%27t%20stop%21.md".
 export function encodeKey(key: string): string {
   const segments = key.split("/");
-  const encodedSegments = segments.map((segment) => encodeURIComponent(segment));
-  const encodedKey = encodedSegments.join("/");
-  return encodedKey;
+  const encodedSegments = segments.map((segment) => encodeComponent(segment));
+
+  return encodedSegments.join("/");
+}
+
+// percentEncode returns the %XX form of a single ASCII character.
+function percentEncode(char: string): string {
+  return `%${char.charCodeAt(0).toString(16).toUpperCase()}`;
 }

--- a/src/storage/storage.itest.ts
+++ b/src/storage/storage.itest.ts
@@ -192,6 +192,32 @@ test("putObject/getObject round-trips a key containing a space and ampersand", a
   assert.deepEqual(getResult.body, body);
 });
 
+test("putObject/getObject round-trips a key with SigV4-sensitive characters ! ' ( ) *", async () => {
+  const client = createS3Client(liveSettings, SECRET_ACCESS_KEY);
+  const body = new TextEncoder().encode("sigv4 edge");
+  const key = "encode-test/Don't forget! (draft) *.md";
+
+  const putResult = await client.putObject(key, body);
+  assert.equal(putResult.ok, true);
+
+  const getResult = await client.getObject(key);
+  assert.equal(getResult.ok, true);
+  assert.deepEqual(getResult.body, body);
+
+  // The listing must hand back the exact key the vault knows, or sync would treat the object as
+  // a phantom remote file and the real note as locally new.
+  const listResult = await client.listObjects("encode-test/Don't");
+  assert.equal(listResult.ok, true);
+  const keys: string[] = [];
+  for (const object of listResult.objects) {
+    keys.push(object.key);
+  }
+  assert.deepEqual(keys, [key]);
+
+  const deleteResult = await client.deleteObject(key);
+  assert.equal(deleteResult.ok, true);
+});
+
 test("putObject/getObject round-trips a key containing a hash and percent", async () => {
   const client = createS3Client(liveSettings, SECRET_ACCESS_KEY);
   const body = new TextEncoder().encode("edge cases");

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -1,6 +1,6 @@
 import { AwsClient } from "aws4fetch";
 import { endpointFor, type GeodeSettings, regionFor } from "../settings/settings.ts";
-import { encodeKey } from "./encode.ts";
+import { encodeComponent, encodeKey } from "./encode.ts";
 import { messageFor, statusForHttp } from "./errors.ts";
 import { parseListObjectsXml } from "./xml.ts";
 
@@ -228,10 +228,10 @@ async function s3ListObjects(
   do {
     let url = `${baseUrl}?list-type=2`;
     if (prefix !== undefined && prefix !== "") {
-      url += `&prefix=${encodeURIComponent(prefix)}`;
+      url += `&prefix=${encodeComponent(prefix)}`;
     }
     if (continuationToken !== undefined) {
-      url += `&continuation-token=${encodeURIComponent(continuationToken)}`;
+      url += `&continuation-token=${encodeComponent(continuationToken)}`;
     }
 
     let response: Response;


### PR DESCRIPTION
Resolves [#92](https://github.com/8thpark/geode/issues/92)

## Problem

- Object keys were encoded with `encodeURIComponent`, which leaves `! ' ( ) *` bare on the wire, while SigV4 signatures are computed over the strictly encoded RFC 3986 form
- Whether that mismatch breaks depends on how each provider canonicalizes the path before verifying the signature, so a note named `Don't forget!.md` could fail to sync on some providers with an unexplained per file error

## Changes

- Percent encode `! ' ( ) *` in object keys and in the `prefix` and `continuation-token` list params, so the wire path matches the signed canonical form byte for byte
- Add unit tests for the encoder and an end to end round trip test covering all five characters through put, get, list, and delete

## Why

- Apostrophes and parentheses are extremely common in real note names, and sync must be boring for those too
- Strict encoding removes any dependence on provider specific canonicalization, the same choice every AWS SDK makes; verified against MinIO before and after the change

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a SigV4 signing mismatch by encoding the five characters (`! ' ( ) *`) that `encodeURIComponent` leaves bare but RFC 3986 / SigV4 requires to be percent-encoded, ensuring the bytes on the wire match the signed canonical form byte-for-byte across all providers.

- Introduces `encodeComponent` (a thin wrapper over `encodeURIComponent` that also encodes the five SigV4-sensitive characters) and wires it into `encodeKey` and the `prefix` / `continuation-token` query parameters in `s3ListObjects`.
- Adds unit tests for every encoding case and a full end-to-end integration test exercising all five characters through put, get, list, and delete.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a narrow, well-tested encoding fix with no behavioural regressions for callers.

The `percentEncode` helper produces the correct `%XX` form for all five target characters. The regex `[!'()*]` is a literal character class with no unintended matches. `encodeComponent` and `encodeKey` compose cleanly, and the switch in `s3ListObjects` is the only remaining call site that needed updating. Unit tests cover all encoding cases, and the integration test verifies the full round-trip through a real S3-compatible endpoint.

**Files Needing Attention:** No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/storage/encode.ts | Introduces `encodeComponent` (strict RFC 3986 / SigV4 encoding) and rewires `encodeKey` to use it; `percentEncode` helper is correct for all five target characters |
| src/storage/encode.test.ts | New unit tests cover all five SigV4-sensitive characters, plain paths, non-ASCII, multi-segment keys, and the slash-vs-component distinction; good coverage |
| src/storage/storage.ts | Switches `prefix` and `continuation-token` query parameters from `encodeURIComponent` to `encodeComponent`; change is minimal and consistent with the encoding fix |
| src/storage/storage.itest.ts | Adds an end-to-end round-trip integration test covering all five characters through put, get, list (with prefix containing `'` and `/`), and delete |

<sub>Reviews (1): Last reviewed commit: ["Fix"](https://github.com/8thpark/geode/commit/328958d2eb8bfd805f63515a783f6bec2408e9ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47056945)</sub>

<!-- /greptile_comment -->