### PR TITLE
Sync → Refuse a first sync that would orphan remote files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,9 +48,11 @@ Two tiers, two commands:
 - `npm run test:integration` — integration tests, real HTTP against a real S3 compatible server
   (MinIO). Brings up `docker-compose.yml` itself if it isn't already running, so there's no
   manual pre-step; safe to run repeatedly regardless of current state. Runs against the
-  `geode-test` bucket (separate from `geode-dev`, so automated runs don't collide with whatever
-  you're doing manually in Obsidian). Still requires Docker installed and Colima (or your
-  alternative) started — it can bring the *stack* up, not the VM underneath it.
+  `geode-test` bucket (storage tests) and `geode-sync-test` (sync tests, which wipe their bucket
+  between scenarios and so need it to themselves), both separate from `geode-dev` so automated
+  runs don't collide with whatever you're doing manually in Obsidian. Still requires Docker
+  installed and Colima (or your alternative) started — it can bring the *stack* up, not the VM
+  underneath it.
 
 Both tiers use the exact same `docker-compose.yml` MinIO setup as interactive dev — one S3
 compatible server, not a second hand-rolled fake to keep in sync.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,8 @@ services:
       /bin/sh -c "
       mc alias set local http://minio:9000 geodedev geodedev &&
       mc mb --ignore-existing local/geode-dev &&
-      mc mb --ignore-existing local/geode-test
+      mc mb --ignore-existing local/geode-test &&
+      mc mb --ignore-existing local/geode-sync-test
       "
 
 volumes:

--- a/src/sync/fake.ts
+++ b/src/sync/fake.ts
@@ -2,6 +2,7 @@ import type {
   DeleteResult,
   GetResult,
   ListResult,
+  ObjectMeta,
   PutResult,
   StorageClient,
 } from "../storage/storage.ts";
@@ -116,8 +117,15 @@ export function fakeStorage(objects: Record<string, string> = {}): {
       etags.delete(key);
       return { ok: true, status: "ok", message: "" };
     },
-    listObjects: async (): Promise<ListResult> => {
-      return { ok: true, status: "ok", message: "", objects: [] };
+    listObjects: async (prefix): Promise<ListResult> => {
+      const objects: ObjectMeta[] = [];
+      for (const [key, content] of store) {
+        if (prefix !== undefined && prefix !== "" && !key.startsWith(prefix)) {
+          continue;
+        }
+        objects.push({ key, size: content.length, lastModified: "" });
+      }
+      return { ok: true, status: "ok", message: "", objects };
     },
   };
   return { storage, objects: store };

--- a/src/sync/sync.itest.ts
+++ b/src/sync/sync.itest.ts
@@ -102,9 +102,12 @@ async function sync(d: Device, now = Date.now()): Promise<SyncOutcome> {
 
 // resetRemote clears the manifest and every object, so each scenario starts from an empty bucket;
 // the bucket is exclusively this file's, so a full wipe never disturbs another test file's keys.
+// A failed listing fails the scenario here rather than proceeding with a stale bucket, which
+// would surface later as a baffling orphan refusal on the scenario's first sync.
 async function resetRemote(): Promise<void> {
   await storage.deleteObject(MANIFEST_KEY);
   const listed = await storage.listObjects();
+  assert.ok(listed.ok, `resetRemote: listing failed: ${listed.message}`);
   for (const object of listed.objects) {
     await storage.deleteObject(object.key);
   }

--- a/src/sync/sync.itest.ts
+++ b/src/sync/sync.itest.ts
@@ -28,7 +28,10 @@ const liveSettings: GeodeSettings = {
   provider: "custom",
   endpoint: "http://localhost:4568",
   region: "us-east-1",
-  bucket: "geode-test",
+  // sync.itest has this bucket to itself: syncOnce's first sync path lists the whole bucket
+  // (#109), so sharing geode-test with storage.itest's leftover objects would trip the orphan
+  // refusal in every scenario here.
+  bucket: "geode-sync-test",
   accessKeyId: "geodedev",
 };
 
@@ -97,11 +100,11 @@ async function sync(d: Device, now = Date.now()): Promise<SyncOutcome> {
   return outcome;
 }
 
-// resetRemote clears the manifest and every object under prefix, so each scenario starts from a
-// clean shared bucket without disturbing the other itest files' keys.
-async function resetRemote(prefix: string): Promise<void> {
+// resetRemote clears the manifest and every object, so each scenario starts from an empty bucket;
+// the bucket is exclusively this file's, so a full wipe never disturbs another test file's keys.
+async function resetRemote(): Promise<void> {
   await storage.deleteObject(MANIFEST_KEY);
-  const listed = await storage.listObjects(prefix);
+  const listed = await storage.listObjects();
   for (const object of listed.objects) {
     await storage.deleteObject(object.key);
   }
@@ -115,7 +118,7 @@ function cleanup(...devices: Device[]): void {
 }
 
 test("sync: two devices converge on each other's changes", async () => {
-  await resetRemote("one/");
+  await resetRemote();
   const a = newDevice();
   const b = newDevice();
   try {
@@ -140,7 +143,7 @@ test("sync: two devices converge on each other's changes", async () => {
 });
 
 test("sync: three devices converge through the shared remote", async () => {
-  await resetRemote("two/");
+  await resetRemote();
   const a = newDevice();
   const b = newDevice();
   const c = newDevice();
@@ -168,7 +171,7 @@ test("sync: three devices converge through the shared remote", async () => {
 });
 
 test("sync: a two device conflict pushes the copy so the other device pulls it clean", async () => {
-  await resetRemote("three/");
+  await resetRemote();
   const a = newDevice();
   const b = newDevice();
   const now = Date.parse("2026-07-14T10:00:00.000Z");
@@ -211,7 +214,7 @@ test("sync: a two device conflict pushes the copy so the other device pulls it c
 });
 
 test("sync: a file deleted independently on both devices converges without a conflict", async () => {
-  await resetRemote("four/");
+  await resetRemote();
   const a = newDevice();
   const b = newDevice();
   try {
@@ -245,7 +248,7 @@ test("sync: a file deleted independently on both devices converges without a con
 });
 
 test("sync: a file deleted on one device and edited on another restores the edit, no phantom read of the deleted file", async () => {
-  await resetRemote("five/");
+  await resetRemote();
   const a = newDevice();
   const b = newDevice();
   try {
@@ -274,7 +277,7 @@ test("sync: a file deleted on one device and edited on another restores the edit
 });
 
 test("sync: a stale state.json from an older build never deletes the vault on the first sync", async () => {
-  await resetRemote("seven/");
+  await resetRemote();
   const a = newDevice();
   try {
     // Reproduce an upgrader's poisoned ancestor. The older build wrote state.json on every file
@@ -320,7 +323,7 @@ test("sync: two devices syncing at overlapping times never silently delete a fil
   // reading the manifest and uploading its own, the exact interleaving overlapping automatic
   // syncs produce. Before the fix A's unconditional manifest upload clobbered B's, so B's next
   // sync read from-b.md as a remote deletion and silently deleted it.
-  await resetRemote("eight/");
+  await resetRemote();
   const a = newDevice();
   const b = newDevice();
   try {
@@ -360,8 +363,40 @@ test("sync: two devices syncing at overlapping times never silently delete a fil
   }
 });
 
+test("sync: a deleted manifest with surviving objects refuses a first sync instead of orphaning them", async () => {
+  // Reproduces #109. A syncs a note up, then the manifest alone is deleted (a bucket lifecycle
+  // rule, manual cleanup, a partial restore) while the object survives. B, never synced, then
+  // sees what looks like a first sync; before the fix it pushed its own files and wrote a fresh
+  // manifest that never mentioned A's note, orphaning it forever.
+  await resetRemote();
+  const a = newDevice();
+  const b = newDevice();
+  try {
+    await writeLocal(a, "nine/from-a.md", "a's note");
+    assert.equal((await sync(a)).ok, true);
+
+    await storage.deleteObject(MANIFEST_KEY);
+    await writeLocal(b, "nine/from-b.md", "b's note");
+
+    const outcome = await sync(b);
+    assert.ok(!outcome.ok);
+    assert.equal(outcome.message, "bucket has files but no manifest; sync would orphan them");
+    assert.deepEqual(outcome.failures, [
+      { path: "nine/from-a.md", message: "in the bucket but not in the local vault" },
+    ]);
+
+    // Nothing was pushed and no manifest was written; A's object is untouched.
+    const kept = await storage.getObject("nine/from-a.md");
+    assert.equal(new TextDecoder().decode(kept.body ?? new Uint8Array()), "a's note");
+    assert.equal((await storage.getObject("nine/from-b.md")).ok, false);
+    assert.equal((await storage.getObject(MANIFEST_KEY)).ok, false);
+  } finally {
+    cleanup(a, b);
+  }
+});
+
 test("sync: an edit on one device and a delete on another preserves the edit as a copy, no phantom pull failure", async () => {
-  await resetRemote("six/");
+  await resetRemote();
   const a = newDevice();
   const b = newDevice();
   try {

--- a/src/sync/sync.test.ts
+++ b/src/sync/sync.test.ts
@@ -4,7 +4,13 @@ import { encodeSnapshot, hashBytes, type Snapshot } from "../vault/vault.ts";
 import type { LocalWriter } from "./execute.ts";
 import { empty, fakeLocalWriter, fakeReader, fakeStorage, file, snapshot } from "./fake.ts";
 import { conflictCopyPath, MANIFEST_KEY } from "./plan.ts";
-import { adoptLiveStats, readRemoteManifest, revertFailedPaths, syncOnce } from "./sync.ts";
+import {
+  adoptLiveStats,
+  orphanedKeys,
+  readRemoteManifest,
+  revertFailedPaths,
+  syncOnce,
+} from "./sync.ts";
 
 // hashOf returns the real content hash of text, for snapshots whose entries executeSyncPlan's
 // drift check will verify against live bytes.
@@ -130,6 +136,78 @@ test("syncOnce: a present but empty manifest still trusts the ancestor and pulls
 
   assert.equal(outcome.ok, true);
   assert.equal(files.has("a.md"), false);
+});
+
+test("syncOnce: a missing manifest with surviving remote objects refuses, never orphans them", async () => {
+  // Reproduces #109. A lifecycle rule or manual cleanup deleted the manifest while file objects
+  // survived. Before the fix this read as a clean first sync: the pass pushed local files and
+  // wrote a manifest that never mentioned the survivors, so no device would ever pull, list, or
+  // delete them again. The pass must refuse instead, naming each stranded key.
+  const { storage, objects } = fakeStorage({ "keep/other-device.md": "not local" });
+  const reader = fakeReader({ "a.md": "alpha" });
+  const { writer } = fakeLocalWriter();
+
+  const outcome = await syncOnce(empty, reader, writer, storage, 1);
+
+  assert.deepEqual(outcome, {
+    ok: false,
+    message: "bucket has files but no manifest; sync would orphan them",
+    failures: [
+      { path: "keep/other-device.md", message: "in the bucket but not in the local vault" },
+    ],
+    snapshot: null,
+  });
+  // Nothing was pushed and no manifest was invented.
+  assert.equal(objects.has("a.md"), false);
+  assert.equal(objects.has(MANIFEST_KEY), false);
+});
+
+test("syncOnce: an interrupted first sync's own uploads never block the retry", async () => {
+  // A first sync that pushed a.md and then died before its manifest upload leaves objects and no
+  // manifest, the same bucket signature as #109's hazard. Every such object matches a local path,
+  // so nothing can be orphaned; the retry must fold them in and complete, not refuse.
+  const { storage, objects } = fakeStorage({ "a.md": "alpha" });
+  const reader = fakeReader({ "a.md": "alpha", "b.md": "beta" });
+  const { writer } = fakeLocalWriter();
+
+  const outcome = await syncOnce(empty, reader, writer, storage, 1);
+
+  assert.equal(outcome.ok, true);
+  assert.equal(objects.get("a.md"), "alpha");
+  assert.equal(objects.get("b.md"), "beta");
+  assert.equal(objects.has(MANIFEST_KEY), true);
+});
+
+test("syncOnce: a failed bucket listing on a first sync is reported, never guessed at as empty", async () => {
+  const { storage } = fakeStorage();
+  storage.listObjects = async () => ({
+    ok: false,
+    status: "server",
+    message: "Storage rejected the list (500)",
+    objects: [],
+  });
+  const reader = fakeReader({ "a.md": "alpha" });
+  const { writer } = fakeLocalWriter();
+
+  const outcome = await syncOnce(empty, reader, writer, storage, 1);
+
+  assert.deepEqual(outcome, {
+    ok: false,
+    message: "Storage rejected the list (500)",
+    failures: [],
+    snapshot: null,
+  });
+});
+
+test("orphanedKeys: keys with no local counterpart are orphans; local matches and the manifest key are not", () => {
+  const objects = [
+    { key: "a.md", size: 5, lastModified: "" },
+    { key: "keep/b.md", size: 5, lastModified: "" },
+    { key: MANIFEST_KEY, size: 5, lastModified: "" },
+  ];
+  const local = snapshot(file("a.md", "h1"));
+
+  assert.deepEqual(orphanedKeys(objects, local), ["keep/b.md"]);
 });
 
 test("readRemoteManifest: a non 404 failure is reported, never guessed at as empty", async () => {

--- a/src/sync/sync.ts
+++ b/src/sync/sync.ts
@@ -1,4 +1,4 @@
-import type { PutCondition, StorageClient } from "../storage/storage.ts";
+import type { ObjectMeta, PutCondition, StorageClient } from "../storage/storage.ts";
 import {
   byPath,
   decodeSnapshot,
@@ -46,6 +46,27 @@ export function adoptLiveStats(manifest: Snapshot, live: Snapshot): Snapshot {
   }
 
   return { files };
+}
+
+// orphanedKeys returns the bucket keys a first sync would strand: objects with no local file at
+// their key, which a manifest built purely from local files would never mention, so no device
+// would ever pull, list, or delete them again (#109). The manifest key itself is bookkeeping,
+// never a vault file, and is not counted; if one appears in the listing (another device's first
+// sync landing mid pass) the conditional manifest upload catches it loudly. Exported for its
+// tests; syncOnce is the only production caller.
+export function orphanedKeys(objects: ObjectMeta[], local: Snapshot): string[] {
+  const localByPath = byPath(local.files);
+  const orphans: string[] = [];
+  for (const object of objects) {
+    if (object.key === MANIFEST_KEY) {
+      continue;
+    }
+    if (!localByPath.has(object.key)) {
+      orphans.push(object.key);
+    }
+  }
+
+  return orphans;
 }
 
 // readRemoteManifest fetches and parses the remote manifest. A confirmed 404 means no manifest
@@ -154,6 +175,33 @@ export async function syncOnce(
   }
 
   const local = await takeSnapshot(reader, ancestor);
+
+  // A missing manifest usually means a fresh bucket, but not always: a lifecycle rule, manual
+  // cleanup, or partial restore can remove the manifest while file objects survive (#109). The
+  // pass below would build a manifest purely from local files, leaving every surviving object
+  // invisible: never pulled, never listed, orphaned forever. Refuse loudly instead when the
+  // bucket holds objects no local file accounts for. Objects that do match a local path are safe
+  // to proceed over — an interrupted first sync leaves exactly those, and each push's own
+  // precondition adopts identical bytes and refuses divergent ones.
+  if (remote.firstSync) {
+    const listed = await storage.listObjects();
+    if (!listed.ok) {
+      return { ok: false, message: listed.message, failures: [], snapshot: null };
+    }
+    const orphans = orphanedKeys(listed.objects, local);
+    if (orphans.length > 0) {
+      const failures: SyncFailure[] = [];
+      for (const key of orphans) {
+        failures.push({ path: key, message: "in the bucket but not in the local vault" });
+      }
+      return {
+        ok: false,
+        message: "bucket has files but no manifest; sync would orphan them",
+        failures,
+        snapshot: null,
+      };
+    }
+  }
 
   const actions = planSync(ancestor, local, remote.snapshot);
   const executed = await executeSyncPlan(


### PR DESCRIPTION
Resolves [#109](https://github.com/8thpark/geode/issues/109)

## Problem

- A missing manifest is treated as a clean first sync, so the pass pushes local files and writes a fresh manifest built purely from them
- If the manifest was deleted while file objects survived (a bucket lifecycle rule, manual cleanup, a partial restore), every surviving object becomes invisible: absent from the new manifest, never pulled, never listed, orphaned forever
- `listObjects` existed on the storage client but sync never consulted it

## Changes

- On a first sync, list the bucket and refuse the pass when it holds objects with no local file at their key, exactly the set a fresh manifest would strand; the status bar names the refusal and the log names each stranded key
- Objects that do match a local path still proceed, so an interrupted first sync (files pushed, manifest upload never landed) keeps self healing on retry
- A failed listing refuses the pass too, never guessed at as an empty bucket
- Give the sync integration tests their own `geode-sync-test` bucket with a full wipe between scenarios, since the first sync check lists the whole bucket

## Why

- Silence must mean everything is fine; a sync that quietly strands remote files is the exact failure mode this project exists to rule out
- Refusing loudly leaves every recovery open (restore the manifest, empty the bucket, copy the files into the vault), while proceeding forecloses them all silently

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes the silent-orphan hole introduced when a manifest is deleted while bucket objects survive: a first sync now lists the bucket and refuses the pass when any object has no local counterpart, naming each stranded key. Objects that do match local files still proceed, so an interrupted first sync (files pushed, manifest never landed) heals correctly on retry.

- `orphanedKeys` in `sync.ts` drives the new guard; `syncOnce` calls it only on first-sync paths, and a failed listing refuses rather than proceeding.
- `fakeStorage.listObjects` is fixed to reflect the in-memory store instead of always returning empty, making the three new unit tests meaningful.
- Sync integration tests move to a dedicated `geode-sync-test` bucket with a full wipe between scenarios, since the whole-bucket listing would trip the orphan refusal if leftover objects from other test files were present.

<h3>Confidence Score: 5/5</h3>

The change is additive and conservative: it only adds a refusal on the first-sync code path that previously had no listing call, and every new failure path returns early without touching the bucket.

The orphan detection logic is correct, all new failure modes return without side effects, the fakeStorage fix makes the unit tests genuinely exercise the new path, and the integration test isolation strategy is sound. No pre-existing behaviour on non-first-sync paths is touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/sync/sync.ts | Adds orphanedKeys helper and first-sync bucket listing guard in syncOnce; logic is correct, ordering of snapshot-then-list is sound, and all failure paths return without side effects. |
| src/sync/fake.ts | fakeStorage.listObjects now iterates the in-memory store instead of always returning empty; prefix filtering mirrors the real S3 implementation correctly. |
| src/sync/sync.test.ts | Four new unit tests cover the orphan refusal, interrupted-first-sync pass-through, failed-listing refusal, and the orphanedKeys function directly; all assertions match the implementation. |
| src/sync/sync.itest.ts | Migrated to dedicated geode-sync-test bucket with full wipe between scenarios; resetRemote now asserts on the listing result and the new orphan-refusal integration test is correct. |
| docker-compose.yml | Adds geode-sync-test bucket creation alongside existing geode-test; shell syntax is correct. |
| CONTRIBUTING.md | Documentation updated to describe both test buckets and why they are separate; accurate. |

<sub>Reviews (2): Last reviewed commit: ["Address comment"](https://github.com/8thpark/geode/commit/61c4e93efe91d515abdee6394bd7c3ab1f5992d8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47059973)</sub>

<!-- /greptile_comment -->