### PR TITLE
Sync → Soft delete window for synced deletions

### DIFF
--- a/src/storage/storage.itest.ts
+++ b/src/storage/storage.itest.ts
@@ -113,6 +113,53 @@ test("deleteObject removes an object", async () => {
   assert.equal(getResult.status, "not_found");
 });
 
+test("copyObject duplicates the bytes under a new key, leaving the source intact", async () => {
+  const client = createS3Client(liveSettings, SECRET_ACCESS_KEY);
+  const body = new TextEncoder().encode("copy me");
+  await client.putObject("copy-test/source.md", body);
+
+  const copyResult = await client.copyObject("copy-test/source.md", "copy-test/dest.md");
+  assert.equal(copyResult.ok, true);
+  assert.equal(copyResult.status, "ok");
+
+  const dest = await client.getObject("copy-test/dest.md");
+  assert.equal(dest.ok, true);
+  assert.deepEqual(dest.body, body);
+  const source = await client.getObject("copy-test/source.md");
+  assert.equal(source.ok, true);
+
+  await client.deleteObject("copy-test/source.md");
+  await client.deleteObject("copy-test/dest.md");
+});
+
+test("copyObject round-trips a source key with SigV4-sensitive characters", async () => {
+  const client = createS3Client(liveSettings, SECRET_ACCESS_KEY);
+  const key = "copy-test/Don't stop! (really).md";
+  const body = new TextEncoder().encode("tricky source");
+  await client.putObject(key, body);
+
+  const copyResult = await client.copyObject(key, "copy-test/tricky-dest.md");
+  assert.equal(copyResult.ok, true);
+
+  const dest = await client.getObject("copy-test/tricky-dest.md");
+  assert.equal(dest.ok, true);
+  assert.deepEqual(dest.body, body);
+
+  await client.deleteObject(key);
+  await client.deleteObject("copy-test/tricky-dest.md");
+});
+
+test("copyObject of a missing source fails with not_found, never a phantom empty object", async () => {
+  const client = createS3Client(liveSettings, SECRET_ACCESS_KEY);
+
+  const copyResult = await client.copyObject("copy-test/does-not-exist.md", "copy-test/nope.md");
+  assert.equal(copyResult.ok, false);
+  assert.equal(copyResult.status, "not_found");
+
+  const dest = await client.getObject("copy-test/nope.md");
+  assert.equal(dest.ok, false);
+});
+
 test("listObjects returns only keys under the given prefix", async () => {
   const client = createS3Client(liveSettings, SECRET_ACCESS_KEY);
   await client.putObject("list-test/a.md", new TextEncoder().encode("a"));

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -12,6 +12,14 @@ export type ConnectionResult = {
   message: string;
 };
 
+// CopyResult reports whether an object was copied to a new key. Message is the empty string when
+// ok is true.
+export type CopyResult = {
+  ok: boolean;
+  status: ResultStatus;
+  message: string;
+};
+
 // DeleteResult reports whether an object was removed. Message is the empty string when ok is
 // true.
 export type DeleteResult = {
@@ -77,6 +85,7 @@ export type ResultStatus =
 export type StorageClient = {
   putObject: (key: string, body: Uint8Array, condition?: PutCondition) => Promise<PutResult>;
   getObject: (key: string) => Promise<GetResult>;
+  copyObject: (sourceKey: string, destKey: string) => Promise<CopyResult>;
   deleteObject: (key: string) => Promise<DeleteResult>;
   listObjects: (prefix?: string) => Promise<ListResult>;
 };
@@ -94,6 +103,8 @@ export function createS3Client(settings: GeodeSettings, secretAccessKey: string)
   return {
     putObject: (key, body, condition) => s3PutObject(client, baseUrl, key, body, condition),
     getObject: (key) => s3GetObject(client, baseUrl, key),
+    copyObject: (sourceKey, destKey) =>
+      s3CopyObject(client, baseUrl, settings.bucket, sourceKey, destKey),
     deleteObject: (key) => s3DeleteObject(client, baseUrl, key),
     listObjects: (prefix) => s3ListObjects(client, baseUrl, prefix),
   };
@@ -177,6 +188,45 @@ function missingFieldFor(settings: GeodeSettings, secretAccessKey: string): stri
   }
 
   return "";
+}
+
+// s3CopyObject server-side copies sourceKey to destKey within the same bucket, so the bytes never
+// travel through the client. The x-amz-copy-source header names the source as "/bucket/key" with
+// the key percent-encoded exactly as a request path is, so a source containing spaces or SigV4
+// sensitive characters is signed byte for byte the way the server canonicalizes it. S3 has a
+// documented quirk where CopyObject can answer 200 and then carry an <Error> in the body when the
+// copy fails mid-stream; treating that as success would let the caller delete a source it never
+// actually backed up, so the body is inspected and a failure surfaced rather than swallowed.
+async function s3CopyObject(
+  client: AwsClient,
+  baseUrl: string,
+  bucket: string,
+  sourceKey: string,
+  destKey: string,
+): Promise<CopyResult> {
+  const source = `/${bucket}/${encodeKey(sourceKey)}`;
+  let response: Response;
+  try {
+    response = await client.fetch(`${baseUrl}/${encodeKey(destKey)}`, {
+      method: "PUT",
+      headers: { "x-amz-copy-source": source },
+    });
+  } catch (err) {
+    return { ok: false, status: "network", message: messageFor(err) };
+  }
+
+  if (!response.ok) {
+    return {
+      ok: false,
+      status: statusForHttp(response.status),
+      message: `Storage rejected the copy (${response.status})`,
+    };
+  }
+  const body = await response.text();
+  if (body.includes("<Error")) {
+    return { ok: false, status: "server", message: "Storage rejected the copy (200 error body)" };
+  }
+  return { ok: true, status: "ok", message: "" };
 }
 
 // s3DeleteObject removes key from the bucket.

--- a/src/sync/execute.test.ts
+++ b/src/sync/execute.test.ts
@@ -3,7 +3,7 @@ import { test } from "node:test";
 import { hashBytes } from "../vault/vault.ts";
 import { executeSyncPlan } from "./execute.ts";
 import { empty, fakeLocalWriter, fakeReader, fakeStorage, file, snapshot } from "./fake.ts";
-import { conflictCopyPath, type SyncAction } from "./plan.ts";
+import { conflictCopyPath, type SyncAction, trashKeyFor } from "./plan.ts";
 
 // hashOf returns the real content hash of text, for building local snapshots whose entries
 // executeSyncPlan's drift check can verify against a fake reader's live bytes.
@@ -30,14 +30,62 @@ test("executeSyncPlan: push reads the local file and puts it remotely", async ()
   assert.equal(files.size, 0);
 });
 
-test("executeSyncPlan: pushDelete removes the remote object", async () => {
+test("executeSyncPlan: pushDelete trashes the remote object before removing its live key", async () => {
   const reader = fakeReader({});
   const { writer } = fakeLocalWriter();
   const { storage, objects } = fakeStorage({ "a.md": "hello" });
 
-  await executeSyncPlan([{ kind: "pushDelete", path: "a.md" }], empty, reader, writer, storage, 1);
+  const { failures } = await executeSyncPlan(
+    [{ kind: "pushDelete", path: "a.md" }],
+    empty,
+    reader,
+    writer,
+    storage,
+    0,
+  );
 
+  assert.deepEqual(failures, []);
   assert.equal(objects.has("a.md"), false);
+  assert.equal(objects.get(trashKeyFor("a.md", 0)), "hello");
+});
+
+test("executeSyncPlan: pushDelete of an already absent remote object succeeds without trashing", async () => {
+  const reader = fakeReader({});
+  const { writer } = fakeLocalWriter();
+  const { storage, objects } = fakeStorage({});
+
+  const { completed, failures } = await executeSyncPlan(
+    [{ kind: "pushDelete", path: "a.md" }],
+    empty,
+    reader,
+    writer,
+    storage,
+    0,
+  );
+
+  assert.deepEqual(failures, []);
+  assert.equal(completed.length, 1);
+  assert.equal(objects.size, 0);
+});
+
+test("executeSyncPlan: pushDelete leaves the live object intact when the trash copy fails", async () => {
+  const reader = fakeReader({});
+  const { writer } = fakeLocalWriter();
+  const { storage, objects } = fakeStorage({ "a.md": "hello" });
+  storage.copyObject = async () => ({ ok: false, status: "server", message: "copy boom" });
+
+  const { failed, failures } = await executeSyncPlan(
+    [{ kind: "pushDelete", path: "a.md" }],
+    empty,
+    reader,
+    writer,
+    storage,
+    0,
+  );
+
+  assert.deepEqual(failures, [{ path: "a.md", message: "copy boom" }]);
+  assert.equal(failed.length, 1);
+  assert.equal(objects.get("a.md"), "hello");
 });
 
 test("executeSyncPlan: pull fetches the remote object and writes it locally", async () => {

--- a/src/sync/execute.ts
+++ b/src/sync/execute.ts
@@ -1,6 +1,6 @@
 import type { PutCondition, StorageClient } from "../storage/storage.ts";
 import { byPath, type FileState, hashBytes, type Reader, type Snapshot } from "../vault/vault.ts";
-import { conflictCopyPath, type SyncAction } from "./plan.ts";
+import { conflictCopyPath, type SyncAction, trashKeyFor } from "./plan.ts";
 
 // DRIFT_MESSAGE is the failure reported when a local file changed after the snapshot an action
 // was planned from; the next sync re-snapshots and replans the path as a conflict.
@@ -190,6 +190,18 @@ async function executeAction(
   }
 
   if (action.kind === "pushDelete") {
+    // Park the object under the reserved trash prefix before removing it from its live key, so a
+    // mistaken delete stays recoverable (#53). A copy that 404s means the object is already gone
+    // remotely (another device deleted it), which is the end state a pushDelete wants: nothing to
+    // trash, nothing to delete. Any other copy failure aborts before the delete, so the live
+    // object is never destroyed without a backup sitting beside it.
+    const copied = await storage.copyObject(action.path, trashKeyFor(action.path, now));
+    if (!copied.ok) {
+      if (copied.status === "not_found") {
+        return successfulAction();
+      }
+      return failedAction(action.path, copied.message, false);
+    }
     const result = await storage.deleteObject(action.path);
     if (!result.ok) {
       return failedAction(action.path, result.message, false);

--- a/src/sync/fake.ts
+++ b/src/sync/fake.ts
@@ -1,4 +1,5 @@
 import type {
+  CopyResult,
   DeleteResult,
   GetResult,
   ListResult,
@@ -111,6 +112,16 @@ export function fakeStorage(objects: Record<string, string> = {}): {
         body: new TextEncoder().encode(content),
         etag,
       };
+    },
+    copyObject: async (sourceKey, destKey): Promise<CopyResult> => {
+      const content = store.get(sourceKey);
+      if (content === undefined) {
+        return { ok: false, status: "not_found", message: "Storage rejected the copy (404)" };
+      }
+      revision++;
+      etags.set(destKey, `"v${revision}"`);
+      store.set(destKey, content);
+      return { ok: true, status: "ok", message: "" };
     },
     deleteObject: async (key): Promise<DeleteResult> => {
       store.delete(key);

--- a/src/sync/plan.test.ts
+++ b/src/sync/plan.test.ts
@@ -1,7 +1,13 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import { empty, file, snapshot } from "./fake.ts";
-import { conflictCopyPath, MANIFEST_KEY, manifestAfterSync, planSync } from "./plan.ts";
+import {
+  conflictCopyPath,
+  MANIFEST_KEY,
+  manifestAfterSync,
+  planSync,
+  trashKeyFor,
+} from "./plan.ts";
 
 test("planSync: a path only changed locally is pushed", () => {
   const previous = empty;
@@ -87,6 +93,21 @@ test("planSync: the manifest's own path is never turned into an action", () => {
   const remote = snapshot(file(MANIFEST_KEY, "h2"));
 
   assert.deepEqual(planSync(previous, local, remote), []);
+});
+
+test("planSync: a trashed copy under the reserved prefix is never turned into an action", () => {
+  const previous = empty;
+  const local = snapshot(file(".geode/trash/2020-01-01/a.md", "h1"));
+  const remote = snapshot(file(".geode/trash/2020-01-01/b.md", "h2"));
+
+  assert.deepEqual(planSync(previous, local, remote), []);
+});
+
+test("trashKeyFor: parks the path under the reserved trash prefix behind a timestamp folder", () => {
+  assert.equal(
+    trashKeyFor("notes/a.md", Date.UTC(2026, 0, 2, 3, 4, 5)),
+    ".geode/trash/2026-01-02T03-04-05-000Z/notes/a.md",
+  );
 });
 
 test("manifestAfterSync: a push records the local snapshot's entry", () => {

--- a/src/sync/plan.ts
+++ b/src/sync/plan.ts
@@ -5,6 +5,16 @@ import { byPath, type Change, diffSnapshots, type Snapshot } from "../vault/vaul
 // path, on either side, even if a vault happens to contain a file at this exact path.
 export const MANIFEST_KEY = ".geode/manifest.json";
 
+// RESERVED_PREFIX namespaces geode's own bookkeeping in the bucket: the manifest, and the trashed
+// copies of deleted objects. Nothing under it is ever a real vault file to sync, list as an
+// orphan, or diff, on either side, even if a vault happens to hold a file at a colliding path.
+export const RESERVED_PREFIX = ".geode/";
+
+// TRASH_PREFIX is where a pushed deletion parks the object before removing it from its live key,
+// giving a mistaken delete a recovery window instead of destroying the bytes outright (#53). It
+// sits under RESERVED_PREFIX, so trashed copies never re-enter a sync as vault files.
+export const TRASH_PREFIX = ".geode/trash/";
+
 // SyncAction is one thing a sync needs to do to bring local and remote back in step. A conflict
 // carries deletedSide so executeSyncPlan never has to guess, from a failed read, whether a deleted
 // side is why there's nothing there: "local" means there's no local content to preserve, "remote"
@@ -147,6 +157,17 @@ export function planSync(previous: Snapshot, local: Snapshot, remote: Snapshot):
   return actions;
 }
 
+// trashKeyFor returns the reserved key a pushed deletion parks path at before removing the live
+// object, timestamped so a later delete of a recreated path never overwrites an earlier trashed
+// copy. The original path is preserved under the stamped folder, so a recovery can see where the
+// object came from. now is passed in rather than read internally so the key is deterministic under
+// test, matching conflictCopyPath.
+export function trashKeyFor(path: string, now: number): string {
+  const stamp = new Date(now).toISOString().replace(/[:.]/g, "-");
+
+  return `${TRASH_PREFIX}${stamp}/${path}`;
+}
+
 // changesByPath builds a lookup from path to change, for matching a local change against a
 // remote change at that same path.
 function changesByPath(changes: Change[]): Map<string, Change> {
@@ -160,5 +181,5 @@ function changesByPath(changes: Change[]): Map<string, Change> {
 // isReservedPath reports whether path is geode's own bookkeeping, never a real vault file to
 // sync, even if something in the vault happens to collide with it.
 function isReservedPath(path: string): boolean {
-  return path === MANIFEST_KEY;
+  return path.startsWith(RESERVED_PREFIX);
 }

--- a/src/sync/sync.test.ts
+++ b/src/sync/sync.test.ts
@@ -199,11 +199,12 @@ test("syncOnce: a failed bucket listing on a first sync is reported, never guess
   });
 });
 
-test("orphanedKeys: keys with no local counterpart are orphans; local matches and the manifest key are not", () => {
+test("orphanedKeys: keys with no local counterpart are orphans; local matches and reserved keys are not", () => {
   const objects = [
     { key: "a.md", size: 5, lastModified: "" },
     { key: "keep/b.md", size: 5, lastModified: "" },
     { key: MANIFEST_KEY, size: 5, lastModified: "" },
+    { key: ".geode/trash/2020-01-01/gone.md", size: 5, lastModified: "" },
   ];
   const local = snapshot(file("a.md", "h1"));
 

--- a/src/sync/sync.ts
+++ b/src/sync/sync.ts
@@ -9,7 +9,13 @@ import {
   takeSnapshot,
 } from "../vault/vault.ts";
 import { executeSyncPlan, type LocalWriter, type SyncFailure } from "./execute.ts";
-import { MANIFEST_KEY, manifestAfterSync, planSync, type SyncAction } from "./plan.ts";
+import {
+  MANIFEST_KEY,
+  manifestAfterSync,
+  planSync,
+  RESERVED_PREFIX,
+  type SyncAction,
+} from "./plan.ts";
 
 // SyncOutcome is the result of a single sync pass. On success it carries the new snapshot to
 // persist as the next sync's starting point and how many actions were applied; on failure it
@@ -50,15 +56,16 @@ export function adoptLiveStats(manifest: Snapshot, live: Snapshot): Snapshot {
 
 // orphanedKeys returns the bucket keys a first sync would strand: objects with no local file at
 // their key, which a manifest built purely from local files would never mention, so no device
-// would ever pull, list, or delete them again (#109). The manifest key itself is bookkeeping,
-// never a vault file, and is not counted; if one appears in the listing (another device's first
-// sync landing mid pass) the conditional manifest upload catches it loudly. Exported for its
-// tests; syncOnce is the only production caller.
+// would ever pull, list, or delete them again (#109). Keys under the reserved prefix are geode's
+// own bookkeeping (the manifest, trashed deletions), never vault files, and are not counted; if
+// the manifest appears in the listing (another device's first sync landing mid pass) the
+// conditional manifest upload catches it loudly. Exported for its tests; syncOnce is the only
+// production caller.
 export function orphanedKeys(objects: ObjectMeta[], local: Snapshot): string[] {
   const localByPath = byPath(local.files);
   const orphans: string[] = [];
   for (const object of objects) {
-    if (object.key === MANIFEST_KEY) {
+    if (object.key.startsWith(RESERVED_PREFIX)) {
       continue;
     }
     if (!localByPath.has(object.key)) {

--- a/src/vault/fs.ts
+++ b/src/vault/fs.ts
@@ -5,7 +5,7 @@
 // without needing a running Obsidian.
 import { existsSync, readdirSync, statSync } from "node:fs";
 import { mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import type { DataAdapter, TFile, Vault } from "obsidian";
 
 // nodeVault returns a Vault and DataAdapter both backed by the same temp directory root. Only the
@@ -29,6 +29,16 @@ export function nodeVault(root: string): { vault: Vault; adapter: DataAdapter } 
     },
     remove: async (path: string): Promise<void> => {
       await rm(abs(root, path));
+    },
+    trashSystem: async (): Promise<boolean> => {
+      // A temp-dir harness has no desktop trash, exactly like a headless CI host; returning false
+      // drives the same trashLocal fallback the real adapter takes there.
+      return false;
+    },
+    trashLocal: async (path: string): Promise<void> => {
+      const dest = `.trash/${path}`;
+      await mkdir(dirname(abs(root, dest)), { recursive: true });
+      await rename(abs(root, path), abs(root, dest));
     },
     rename: async (path: string, newPath: string): Promise<void> => {
       await rename(abs(root, path), abs(root, newPath));

--- a/src/vault/obsidian.test.ts
+++ b/src/vault/obsidian.test.ts
@@ -182,6 +182,67 @@ test("createObsidianLocalWriter: a failed write of the staged bytes leaves the d
   assert.equal(files.get("a.md"), "old content");
 });
 
+// fakeDeleteAdapter returns a DataAdapter for exercising deleteFile: trashSystemAvailable mimics an
+// OS whose system trash works (true) or is unavailable, as on mobile or a headless host (false),
+// and ops logs every trash/remove call so a test can assert a file is only ever trashed, never
+// hard removed.
+function fakeDeleteAdapter(
+  trashSystemAvailable: boolean,
+  seed: Record<string, string> = {},
+): { adapter: DataAdapter; files: Map<string, string>; ops: string[] } {
+  const files = new Map<string, string>(Object.entries(seed));
+  const ops: string[] = [];
+  const adapter = {
+    exists: async (path: string) => files.has(path),
+    remove: async (path: string) => {
+      ops.push(`remove ${path}`);
+      files.delete(path);
+    },
+    trashSystem: async (path: string) => {
+      ops.push(`trashSystem ${path}`);
+      if (!trashSystemAvailable) {
+        return false;
+      }
+      files.delete(path);
+      return true;
+    },
+    trashLocal: async (path: string) => {
+      ops.push(`trashLocal ${path}`);
+      files.delete(path);
+    },
+  };
+  return { adapter: adapter as unknown as DataAdapter, files, ops };
+}
+
+test("createObsidianLocalWriter: deleteFile moves the file to system trash, never hard removing it", async () => {
+  const { adapter, files, ops } = fakeDeleteAdapter(true, { "a.md": "bye" });
+  const writer = createObsidianLocalWriter(adapter);
+
+  await writer.deleteFile("a.md");
+
+  assert.equal(files.has("a.md"), false);
+  assert.deepEqual(ops, ["trashSystem a.md"]);
+});
+
+test("createObsidianLocalWriter: deleteFile falls back to local trash when system trash is unavailable", async () => {
+  const { adapter, files, ops } = fakeDeleteAdapter(false, { "a.md": "bye" });
+  const writer = createObsidianLocalWriter(adapter);
+
+  await writer.deleteFile("a.md");
+
+  assert.equal(files.has("a.md"), false);
+  assert.deepEqual(ops, ["trashSystem a.md", "trashLocal a.md"]);
+});
+
+test("createObsidianLocalWriter: deleteFile of a missing file is a no-op", async () => {
+  const { adapter, ops } = fakeDeleteAdapter(true);
+  const writer = createObsidianLocalWriter(adapter);
+
+  await writer.deleteFile("a.md");
+
+  assert.deepEqual(ops, []);
+});
+
 test("createObsidianStore: a missing state file reads back as empty", async () => {
   const store = createObsidianStore(fakeAdapter(), STATE_PATH, DEFAULT_SETTINGS);
 

--- a/src/vault/obsidian.ts
+++ b/src/vault/obsidian.ts
@@ -29,7 +29,16 @@ export function createObsidianLocalWriter(adapter: DataAdapter): LocalWriter {
       if (!exists) {
         return;
       }
-      await adapter.remove(path);
+      // A pulled deletion is moved to trash, never hard removed, so a delete that turns out to be
+      // a mistake stays recoverable on this device (#53), mirroring what Obsidian does for a
+      // manual delete. System trash is tried first and the vault-local .trash folder is the
+      // fallback when the OS has no trash (mobile, a headless host), so the file is always
+      // recoverable somewhere rather than gone.
+      const trashed = await adapter.trashSystem(path);
+      if (trashed) {
+        return;
+      }
+      await adapter.trashLocal(path);
     },
     renameFile: async (path, newPath) => {
       await ensureParentDir(adapter, newPath);


### PR DESCRIPTION
Resolves [#53](https://github.com/8thpark/geode/issues/53)

## Problem

- A synced deletion applied immediately and permanently on both sides; `pushDelete` hard removed the remote object and `pullDelete` hard removed the local file, so a mistaken delete propagated to every device before anyone could notice
- No recovery path existed for a deletion made in error, whether a bad selection or a stray keystroke

## Changes

- Remote deletions now copy the object to a reserved `.geode/trash/` prefix before removing the live key, so the encrypted bytes survive a mistaken delete
- Local deletions now move the file to trash rather than hard removing it, mirroring how Obsidian handles a manual delete
- Aborts the remote delete when the trash copy fails, so the live object is never destroyed without a backup beside it
- Treats the whole `.geode/` namespace as reserved bookkeeping, so trashed copies are never synced, diffed, or flagged as orphans

## Why

- The `v0.1.0` milestone is no silent data loss, and a mistaken delete syncing everywhere permanently is exactly that
- Recovery must not depend on a single device, the bucket is the canonical store for other devices and for MCP, CLI, and API consumers that have no local trash

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Remote deletions now preserve encrypted objects under a timestamped reserved trash prefix before deleting live keys, while pulled local deletions use Obsidian’s system or vault-local trash.
- Adds S3 server-side copy support and aborts remote deletion when backup creation fails.
- Excludes the entire `.geode/` namespace from synchronization and orphan detection.
- Extends storage, planning, execution, filesystem, and Obsidian tests for soft-delete behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with remote and local deletion paths retaining recoverable copies and no actionable defects identified.

Remote deletion proceeds only after a successful backup copy, copy failures preserve the live object, local deletion uses supported trash fallbacks, and reserved trash objects are consistently excluded from planning and orphan detection.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/storage/storage.ts | Adds same-bucket CopyObject support, including HTTP failure handling and detection of embedded S3 error responses. |
| src/sync/execute.ts | Copies remotely deleted objects into reserved trash before deleting their live keys and preserves the live object when copying fails. |
| src/sync/plan.ts | Introduces timestamped trash keys and consistently reserves the complete `.geode/` namespace from synchronization. |
| src/sync/sync.ts | Excludes reserved bookkeeping and trash objects from first-sync orphan detection. |
| src/vault/obsidian.ts | Replaces hard local deletion with system trash and vault-local trash fallback behavior. |
| src/vault/fs.ts | Extends the filesystem-backed test adapter with local-trash behavior for integration testing. |

<sub>Reviews (1): Last reviewed commit: ["Soft deletes to trash"](https://github.com/8thpark/geode/commit/ede84ed1f2fd99dc4867b5c1b1f8a27a69d5f4d8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47502470)</sub>

<!-- /greptile_comment -->