### PR TITLE
Vault →  add unicode normalization to file paths

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -35,11 +35,7 @@ const VAULT_STATE_DEBOUNCE_MS = 2000;
 // equivalent) so the Settings command can jump straight to Geode's tab, and opening the log view
 // can close the settings modal out from under itself.
 type AppWithSetting = App & {
-  setting: {
-    open: () => void;
-    close: () => void;
-    openTabById: (id: string) => void;
-  };
+  setting: { open: () => void; close: () => void; openTabById: (id: string) => void };
 };
 
 // SyncStatus is the state the status bar item reflects.
@@ -203,14 +199,8 @@ export default class GeodePlugin extends Plugin {
   // runSync does the actual work of syncNow, split out so syncNow can own the in flight guard
   // and status bar bookkeeping around it without this getting lost in indentation.
   private async runSync(dir: string): Promise<void> {
-    const secretAccessKey = this.app.secretStorage.getSecret(this.settings.secretId);
-    if (secretAccessKey === null) {
-      this.logger.error(`sync: secret access key not found for ID "${this.settings.secretId}"`);
-      this.setSyncStatus("error", "secret access key not found; open settings to reconfigure");
-      return;
-    }
-
-    const storage = createS3Client(this.settings, rawSecret);
+    const secretAccessKey = this.app.secretStorage.getSecret(this.settings.secretId) ?? "";
+    const storage = createS3Client(this.settings, secretAccessKey);
     const stateStore = createObsidianStore(this.app.vault.adapter, `${dir}/state.json`);
     const reader = createObsidianReader(this.app.vault);
     const localWriter = createObsidianLocalWriter(this.app.vault.adapter);

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,7 +35,11 @@ const VAULT_STATE_DEBOUNCE_MS = 2000;
 // equivalent) so the Settings command can jump straight to Geode's tab, and opening the log view
 // can close the settings modal out from under itself.
 type AppWithSetting = App & {
-  setting: { open: () => void; close: () => void; openTabById: (id: string) => void };
+  setting: {
+    open: () => void;
+    close: () => void;
+    openTabById: (id: string) => void;
+  };
 };
 
 // SyncStatus is the state the status bar item reflects.
@@ -199,8 +203,14 @@ export default class GeodePlugin extends Plugin {
   // runSync does the actual work of syncNow, split out so syncNow can own the in flight guard
   // and status bar bookkeeping around it without this getting lost in indentation.
   private async runSync(dir: string): Promise<void> {
-    const secretAccessKey = this.app.secretStorage.getSecret(this.settings.secretId) ?? "";
-    const storage = createS3Client(this.settings, secretAccessKey);
+    const secretAccessKey = this.app.secretStorage.getSecret(this.settings.secretId);
+    if (secretAccessKey === null) {
+      this.logger.error(`sync: secret access key not found for ID "${this.settings.secretId}"`);
+      this.setSyncStatus("error", "secret access key not found; open settings to reconfigure");
+      return;
+    }
+
+    const storage = createS3Client(this.settings, rawSecret);
     const stateStore = createObsidianStore(this.app.vault.adapter, `${dir}/state.json`);
     const reader = createObsidianReader(this.app.vault);
     const localWriter = createObsidianLocalWriter(this.app.vault.adapter);

--- a/src/storage/storage.test.ts
+++ b/src/storage/storage.test.ts
@@ -141,3 +141,17 @@ test("parseListObjectsXml ignores the token on the final page", () => {
 
   assert.equal(parseListObjectsXml(xml).nextContinuationToken, undefined);
 });
+
+test("parseListObjectsXml normalizes NFD keys to NFC", () => {
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult>
+  <Contents>
+    <Key>caf\u0065\u0301.md</Key>
+    <LastModified>2026-07-13T00:00:00.000Z</LastModified>
+    <Size>12</Size>
+  </Contents>
+</ListBucketResult>`;
+
+  const page = parseListObjectsXml(xml);
+  assert.equal(page.objects[0].key, "caf\u00e9.md");
+});

--- a/src/storage/xml.ts
+++ b/src/storage/xml.ts
@@ -1,3 +1,4 @@
+import { normalizeKey } from "../vault/vault.ts";
 import type { ObjectMeta } from "./storage.ts";
 
 // ListPage is one page of a ListObjectsV2 response: the objects it carries and, when the listing
@@ -20,7 +21,7 @@ export function parseListObjectsXml(xml: string): ListPage {
   while (match !== null) {
     const block = match[1];
     objects.push({
-      key: decodeXmlText(fieldFrom(block, "Key")),
+      key: normalizeKey(decodeXmlText(fieldFrom(block, "Key"))),
       size: Number(fieldFrom(block, "Size")),
       lastModified: fieldFrom(block, "LastModified"),
     });

--- a/src/vault/obsidian.ts
+++ b/src/vault/obsidian.ts
@@ -6,6 +6,7 @@ import {
   encodeSnapshot,
   type FileInfo,
   fingerprintSettings,
+  normalizeKey,
   type Reader,
   type Snapshot,
   type Store,
@@ -58,7 +59,7 @@ export function createObsidianReader(vault: Vault): Reader {
     listFiles: async () => {
       const files: FileInfo[] = [];
       for (const file of vault.getFiles()) {
-        files.push({ path: file.path, size: file.stat.size, mtime: file.stat.mtime });
+        files.push({ path: normalizeKey(file.path), size: file.stat.size, mtime: file.stat.mtime });
       }
       return files;
     },

--- a/src/vault/vault.test.ts
+++ b/src/vault/vault.test.ts
@@ -7,6 +7,7 @@ import {
   encodeSnapshot,
   type FileInfo,
   isSnapshot,
+  normalizeKey,
   type Reader,
   SNAPSHOT_VERSION,
   type Snapshot,
@@ -110,6 +111,61 @@ test("isSnapshot: only a non-null object with a files array is accepted", () => 
 
   for (const { name, value, want } of cases) {
     assert.equal(isSnapshot(value), want, name);
+  }
+});
+
+const normalizeKeyCases: { name: string; key: string; want: string }[] = [
+  {
+    name: "pure ASCII passes through unchanged",
+    key: "notes/hello.md",
+    want: "notes/hello.md",
+  },
+  {
+    name: "empty string passes through",
+    key: "",
+    want: "",
+  },
+  {
+    name: "already NFC passes through unchanged",
+    key: "café.md",
+    want: "café.md",
+  },
+  {
+    name: "NFD e-acute composes to NFC",
+    key: "caf\u0065\u0301.md",
+    want: "caf\u00e9.md",
+  },
+  {
+    name: "NFD u-diaeresis composes to NFC",
+    key: "m\u0075\u0308.md",
+    want: "m\u00fc.md",
+  },
+  {
+    name: "mixed NFC and NFD paths are normalized",
+    key: "notes/café \u0065\u0301.md",
+    want: "notes/café \u00e9.md",
+  },
+];
+
+for (const { name, key, want } of normalizeKeyCases) {
+  test(`normalizeKey: ${name}`, () => {
+    assert.equal(normalizeKey(key), want);
+  });
+}
+
+test("decodeSnapshot: normalizes NFD paths to NFC on read", () => {
+  const nfdPath = "caf\u0065\u0301.md";
+  const nfcPath = "caf\u00e9.md";
+  const raw = JSON.stringify({
+    version: 1,
+    files: [{ path: nfdPath, size: 1, mtime: 2, hash: "h" }],
+  });
+
+  const result = decodeSnapshot(raw);
+
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.snapshot.files[0].path, nfcPath);
   }
 });
 

--- a/src/vault/vault.ts
+++ b/src/vault/vault.ts
@@ -92,9 +92,20 @@ export function decodeSnapshot(raw: string): DecodedSnapshot {
   if (!isSnapshot(parsed)) {
     return { ok: false, reason: "corrupt" };
   }
+
   const settingsFingerprint = (parsed as { settingsFingerprint?: unknown }).settingsFingerprint;
   const fingerprintStr = typeof settingsFingerprint === "string" ? settingsFingerprint : undefined;
-  const snapshot: Snapshot = { files: parsed.files };
+
+  const files: FileState[] = [];
+  for (let i = 0; i < parsed.files.length; i++) {
+    const f = parsed.files[i];
+    files.push({
+      ...f,
+      path: normalizeKey(f.path),
+    });
+  }
+  const snapshot: Snapshot = { files };
+
   if (fingerprintStr !== undefined) {
     snapshot.settingsFingerprint = fingerprintStr;
   }
@@ -131,7 +142,11 @@ export function diffSnapshots(previous: Snapshot, current: Snapshot): Change[] {
 // encodeSnapshot serializes a snapshot for persistence, stamping the format version so every
 // manifest and state.json written from here on carries the marker decodeSnapshot branches on.
 export function encodeSnapshot(snapshot: Snapshot): string {
-  const result: { version: number; files: FileState[]; settingsFingerprint?: string } = {
+  const result: {
+    version: number;
+    files: FileState[];
+    settingsFingerprint?: string;
+  } = {
     version: SNAPSHOT_VERSION,
     files: snapshot.files,
   };
@@ -177,6 +192,13 @@ export async function hashBytes(data: Uint8Array): Promise<string> {
 // check stops at the array itself: a malformed entry degrades rather than crashes downstream.
 export function isSnapshot(value: unknown): value is Snapshot {
   return typeof value === "object" && value !== null && Array.isArray((value as Snapshot).files);
+}
+
+// normalizeKey returns the NFC canonical form of a path so that composed and decomposed
+// representations of the same visible name (e.g. "é.md") always produce the same identity,
+// regardless of the platform that created the file.
+export function normalizeKey(key: string): string {
+  return key.normalize("NFC");
 }
 
 // takeSnapshot walks every file the reader currently sees and returns their content hashes. A


### PR DESCRIPTION


## Problem
File paths are used as S3 keys and manifest identities byte for byte, with no Unicode normalization. The same visible name ("é.md") can be composed (NFC) on one platform and decomposed (NFD) on another, producing two distinct keys for one note; each device then sees a phantom second file, and edits fork between them. Case insensitivity has an issue (https://github.com/8thpark/geode/issues/94); normalization is the same class of identity bug and lands the moment a vault with accented filenames syncs between macOS/iOS and anything else.

## Changes
Added a helper `normalizeKey` function that returns the NFC canonical form of a path so that composed and decomposed representations of the same visible name (e.g. "é.md") always produce the same identity, regardless of the platform that created the file.

## Tests
Added new tests in `vault.test.ts` for testing the helper function, and a new one in `storage.test.ts`,  test confirming `parseListObjectsXml` returns NFC-normalized keys from NFD XML input.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds NFC canonicalization for vault paths, decoded snapshot entries, and keys parsed from S3 listings.
- Introduces normalizeKey and unit coverage for common NFC/NFD conversions.
- Normalizes local file identities returned by the Obsidian reader.
- Normalizes persisted manifest paths during decoding and S3 listing keys during XML parsing.

<h3>Confidence Score: 2/5</h3>

This PR should not merge until canonical path identities are separated from the physical local paths and legacy S3 keys used to address existing files.

Normalization currently discards byte-exact locators on both sides of synchronization, so accented NFD files can abort local snapshots and existing NFD-keyed S3 objects can become unreachable.

**Files Needing Attention:** src/vault/obsidian.ts, src/vault/vault.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/vault/obsidian.ts | Normalizes local identities but loses the original physical path required by subsequent Vault lookups. |
| src/vault/vault.ts | Adds normalization and snapshot migration, but converting persisted paths also changes the locator used for legacy S3 objects. |
| src/storage/xml.ts | Normalizes listed keys for canonical orphan comparisons; listing values do not directly drive object-addressing operations. |
| src/vault/vault.test.ts | Covers normalization and snapshot decoding but not local physical-path lookup or legacy remote-object access. |
| src/storage/storage.test.ts | Adds focused coverage that NFD XML listing keys are returned in NFC. |

<sub>Reviews (1): Last reviewed commit: ["fix: normalize the file path names, usin..."](https://github.com/8thpark/geode/commit/54691b7430f86fba0ed16792f835bf439170d020) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47651399)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->