### PR TITLE
Sync → Guard remote deletes against a concurrent push

### DIFF
--- a/src/sync/execute.test.ts
+++ b/src/sync/execute.test.ts
@@ -88,6 +88,54 @@ test("executeSyncPlan: pushDelete leaves the live object intact when the trash c
   assert.equal(objects.get("a.md"), "hello");
 });
 
+test("executeSyncPlan: pushDelete removes the object when it still matches the snapshot", async () => {
+  const reader = fakeReader({});
+  const { writer } = fakeLocalWriter();
+  const { storage, objects } = fakeStorage({ "a.md": "hello" });
+  const remote = snapshot(file("a.md", await hashOf("hello")));
+
+  const { completed, failures } = await executeSyncPlan(
+    [{ kind: "pushDelete", path: "a.md" }],
+    empty,
+    reader,
+    writer,
+    storage,
+    0,
+    remote,
+  );
+
+  assert.deepEqual(failures, []);
+  assert.equal(completed.length, 1);
+  assert.equal(objects.has("a.md"), false);
+  assert.equal(objects.get(trashKeyFor("a.md", 0)), "hello");
+});
+
+test("executeSyncPlan: pushDelete aborts as concurrent when the remote object drifted", async () => {
+  const reader = fakeReader({});
+  const { writer } = fakeLocalWriter();
+  // Another device pushed new content to a.md after the manifest this pass planned from was read.
+  const { storage, objects } = fakeStorage({ "a.md": "hello world" });
+  const remote = snapshot(file("a.md", await hashOf("hello")));
+
+  const { concurrent, failed, failures } = await executeSyncPlan(
+    [{ kind: "pushDelete", path: "a.md" }],
+    empty,
+    reader,
+    writer,
+    storage,
+    0,
+    remote,
+  );
+
+  assert.equal(concurrent, true);
+  assert.equal(failed.length, 1);
+  assert.equal(failures.length, 1);
+  assert.equal(failures[0]?.path, "a.md");
+  // The newer bytes survive untouched: nothing deleted, nothing trashed.
+  assert.equal(objects.get("a.md"), "hello world");
+  assert.equal(objects.has(trashKeyFor("a.md", 0)), false);
+});
+
 test("executeSyncPlan: pull fetches the remote object and writes it locally", async () => {
   const reader = fakeReader({});
   const { writer, files } = fakeLocalWriter();

--- a/src/sync/execute.test.ts
+++ b/src/sync/execute.test.ts
@@ -88,7 +88,7 @@ test("executeSyncPlan: pushDelete leaves the live object intact when the trash c
   assert.equal(objects.get("a.md"), "hello");
 });
 
-test("executeSyncPlan: pushDelete removes the object when it still matches the snapshot", async () => {
+test("executeSyncPlan: pushDelete removes the object that still matches the snapshot", async () => {
   const reader = fakeReader({});
   const { writer } = fakeLocalWriter();
   const { storage, objects } = fakeStorage({ "a.md": "hello" });
@@ -110,7 +110,7 @@ test("executeSyncPlan: pushDelete removes the object when it still matches the s
   assert.equal(objects.get(trashKeyFor("a.md", 0)), "hello");
 });
 
-test("executeSyncPlan: pushDelete aborts as concurrent when the remote object drifted", async () => {
+test("executeSyncPlan: pushDelete aborts as concurrent when remote object drifted", async () => {
   const reader = fakeReader({});
   const { writer } = fakeLocalWriter();
   // Another device pushed new content to a.md after the manifest this pass planned from was read.

--- a/src/sync/execute.ts
+++ b/src/sync/execute.ts
@@ -190,6 +190,12 @@ async function executeAction(
   }
 
   if (action.kind === "pushDelete") {
+    // Confirm the remote object still holds the bytes this pass planned to delete before touching
+    // it. A drifted or already absent object is handled without destroying newer content (#133).
+    const drift = await checkRemoteDrift(action.path, remoteByPath.get(action.path), storage);
+    if (drift !== null) {
+      return drift;
+    }
     // Park the object under the reserved trash prefix before removing it from its live key, so a
     // mistaken delete stays recoverable (#53). A copy that 404s means the object is already gone
     // remotely (another device deleted it), which is the end state a pushDelete wants: nothing to
@@ -377,6 +383,42 @@ async function putCondition(
   }
 
   return { ok: true, kind: "put", condition: { kind: "ifMatch", etag: fetched.etag } };
+}
+
+// checkRemoteDrift confirms the object a pushDelete is about to destroy still holds the bytes the
+// plan snapshotted. It returns the result to hand straight back when the delete must not proceed,
+// or null when it is safe. Another device can push new content to this path in the window between
+// the manifest being read and the delete running (#133); an unconditional delete would discard
+// those bytes, and because the manifest CAS then loses without the winner re-uploading, they would
+// not reappear until that file was next edited locally. A remote hash that no longer matches the
+// snapshot is exactly that race, failed as concurrent so the pass abandons its stale manifest and
+// the next sync replans; an object already gone is the end state the delete wants, so it succeeds.
+// Verifying right before the delete shrinks the residual window to the gap between this read and
+// the delete itself, the same shape checkLocalDrift uses for local writes; closing it entirely
+// needs a conditional delete, which awaits provider probing (#108). expected is undefined only for
+// a caller that supplied no remote view (the empty default), which cannot happen through syncOnce
+// where a pushDelete always carries a manifest entry; such a caller keeps the prior unconditional
+// behaviour, its delete still recoverable from the trash copy (#53).
+async function checkRemoteDrift(
+  path: string,
+  expected: FileState | undefined,
+  storage: StorageClient,
+): Promise<ActionResult | null> {
+  if (expected === undefined) {
+    return null;
+  }
+  const fetched = await storage.getObject(path);
+  if (!fetched.ok || fetched.body === null) {
+    if (fetched.status === "not_found") {
+      return successfulAction();
+    }
+    return failedAction(path, fetched.message, false);
+  }
+  if ((await hashBytes(fetched.body)) !== expected.hash) {
+    return failedAction(path, REMOTE_DRIFT_MESSAGE, true);
+  }
+
+  return null;
 }
 
 // remoteMatches reports whether path already holds bytes, making a failed create idempotent. A


### PR DESCRIPTION
Resolves [#133](https://github.com/8thpark/geode/issues/133)

## Problem

- A pushed deletion issued an unconditional `DELETE`, so content another device pushed to the same path between the manifest being read and the delete running was destroyed
- The manifest CAS then failed the pass, but the bytes were already gone, and the winning device would not re-upload them until that file was next edited locally
- File pushes already carried preconditions for this race; deletes did not

## Changes

- Verify the remote object still matches the planned snapshot immediately before trashing and deleting it, aborting as a concurrent conflict when it has drifted
- Treat an already absent object as success, the end state a delete wants
- Add tests covering the matching and drifted cases

## Why

- Deletes should be as safe against a concurrent writer as pushes already are, so no edit is ever silently lost
- Keeps the change provider agnostic; a fully atomic `If-Match` delete is left to provider probing (#108)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds remote drift detection before executing pushed deletions.
- Hashes the current remote object against the planned snapshot before trashing and deleting it.
- Treats an already absent remote object as a successful deletion.
- Adds coverage for matching and concurrently modified remote objects.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/sync/execute.ts | Adds a pre-delete remote hash check that preserves concurrently updated content and handles absent objects idempotently. |
| src/sync/execute.test.ts | Covers successful deletion of matching content and conflict handling for drifted remote content. |

<sub>Reviews (2): Last reviewed commit: ["Line lengths"](https://github.com/8thpark/geode/commit/886494554c8816bbf35c9eb51e86e8bee19e2069) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47659617)</sub>

<!-- /greptile_comment -->