### PR TITLE
Storage → Test connection verifies conditional writes

### DIFF
--- a/src/storage/storage.test.ts
+++ b/src/storage/storage.test.ts
@@ -1,8 +1,40 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import { DEFAULT_SETTINGS, type GeodeSettings } from "../settings/settings.ts";
-import { testConnection } from "./storage.ts";
+import { probeConditionalWrites, type StorageClient, testConnection } from "./storage.ts";
 import { parseListObjectsXml } from "./xml.ts";
+
+// honouringPut is a putObject that enforces ifAbsent the way a correct S3 server does: the first
+// write to a key lands, a later ifAbsent write to the same key is rejected as a conflict.
+function honouringPut(): StorageClient["putObject"] {
+  const seen = new Set<string>();
+  return async (key, _body, condition) => {
+    if (condition !== undefined && condition.kind === "ifAbsent" && seen.has(key)) {
+      return { ok: false, status: "conflict", message: "Storage rejected the write (412)" };
+    }
+    seen.add(key);
+    return { ok: true, status: "ok", message: "" };
+  };
+}
+
+// probeStub returns a StorageClient whose methods succeed with an etag by default, so each test
+// overrides only the behaviour it exercises.
+function probeStub(over: Partial<StorageClient>): StorageClient {
+  const base: StorageClient = {
+    putObject: async () => ({ ok: true, status: "ok", message: "" }),
+    getObject: async () => ({
+      ok: true,
+      status: "ok",
+      message: "",
+      body: new Uint8Array(),
+      etag: '"probe"',
+    }),
+    copyObject: async () => ({ ok: true, status: "ok", message: "" }),
+    deleteObject: async () => ({ ok: true, status: "ok", message: "" }),
+    listObjects: async () => ({ ok: true, status: "ok", message: "", objects: [] }),
+  };
+  return { ...base, ...over };
+}
 
 const missingFieldCases: {
   name: string;
@@ -85,6 +117,80 @@ test("testConnection: R2 with empty endpoint and region passes field check", asy
 
   assert.equal(result.ok, false);
   assert.ok(!result.message.startsWith("Fill in"));
+});
+
+test("probeConditionalWrites: passes when the provider honours conditional writes", async () => {
+  const client = probeStub({ putObject: honouringPut() });
+
+  const result = await probeConditionalWrites(client);
+
+  assert.equal(result.ok, true);
+  assert.equal(result.status, "ok");
+});
+
+test("probeConditionalWrites: fails when the provider silently ignores the condition", async () => {
+  // Google Cloud Storage's S3 interop accepts If-None-Match: * and does nothing with it, so the
+  // second write clobbers the first instead of conflicting.
+  const client = probeStub({
+    putObject: async () => ({ ok: true, status: "ok", message: "" }),
+  });
+
+  const result = await probeConditionalWrites(client);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.status, "client");
+  assert.match(result.message, /concurrent edits/);
+});
+
+test("probeConditionalWrites: fails when the provider rejects the conditional write", async () => {
+  // Backblaze B2, Wasabi, and Garage reject the precondition outright rather than honour it.
+  const client = probeStub({
+    putObject: async () => ({
+      ok: false,
+      status: "server",
+      message: "Storage rejected the write (501)",
+    }),
+  });
+
+  const result = await probeConditionalWrites(client);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.status, "server");
+  assert.equal(result.message, "Storage rejected the write (501)");
+});
+
+test("probeConditionalWrites: fails when the provider returns no etag", async () => {
+  const client = probeStub({
+    putObject: honouringPut(),
+    getObject: async () => ({
+      ok: true,
+      status: "ok",
+      message: "",
+      body: new Uint8Array(),
+      etag: null,
+    }),
+  });
+
+  const result = await probeConditionalWrites(client);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.status, "client");
+  assert.match(result.message, /ETag/);
+});
+
+test("probeConditionalWrites: deletes its probe object under the reserved prefix", async () => {
+  let deleted = "";
+  const client = probeStub({
+    putObject: honouringPut(),
+    deleteObject: async (key) => {
+      deleted = key;
+      return { ok: true, status: "ok", message: "" };
+    },
+  });
+
+  await probeConditionalWrites(client);
+
+  assert.ok(deleted.startsWith(".geode/"));
 });
 
 test("parseListObjectsXml decodes XML entities in object keys", () => {

--- a/src/storage/storage.test.ts
+++ b/src/storage/storage.test.ts
@@ -193,6 +193,20 @@ test("probeConditionalWrites: deletes its probe object under the reserved prefix
   assert.ok(deleted.startsWith(".geode/"));
 });
 
+test("probeConditionalWrites: a rejecting cleanup does not mask a passing probe", async () => {
+  const client = probeStub({
+    putObject: honouringPut(),
+    deleteObject: async () => {
+      throw new Error("network blip during cleanup");
+    },
+  });
+
+  const result = await probeConditionalWrites(client);
+
+  assert.equal(result.ok, true);
+  assert.equal(result.status, "ok");
+});
+
 test("parseListObjectsXml decodes XML entities in object keys", () => {
   const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <ListBucketResult>

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -4,6 +4,11 @@ import { encodeComponent, encodeKey } from "./encode.ts";
 import { messageFor, statusForHttp } from "./errors.ts";
 import { parseListObjectsXml } from "./xml.ts";
 
+// PROBE_KEY_PREFIX namespaces testConnection's throwaway probe object under geode's reserved bucket
+// prefix (sync's RESERVED_PREFIX). A probe left behind by a failed cleanup therefore sits where
+// sync ignores it, never pulled to every device as a phantom vault file.
+const PROBE_KEY_PREFIX = ".geode/connection-probe-";
+
 // ConnectionResult reports whether a storage provider accepted a test request. Message is the
 // empty string when ok is true.
 export type ConnectionResult = {
@@ -110,8 +115,60 @@ export function createS3Client(settings: GeodeSettings, secretAccessKey: string)
   };
 }
 
-// testConnection sends a signed HEAD request for the configured bucket and reports whether the
-// provider accepted the credentials.
+// probeConditionalWrites confirms the provider actually honours the compare-and-swap sync is built
+// on, not merely that it accepts the credentials. It writes a throwaway object with If-None-Match:
+// *, then issues a second If-None-Match: * write that must be rejected: a provider with no
+// conditional-write support (Backblaze B2, Wasabi, Garage) fails the first write, and one that
+// accepts the header but ignores it (Google Cloud Storage's S3 interop) lets the second write
+// clobber the first, the exact silent data loss the conditional puts exist to prevent. It also
+// checks the read hands back an ETag, which sync needs to make later updates conditional. The probe
+// object is always deleted, best effort.
+export async function probeConditionalWrites(client: StorageClient): Promise<ConnectionResult> {
+  const key = `${PROBE_KEY_PREFIX}${crypto.randomUUID()}`;
+  const body = new TextEncoder().encode("geode connection probe");
+
+  try {
+    const first = await client.putObject(key, body, { kind: "ifAbsent" });
+    if (!first.ok) {
+      return { ok: false, status: first.status, message: first.message };
+    }
+
+    const second = await client.putObject(key, body, { kind: "ifAbsent" });
+    if (second.ok) {
+      return {
+        ok: false,
+        status: "client",
+        message: "Storage ignored a conditional write, so concurrent edits can be lost",
+      };
+    }
+    if (second.status !== "conflict") {
+      return { ok: false, status: second.status, message: second.message };
+    }
+
+    const read = await client.getObject(key);
+    if (!read.ok) {
+      return { ok: false, status: read.status, message: read.message };
+    }
+    if (read.etag === null) {
+      return {
+        ok: false,
+        status: "client",
+        message: "Storage did not return an ETag, which sync needs for conditional writes",
+      };
+    }
+
+    return { ok: true, status: "ok", message: "" };
+  } finally {
+    // Best effort: the probe already proved what it needed to, and a leftover object lives under
+    // the reserved prefix where sync ignores it, so a failed delete must not change the result.
+    await client.deleteObject(key);
+  }
+}
+
+// testConnection reports whether a storage provider is usable for sync: it accepts the credentials
+// (a signed HEAD for the bucket) and honours the conditional writes sync's compare-and-swap depends
+// on (probeConditionalWrites). Reporting ok on the HEAD alone would green-light providers that
+// authenticate fine but silently lose edits under concurrency.
 export async function testConnection(
   settings: GeodeSettings,
   secretAccessKey: string,
@@ -143,7 +200,8 @@ export async function testConnection(
       message: `Storage rejected the request (${response.status})`,
     };
   }
-  return { ok: true, status: "ok", message: "" };
+
+  return probeConditionalWrites(createS3Client(settings, secretAccessKey));
 }
 
 // conditionHeaders converts a PutCondition into the HTTP precondition headers an S3 compatible

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -160,8 +160,10 @@ export async function probeConditionalWrites(client: StorageClient): Promise<Con
     return { ok: true, status: "ok", message: "" };
   } finally {
     // Best effort: the probe already proved what it needed to, and a leftover object lives under
-    // the reserved prefix where sync ignores it, so a failed delete must not change the result.
-    await client.deleteObject(key);
+    // the reserved prefix where sync ignores it. A cleanup that rejects would escape the finally
+    // and replace the probe's verdict, so the rejection is swallowed rather than allowed to mask
+    // an otherwise successful test.
+    await client.deleteObject(key).catch(() => undefined);
   }
 }
 


### PR DESCRIPTION
Resolves [#141](https://github.com/8thpark/geode/issues/141)

## Problem

- `testConnection` reported success the moment a provider accepted the credentials, never checking the conditional writes sync's compare-and-swap depends on
- Providers that reject conditional writes, or accept `If-None-Match: *` and silently ignore it, passed the test then either refused to sync or let concurrent edits overwrite each other with no error

## Changes

- Added a conditional write probe that runs after the credential check, writing and rereading a throwaway object under the reserved prefix to confirm the provider enforces `If-None-Match: *` and returns an `ETag`
- Failed the connection test with a clear message when a provider ignores, rejects, or cannot support the writes sync needs
- Covered each failure mode with unit tests, with the happy path exercised against real storage

## Why

- A connection test that passes for providers that lose edits is worse than none; this makes it answer the question it claims to, before a vault ever trusts the bucket

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a storage compatibility probe that:
- Verifies providers enforce conditional object creation.
- Confirms successful reads return an ETag.
- Deletes the temporary probe object without allowing cleanup rejection to replace the probe verdict.
- Adds unit coverage for supported providers and each compatibility failure mode.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/storage/storage.ts | Adds the conditional-write probe to connection testing and safely suppresses rejected best-effort cleanup. |
| src/storage/storage.test.ts | Covers successful probing, ignored or rejected conditions, missing ETags, reserved-prefix cleanup, and cleanup rejection. |

<sub>Reviews (2): Last reviewed commit: ["Address comment around error handling"](https://github.com/8thpark/geode/commit/f8ace3001d2b54426a0416bd58422ef2ca5f3066) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47667341)</sub>

<!-- /greptile_comment -->