### PR TITLE
feat: warn custom S3 provider users about conditional write requirements

### DIFF
--- a/src/settings/tab.ts
+++ b/src/settings/tab.ts
@@ -198,6 +198,28 @@ function renderProviderFields(tab: GeodeSettingTab, containerEl: HTMLElement): v
     return;
   }
 
+  // Warn users of custom S3-compatible providers that the concurrent sync guard
+  // (issue #83, PR #106) relies on the provider honouring If-Match / If-None-Match
+  // on PUT. R2 and AWS do; many "S3 compatible" endpoints silently ignore
+  // precondition headers and return 200, turning the manifest CAS into a no-op.
+  new Setting(containerEl)
+    .setName("Conditional write support")
+    .setDesc(
+      "Your provider MUST support conditional PUT (If-Match / If-None-Match). "
+      + "Without it the concurrent sync guard is a no-op and overlapping syncs "
+      + "can silently delete files. R2 and AWS S3 support this; many "
+      + "S3-compatible endpoints do not. Verify before using.",
+    )
+    .addButton((button) =>
+      button.setButtonText("How to check?")
+        .onClick(() => {
+          window.open(
+            "https://docs.geodemd.com/troubleshooting#conditional-writes",
+            "_blank",
+          );
+        }),
+    );
+
   new Setting(containerEl)
     .setName("Endpoint")
     .setDesc("The S3 compatible endpoint URL for your storage.")


### PR DESCRIPTION
Addresses issue #108

The concurrent sync guard (issue #83, PR #106) relies on providers honouring If-Match / If-None-Match on PUT. R2 and AWS S3 do; many S3-compatible endpoints silently ignore precondition headers and return 200, turning the manifest CAS into a no-op with no error.

This adds a visible warning in the settings tab when the "Custom" provider is selected:
- Explains that conditional PUT support is required for safe concurrent sync
- Warns that many S3-compatible endpoints do not support it
- Includes a "How to check?" button linking to documentation
- Only rendered when provider is set to "Custom"

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a conditional-write compatibility warning for custom S3 providers.
- Displays the warning only when the Custom provider is selected.
- Explains the concurrent-sync risk posed by providers that ignore conditional PUT headers.
- Adds a button linking users to conditional-write verification documentation.


