### PR TITLE
Sync → Verify conditional write support before trusting the CAS

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,16 @@
+# Roadmap
+
+Planned upcoming releases for **Geode**:
+
+| Version  | Name    | Description                                                      |
+| -------- | ------- | ---------------------------------------------------------------- |
+| `v0.1.0` | Bedrock | Two desktop devices can sync a vault, using a provided S3 bucket |
+| `v0.2.0` |         | iOS & Android support                                            |
+| `v0.3.0` |         | Encyption                                                        |
+| `v0.4.0` |         | MCP                                                              |
+| `v0.5.0` |         | API                                                              |
+| `v0.6.0` |         | CLI                                                              |
+| `v0.7.0` |         | SDK                                                              |
+| `v0.8.0` |         | Browser access                                                   |
+| `v1.0.0` |         | Official v1 Release                                              |
+| `v1.1.0` |         | WebDAV support                                                   |

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ import {
   normalizeSettings,
 } from "./settings/settings";
 import { GeodeSettingTab } from "./settings/tab";
-import { createS3Client } from "./storage/storage";
+import { createS3Client, probeConditionalWrites } from "./storage/storage";
 import { syncOnce } from "./sync/sync";
 import {
   createObsidianLocalWriter,
@@ -78,6 +78,12 @@ export default class GeodePlugin extends Plugin {
   private refreshInFlight: Promise<void> | null = null;
   private refreshQueued = false;
   private syncing = false;
+  // The manifest compare-and-swap that keeps overlapping syncs from clobbering each other (#83)
+  // only holds if the provider honours conditional writes. testConnection probes for this, but
+  // nothing forces a user to run it, so sync verifies once per session before it trusts the CAS
+  // and refuses to run rather than silently lose edits on a provider that ignores preconditions
+  // (#108). Reset on saveSettings so switching provider re-verifies.
+  private conditionalWritesVerified = false;
 
   async onload() {
     await this.loadSettings();
@@ -211,6 +217,18 @@ export default class GeodePlugin extends Plugin {
     }
 
     const storage = createS3Client(this.settings, secretAccessKey);
+
+    if (!this.conditionalWritesVerified) {
+      const probe = await probeConditionalWrites(storage);
+      if (!probe.ok) {
+        this.logger.error(`sync: conditional write check failed: ${probe.message}`);
+        this.setSyncStatus("error", probe.message);
+        return;
+      }
+      this.conditionalWritesVerified = true;
+      this.logger.info("sync: conditional write support verified");
+    }
+
     const stateStore = createObsidianStore(
       this.app.vault.adapter,
       `${dir}/state.json`,
@@ -246,6 +264,9 @@ export default class GeodePlugin extends Plugin {
 
   async saveSettings() {
     await this.saveData(this.settings);
+    // A settings change may point at a different provider, so the next sync must re-verify
+    // conditional write support rather than trust the last provider's result.
+    this.conditionalWritesVerified = false;
     this.logger.info("settings saved");
   }
 


### PR DESCRIPTION
Resolves [#108](https://github.com/8thpark/geode/issues/108)

## Problem

- The concurrent sync guard from `#83` only holds if the provider honours conditional writes, yet nothing at sync time ever verified that it does
- `testConnection` probes for support but is advisory, so a user can sync against a provider that silently ignores preconditions and lose edits again, this time with no error at all

## Changes

- Sync now verifies conditional write support once per session before it trusts the manifest compare and swap, refusing the pass rather than clobbering when a provider ignores preconditions
- Re-verifies after a settings change, so switching provider or bucket can never ride on the previous provider's result

## Why

- The manifest compare and swap is the one guard whose silent failure means lost notes, so the safety net that catches a broken provider must be load bearing at sync time, not merely advisory at setup

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a mandatory conditional-write capability check before the first sync of each session.
- Caches successful verification for subsequent syncs.
- Invalidates the cached result whenever settings are saved.
- Adds a release roadmap document.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or non-blocking defects identified.

The sync path now verifies conditional-write support before relying on compare-and-swap behavior and resets that verification after settings are saved.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/main.ts | Gates synchronization on verified conditional-write support and invalidates verification after settings changes; no actionable defect was established. |
| docs/roadmap.md | Adds a concise roadmap of planned releases without affecting runtime behavior. |

<sub>Reviews (1): Last reviewed commit: ["Add probe"](https://github.com/8thpark/geode/commit/8d2c38b518f0c895e05ef2ac10a899e2ca412e62) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47678791)</sub>

<!-- /greptile_comment -->