### PR TITLE
Sync → Test future manifest halts the pass

### DIFF
--- a/src/sync/sync.test.ts
+++ b/src/sync/sync.test.ts
@@ -95,6 +95,61 @@ test("readRemoteManifest: a manifest from a newer format version refuses the pas
   });
 });
 
+test("syncOnce: a newer manifest version halts the pass before any sync work", async () => {
+  const reader = fakeReader({ "local.md": "local" });
+  reader.fileExists = async () => {
+    throw new Error("unexpected local existence check");
+  };
+  reader.listFiles = async () => {
+    throw new Error("unexpected local listing");
+  };
+  reader.readFile = async () => {
+    throw new Error("unexpected local read");
+  };
+
+  const { writer } = fakeLocalWriter();
+  writer.deleteFile = async () => {
+    throw new Error("unexpected local delete");
+  };
+  writer.renameFile = async () => {
+    throw new Error("unexpected local rename");
+  };
+  writer.writeFile = async () => {
+    throw new Error("unexpected local write");
+  };
+
+  const { storage } = fakeStorage({
+    [MANIFEST_KEY]: JSON.stringify({ version: 2, files: [] }),
+    "remote.md": "remote",
+  });
+  const getObject = storage.getObject;
+  storage.getObject = async (key) => {
+    assert.equal(key, MANIFEST_KEY);
+    return getObject(key);
+  };
+  storage.copyObject = async () => {
+    throw new Error("unexpected remote copy");
+  };
+  storage.deleteObject = async () => {
+    throw new Error("unexpected remote delete");
+  };
+  storage.listObjects = async () => {
+    throw new Error("unexpected remote listing");
+  };
+  storage.putObject = async () => {
+    throw new Error("unexpected remote write");
+  };
+
+  const outcome = await syncOnce(empty, reader, writer, storage, 1);
+
+  assert.deepEqual(outcome, {
+    ok: false,
+    message: "remote manifest needs a newer version of geode",
+    failures: [],
+    snapshot: null,
+  });
+});
+
 test("syncOnce: a stale ancestor is ignored on a first sync, so a populated vault is pushed, not wiped", async () => {
   // An older build wrote state.json on every file event rather than only on completed syncs, so an
   // upgrader carries a `previous` snapshot describing their whole vault even though nothing ever


### PR DESCRIPTION
Resolves #145

## Problem

- The manifest decoder rejects unknown future versions, but no full `syncOnce` test proves the pass stops before doing any work
- A regression could let an older client alter a bucket written by a newer client

## Changes

- Add a full-pass regression test using a future manifest version
- Use fail-fast local and remote collaborators to prove there are no local reads or writes, planning, remote listing, uploads, copies, or deletions
- Assert the pass returns the expected update-required failure with no snapshot progress

## Why

- An older client must never modify data in a format it does not understand

## Testing

- `npm run lint`
- `npm run build`
- `npm test`
- `npm run check-versions`
- `npm run audit`

Integration tests were not run locally because Docker Desktop was unavailable.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a full-pass regression test confirming that `syncOnce` rejects a future manifest version before performing local or remote synchronization work.
- Replaces collaborator operations with fail-fast implementations to detect unintended reads, writes, planning-related listing, copies, uploads, or deletions.
- Verifies the update-required failure response contains no failures or snapshot progress.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the added test accurately exercises the future-manifest rejection path without changing production behavior.

The fail-fast collaborators cover all local and remote work reachable after manifest decoding, while the permitted manifest read returns an unsupported version and the assertion matches the established early-return outcome.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/sync/sync.test.ts | Adds focused regression coverage for the existing future-manifest early-return path; the setup and expected outcome align with the current synchronization contracts, with no actionable issues identified. |

<sub>Reviews (1): Last reviewed commit: ["test(sync): guard unsupported manifest p..."](https://github.com/8thpark/geode/commit/61a298f6cc3b5393d1713db0bd0381306442e715) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47733176)</sub>

<!-- /greptile_comment -->