### PR TITLE
Settings → Block save after failed connection test

### DIFF
--- a/src/settings/settings.test.ts
+++ b/src/settings/settings.test.ts
@@ -1,15 +1,163 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
+  type ConnectionStatus,
+  canSave,
   DEFAULT_SETTINGS,
   draftForDisplay,
   endpointFor,
   type GeodeSettings,
   hasConnectionConfig,
+  isCurrentConnectionResult,
   normalizeSettings,
   regionFor,
+  saveDraft,
   settingsEqual,
 } from "./settings.ts";
+
+const canSaveCases: {
+  name: string;
+  dirty: boolean;
+  connectionStatus: ConnectionStatus;
+  want: boolean;
+}[] = [
+  {
+    name: "dirty draft with no test result is saveable",
+    dirty: true,
+    connectionStatus: "unknown",
+    want: true,
+  },
+  {
+    name: "dirty draft after a successful test is saveable",
+    dirty: true,
+    connectionStatus: "ok",
+    want: true,
+  },
+  {
+    name: "queued save is blocked while a connection test is in flight",
+    dirty: true,
+    connectionStatus: "checking",
+    want: false,
+  },
+  {
+    name: "queued save is blocked when the connection test fails first",
+    dirty: true,
+    connectionStatus: "error",
+    want: false,
+  },
+  {
+    name: "clean draft with no test result is not saveable",
+    dirty: false,
+    connectionStatus: "unknown",
+    want: false,
+  },
+  {
+    name: "clean draft during a connection test is not saveable",
+    dirty: false,
+    connectionStatus: "checking",
+    want: false,
+  },
+  {
+    name: "clean draft after a successful test is not saveable",
+    dirty: false,
+    connectionStatus: "ok",
+    want: false,
+  },
+  {
+    name: "clean draft after a failed test is not saveable",
+    dirty: false,
+    connectionStatus: "error",
+    want: false,
+  },
+];
+
+for (const { name, dirty, connectionStatus, want } of canSaveCases) {
+  test(`canSave: ${name}`, () => {
+    assert.strictEqual(canSave(dirty, connectionStatus), want);
+  });
+}
+
+test("canSave: editing after a failed test restores unknown-state eligibility", () => {
+  assert.strictEqual(canSave(true, "checking"), false);
+  assert.strictEqual(canSave(true, "error"), false);
+  assert.strictEqual(canSave(true, "unknown"), true);
+});
+
+test("isCurrentConnectionResult: an edit invalidates an in-flight result", () => {
+  const testedSettings = { ...DEFAULT_SETTINGS, bucket: "before-edit" };
+  const currentSettings = { ...testedSettings, bucket: "after-edit" };
+
+  assert.strictEqual(isCurrentConnectionResult(1, 1, testedSettings, currentSettings), false);
+  assert.strictEqual(canSave(true, "unknown"), true);
+});
+
+test("isCurrentConnectionResult: only the latest unchanged draft accepts a result", () => {
+  const testedSettings = { ...DEFAULT_SETTINGS, bucket: "unchanged" };
+
+  assert.strictEqual(isCurrentConnectionResult(2, 2, testedSettings, testedSettings), true);
+  assert.strictEqual(isCurrentConnectionResult(1, 2, testedSettings, testedSettings), false);
+});
+
+for (const connectionStatus of ["checking", "error"] as const) {
+  test(`saveDraft: ${connectionStatus} result blocks a queued save`, async () => {
+    const savedSettings = { ...DEFAULT_SETTINGS, bucket: "saved" };
+    let logCalls = 0;
+    let saveCalls = 0;
+    const target = {
+      logger: {
+        info: () => {
+          logCalls += 1;
+        },
+      },
+      settings: savedSettings,
+      saveSettings: async () => {
+        saveCalls += 1;
+      },
+    };
+
+    await saveDraft(target, { ...savedSettings, bucket: "draft" }, connectionStatus);
+
+    assert.deepStrictEqual(target.settings, savedSettings);
+    assert.strictEqual(logCalls, 0);
+    assert.strictEqual(saveCalls, 0);
+  });
+}
+
+for (const connectionStatus of ["unknown", "ok"] as const) {
+  test(`saveDraft: ${connectionStatus} state persists a dirty draft`, async () => {
+    const savedSettings = { ...DEFAULT_SETTINGS, bucket: "saved" };
+    let saveCalls = 0;
+    const target = {
+      logger: { info: () => {} },
+      settings: savedSettings,
+      saveSettings: async () => {
+        saveCalls += 1;
+      },
+    };
+
+    await saveDraft(target, { ...savedSettings, bucket: "draft" }, connectionStatus);
+
+    assert.strictEqual(target.settings.bucket, "draft");
+    assert.strictEqual(saveCalls, 1);
+  });
+}
+
+test("saveDraft: clean unknown state does not persist", async () => {
+  const savedSettings = { ...DEFAULT_SETTINGS, bucket: "saved" };
+  let saveCalls = 0;
+  const target = {
+    logger: { info: () => {} },
+    settings: savedSettings,
+    saveSettings: async () => {
+      saveCalls += 1;
+    },
+  };
+
+  await saveDraft(target, { ...savedSettings }, "unknown");
+
+  assert.deepStrictEqual(target.settings, savedSettings);
+  assert.strictEqual(saveCalls, 0);
+});
 
 const normalizeCases: { name: string; input: unknown; want: GeodeSettings }[] = [
   {

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -10,6 +10,9 @@ export const DEFAULT_SETTINGS: GeodeSettings = {
   secretId: "",
 };
 
+// ConnectionStatus is the current in-memory state of a Test Connection check.
+export type ConnectionStatus = "unknown" | "checking" | "ok" | "error";
+
 // GeodeSettings is the persisted shape of a Geode plugin's user configuration.
 export type GeodeSettings = {
   version: number;
@@ -25,6 +28,24 @@ export type GeodeSettings = {
   // one they picked.
   secretId: string;
 };
+
+// SaveTarget is the narrow persistence surface needed to save a settings draft.
+export type SaveTarget = {
+  logger: {
+    info(message: string): void;
+  };
+  settings: GeodeSettings;
+  saveSettings(): Promise<void>;
+};
+
+// canSave reports whether the current draft may be persisted.
+export function canSave(dirty: boolean, connectionStatus: ConnectionStatus): boolean {
+  if (!dirty) {
+    return false;
+  }
+
+  return connectionStatus === "unknown" || connectionStatus === "ok";
+}
 
 // draftForDisplay returns the draft a settings tab should show for a given render.
 // When auto is true (Obsidian is opening the tab), the draft is re-seeded from saved
@@ -60,6 +81,20 @@ export function hasConnectionConfig(settings: GeodeSettings): boolean {
     return settings.accountId !== "";
   }
   return settings.endpoint !== "" && settings.region !== "";
+}
+
+// isCurrentConnectionResult reports whether a completed test still describes the current draft.
+export function isCurrentConnectionResult(
+  checkId: number,
+  currentCheckId: number,
+  testedSettings: GeodeSettings,
+  currentSettings: GeodeSettings,
+): boolean {
+  if (checkId !== currentCheckId) {
+    return false;
+  }
+
+  return settingsEqual(testedSettings, currentSettings);
 }
 
 // normalizeSettings returns a complete GeodeSettings from whatever loadData produced,
@@ -99,6 +134,21 @@ export function regionFor(settings: GeodeSettings): string {
   }
 
   return settings.region;
+}
+
+// saveDraft persists a copy of draft when the current connection state allows it.
+export async function saveDraft(
+  target: SaveTarget,
+  draft: GeodeSettings,
+  connectionStatus: ConnectionStatus,
+): Promise<void> {
+  if (!canSave(!settingsEqual(draft, target.settings), connectionStatus)) {
+    return;
+  }
+
+  target.logger.info(`saving settings (provider=${draft.provider})`);
+  target.settings = { ...draft };
+  await target.saveSettings();
 }
 
 // settingsEqual reports whether two settings values are identical field for field. Used to

--- a/src/settings/tab.ts
+++ b/src/settings/tab.ts
@@ -10,19 +10,19 @@ import {
 import type GeodePlugin from "../main";
 import { testConnection } from "../storage/storage";
 import {
+  type ConnectionStatus,
+  canSave,
   draftForDisplay,
   type GeodeSettings,
   hasConnectionConfig,
+  isCurrentConnectionResult,
   providerOr,
+  saveDraft,
   settingsEqual,
 } from "./settings";
 
 // DEBUG_LABEL_WIDTH is the column width debug info labels are padded to, so values line up.
 const DEBUG_LABEL_WIDTH = 12;
-
-// ConnectionStatus is the last known state of a Test Connection check. It lives only in memory;
-// it is never persisted and resets to "unknown" whenever the draft changes.
-type ConnectionStatus = "unknown" | "checking" | "ok" | "error";
 
 // renderSettingsTab draws every section into containerEl from the tab's current draft state.
 export function renderSettingsTab(tab: GeodeSettingTab, containerEl: HTMLElement): void {
@@ -417,7 +417,7 @@ export class GeodeSettingTab extends PluginSettingTab {
   // dirty reminder never inherits the connection status colour.
   refreshActionsUI(): void {
     if (this.saveButtonEl !== null) {
-      this.saveButtonEl.setDisabled(!this.dirty);
+      this.saveButtonEl.setDisabled(!canSave(this.dirty, this.connectionStatus));
     }
 
     if (this.statusDotEl !== null) {
@@ -451,35 +451,34 @@ export class GeodeSettingTab extends PluginSettingTab {
   }
 
   async save(): Promise<void> {
-    this.plugin.logger.info(`saving settings (provider=${this.draft.provider})`);
-    this.plugin.settings = { ...this.draft };
-    await this.plugin.saveSettings();
+    await saveDraft(this.plugin, this.draft, this.connectionStatus);
     this.refreshActionsUI();
   }
 
   async checkConnection(): Promise<void> {
     this.checkId += 1;
     const id = this.checkId;
+    const testedSettings = { ...this.draft };
 
     this.plugin.logger.info(
-      `testing connection (provider=${this.draft.provider}, bucket=${this.draft.bucket})`,
+      `testing connection (provider=${testedSettings.provider}, bucket=${testedSettings.bucket})`,
     );
     this.connectionStatus = "checking";
     this.connectionMessage = "";
     this.refreshActionsUI();
 
-    const rawSecret = this.app.secretStorage.getSecret(this.draft.secretId);
+    const rawSecret = this.app.secretStorage.getSecret(testedSettings.secretId);
     let secretAccessKey = "";
     if (rawSecret !== null) {
       secretAccessKey = rawSecret;
     }
     if (secretAccessKey === "") {
-      this.plugin.logger.warn(`no secret found for ID "${this.draft.secretId}"`);
+      this.plugin.logger.warn(`no secret found for ID "${testedSettings.secretId}"`);
     }
 
-    const result = await testConnection(this.draft, secretAccessKey);
+    const result = await testConnection(testedSettings, secretAccessKey);
 
-    if (id !== this.checkId) {
+    if (!isCurrentConnectionResult(id, this.checkId, testedSettings, this.draft)) {
       return;
     }
 


### PR DESCRIPTION
Resolves #157

## Problem

- A dirty draft could still be saved while a connection test was running or after it had failed
- Disabling only the button would not protect against a queued click reaching the persistence method
- An older in-flight result could overwrite the `unknown` state of a draft edited while that test was running

## Changes

- Define one save-eligibility rule: the draft must be dirty and its connection state must be `unknown` or `ok`
- Apply that rule to both the Save button and the persistence boundary
- Test a snapshot of the draft and discard results whose generation or settings no longer match
- Add table-driven and effect-level coverage for all four states, queued saves, and edit-during-flight races

## Validation

- `npm run lint`
- `npm run build`
- `npm test` (208 passed)
- `npm run test:integration` (25 passed)
- `npm run check-versions`
- `npm run audit` (0 vulnerabilities)
- Secretlint on all changed files
- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a unified save-eligibility rule and stale connection-result protection.
- Blocks settings persistence while a connection test is running or after it fails.
- Snapshots tested settings and discards results that no longer match the current generation or draft.
- Adds unit and effect-level coverage for save states, queued saves, and edit-during-test behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified in the changed behavior.

The Save button and persistence boundary now enforce the same eligibility rule, while connection tests use immutable settings snapshots and generation checks before updating state.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/settings/settings.ts | Introduces shared connection-state, save-eligibility, stale-result, and persistence helpers without an accepted defect. |
| src/settings/tab.ts | Applies the shared save rule at both UI and persistence boundaries and prevents obsolete connection results from updating current state. |
| src/settings/settings.test.ts | Adds table-driven and effect-level coverage for all connection states, queued saves, and stale test results. |

<sub>Reviews (1): Last reviewed commit: ["Settings → Block save after failed conne..."](https://github.com/8thpark/geode/commit/1196d00ff15fce6aa91711c8e402a54d2929a0cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48406001)</sub>

<!-- /greptile_comment -->