### PR TITLE
Logs → Live log view

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,4 +74,4 @@ GPL-3.0.
 To the [Greptile](https://greptile.com) team for creating an awesome product, and giving the project
 monthly credits as part of their OSS program.
 
-<img src="https://www.greptile.com/badge.svg" width="300px" alt="Greptile: The War on Bugs">
+<a href="https://www.greptile.com/?utm_source=oss_badge&utm_medium=readme&utm_campaign=greptile_for_open_source"><img src="https://www.greptile.com/badge.svg" width="300px" alt="Greptile: The War on Bugs"></a>

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 - [Security](#security)
 - [Contributing](#contributing)
 - [License](#license)
+- [Thanks](#thanks)
 
 ## What?
 
@@ -42,7 +43,7 @@ notes. As we believe the full power of Obsidian is unlocked via agents.
 > [!IMPORTANT]
 > _The project is currently in **beta**._
 
-We are working hard to get to our first `v0.1.0` release, see
+We are working hard to get to our first `0.1.0` release, see
 [progress](https://github.com/8thpark/geode/milestones).
 
 ## Security
@@ -67,3 +68,10 @@ label and [CONTRIBUTING.md](./CONTRIBUTING.md) for more details.
 **Geode** is available under the [GNU General Public License v3.0](./LICENSE). You are free to use,
 modify, and distribute it, provided any derivative work you distribute is also released under the
 GPL-3.0.
+
+## Thanks
+
+To the [Greptile](https://greptile.com) team for creating an awesome product, and giving the project
+monthly credits as part of their OSS program.
+
+<img src="https://www.greptile.com/badge.svg" width="300px" alt="Greptile: The War on Bugs">

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,15 +2,16 @@
 
 Planned upcoming releases for **Geode**:
 
-| Version  | Name    | Description                                                      |
-| -------- | ------- | ---------------------------------------------------------------- |
-| `v0.1.0` | Bedrock | Two desktop devices can sync a vault, using a provided S3 bucket |
-| `v0.2.0` |         | iOS & Android support                                            |
-| `v0.3.0` |         | Encyption                                                        |
-| `v0.4.0` |         | MCP                                                              |
-| `v0.5.0` |         | API                                                              |
-| `v0.6.0` |         | CLI                                                              |
-| `v0.7.0` |         | SDK                                                              |
-| `v0.8.0` |         | Browser access                                                   |
-| `v1.0.0` |         | Official v1 Release                                              |
-| `v1.1.0` |         | WebDAV support                                                   |
+| Version | Name    | Description                                                      |
+| ------- | ------- | ---------------------------------------------------------------- |
+| `0.1.0` | Bedrock | Two desktop devices can sync a vault, using a provided S3 bucket |
+| `0.2.0` |         | iOS & Android support                                            |
+| `0.3.0` |         | Encyption                                                        |
+| `0.4.0` |         | MCP                                                              |
+| `0.5.0` |         | API                                                              |
+| `0.6.0` |         | CLI                                                              |
+| `0.7.0` |         | SDK                                                              |
+| `0.8.0` |         | Browser access                                                   |
+| `0.9.0` |         | Webhooks                                                         |
+| `1.0.0` |         | Official v1 Release                                              |
+| `1.1.0` |         | WebDAV support                                                   |

--- a/src/log/log.test.ts
+++ b/src/log/log.test.ts
@@ -11,6 +11,12 @@ import {
   trimLogLines,
 } from "./log.ts";
 
+// settle lets the fire-and-forget append promises, and the onEntry notifications chained off
+// them, run to completion before an assertion inspects what a listener saw.
+function settle(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 test("formatLogLine and parseLogLine round trip", () => {
   const entry: LogEntry = {
     time: Date.parse("2026-07-14T10:00:00.000Z"),
@@ -225,18 +231,19 @@ test("createLogger: debug messages persist once minLevel is debug", async () => 
   assert.deepEqual(messages, ["verbose detail"]);
 });
 
-test("createLogger: onEntry receives each persisted entry", () => {
+test("createLogger: onEntry receives each persisted entry once the append settles", async () => {
   const sink = createMemorySink(10);
   const seen: string[] = [];
   const logger = createLogger(sink, "debug", (entry) => seen.push(entry.message));
 
   logger.info("first");
   logger.warn("second");
+  await settle();
 
   assert.deepEqual(seen, ["first", "second"]);
 });
 
-test("createLogger: onEntry is not called for entries below minLevel", () => {
+test("createLogger: onEntry is not called for entries below minLevel", async () => {
   const sink = createMemorySink(10);
   const seen: string[] = [];
   const logger = createLogger(sink, "warn", (entry) => seen.push(entry.message));
@@ -244,6 +251,7 @@ test("createLogger: onEntry is not called for entries below minLevel", () => {
   logger.debug("noisy");
   logger.info("still noisy");
   logger.warn("worth keeping");
+  await settle();
 
   assert.deepEqual(seen, ["worth keeping"]);
 });
@@ -255,6 +263,7 @@ test("createLogger: a throwing onEntry does not break logging or persistence", a
   });
 
   logger.info("still logged");
+  await settle();
 
   const messages: string[] = [];
   for (const entry of await sink.read()) {

--- a/src/log/log.test.ts
+++ b/src/log/log.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
+  createLogBus,
   createLogger,
   createMemorySink,
   formatLogLine,
@@ -222,4 +223,81 @@ test("createLogger: debug messages persist once minLevel is debug", async () => 
     messages.push(entry.message);
   }
   assert.deepEqual(messages, ["verbose detail"]);
+});
+
+test("createLogger: onEntry receives each persisted entry", () => {
+  const sink = createMemorySink(10);
+  const seen: string[] = [];
+  const logger = createLogger(sink, "debug", (entry) => seen.push(entry.message));
+
+  logger.info("first");
+  logger.warn("second");
+
+  assert.deepEqual(seen, ["first", "second"]);
+});
+
+test("createLogger: onEntry is not called for entries below minLevel", () => {
+  const sink = createMemorySink(10);
+  const seen: string[] = [];
+  const logger = createLogger(sink, "warn", (entry) => seen.push(entry.message));
+
+  logger.debug("noisy");
+  logger.info("still noisy");
+  logger.warn("worth keeping");
+
+  assert.deepEqual(seen, ["worth keeping"]);
+});
+
+test("createLogger: a throwing onEntry does not break logging or persistence", async () => {
+  const sink = createMemorySink(10);
+  const logger = createLogger(sink, "debug", () => {
+    throw new Error("listener boom");
+  });
+
+  logger.info("still logged");
+
+  const messages: string[] = [];
+  for (const entry of await sink.read()) {
+    messages.push(entry.message);
+  }
+  assert.deepEqual(messages, ["still logged"]);
+});
+
+test("createLogBus: emit delivers the entry to every subscriber", () => {
+  const bus = createLogBus();
+  const first: LogEntry[] = [];
+  const second: LogEntry[] = [];
+  bus.subscribe((entry) => first.push(entry));
+  bus.subscribe((entry) => second.push(entry));
+
+  const entry: LogEntry = { time: 1, level: "info", message: "hello" };
+  bus.emit(entry);
+
+  assert.deepEqual(first, [entry]);
+  assert.deepEqual(second, [entry]);
+});
+
+test("createLogBus: unsubscribing stops further delivery", () => {
+  const bus = createLogBus();
+  const seen: string[] = [];
+  const unsubscribe = bus.subscribe((entry) => seen.push(entry.message));
+
+  bus.emit({ time: 1, level: "info", message: "before" });
+  unsubscribe();
+  bus.emit({ time: 2, level: "info", message: "after" });
+
+  assert.deepEqual(seen, ["before"]);
+});
+
+test("createLogBus: one throwing listener does not stop the others", () => {
+  const bus = createLogBus();
+  const seen: string[] = [];
+  bus.subscribe(() => {
+    throw new Error("listener boom");
+  });
+  bus.subscribe((entry) => seen.push(entry.message));
+
+  bus.emit({ time: 1, level: "info", message: "delivered" });
+
+  assert.deepEqual(seen, ["delivered"]);
 });

--- a/src/log/log.ts
+++ b/src/log/log.ts
@@ -78,21 +78,17 @@ export function createLogger(sink: LogSink, minLevel: LogLevel, onEntry?: LogLis
     }
     consoleFor(level)(`geode: ${message}`);
     const entry: LogEntry = { time: Date.now(), level, message };
-    // Fire and forget: the Logger API is synchronous, so append can't be awaited. Report a
-    // failed persist to the console rather than leaving it as an unhandled rejection, and never
-    // back into sink, which would recurse if the sink itself is what's failing.
-    sink.append(entry).catch((err) => {
-      console.error(`geode: log sink append failed: ${err}`);
-    });
-    // Notify live listeners separately from persistence: logging must not break if a listener
-    // throws, and a listener shouldn't wait on the disk write to see the entry.
-    if (onEntry !== undefined) {
-      try {
-        onEntry(entry);
-      } catch (err) {
-        console.error(`geode: log listener failed: ${err}`);
-      }
-    }
+    // Fire and forget: the Logger API is synchronous, so append can't be awaited. Notify listeners
+    // only once the append has persisted, so a listener that re-reads the sink is guaranteed to
+    // see this entry rather than racing the write. A failed persist is reported to the console
+    // rather than left as an unhandled rejection, and never logged back into sink, which would
+    // recurse if the sink itself is what's failing.
+    sink
+      .append(entry)
+      .then(() => notify(onEntry, entry))
+      .catch((err) => {
+        console.error(`geode: log sink append failed: ${err}`);
+      });
   };
 
   return {
@@ -225,4 +221,17 @@ function linesOf(text: string): string[] {
     return parts.slice(0, -1);
   }
   return parts;
+}
+
+// notify hands entry to listener, isolating a throwing listener so it can neither reject the
+// append promise it runs inside nor stop the next log call.
+function notify(listener: LogListener | undefined, entry: LogEntry): void {
+  if (listener === undefined) {
+    return;
+  }
+  try {
+    listener(entry);
+  } catch (err) {
+    console.error(`geode: log listener failed: ${err}`);
+  }
 }

--- a/src/log/log.ts
+++ b/src/log/log.ts
@@ -5,6 +5,14 @@ const LEVEL_ORDER: Record<LogLevel, number> = {
   error: 3,
 };
 
+// LogBus fans each logged entry out to any number of listeners, so an open log view can update
+// live instead of polling the sink. In-memory only: it carries entries to whoever is listening
+// right now and keeps no history, the sink remains the source of truth for that.
+export type LogBus = {
+  emit: LogListener;
+  subscribe: (listener: LogListener) => () => void;
+};
+
 // LogEntry is one line of geode's log.
 export type LogEntry = {
   time: number;
@@ -23,6 +31,9 @@ export type Logger = {
 // LogLevel orders from least to most severe.
 export type LogLevel = "debug" | "info" | "warn" | "error";
 
+// LogListener receives each entry as it is logged, for a live view of the log.
+export type LogListener = (entry: LogEntry) => void;
+
 // LogSink persists log entries and reads them back. The real implementation writes to a capped
 // file inside the plugin's own data directory (see adapter.ts); tests, and the fallback used
 // when there's nowhere to persist to, use an in-memory sink (see createMemorySink below).
@@ -32,20 +43,56 @@ export type LogSink = {
   clear: () => Promise<void>;
 };
 
+// createLogBus returns an in-memory LogBus. Listener errors are isolated: one throwing listener
+// must not stop the others, nor break the logging call that triggered the emit.
+export function createLogBus(): LogBus {
+  const listeners = new Set<LogListener>();
+
+  return {
+    emit: (entry) => {
+      for (const listener of listeners) {
+        try {
+          listener(entry);
+        } catch (err) {
+          console.error(`geode: log listener failed: ${err}`);
+        }
+      }
+    },
+    subscribe: (listener) => {
+      listeners.add(listener);
+
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+  };
+}
+
 // createLogger returns a Logger that mirrors every message to the console and persists it via
-// sink, both gated by the same minLevel.
-export function createLogger(sink: LogSink, minLevel: LogLevel): Logger {
+// sink, both gated by the same minLevel. Each persisted entry is also handed to onEntry, if
+// given, so a live view can update without polling.
+export function createLogger(sink: LogSink, minLevel: LogLevel, onEntry?: LogListener): Logger {
   const log = (level: LogLevel, message: string) => {
     if (!levelEnabled(level, minLevel)) {
       return;
     }
     consoleFor(level)(`geode: ${message}`);
+    const entry: LogEntry = { time: Date.now(), level, message };
     // Fire and forget: the Logger API is synchronous, so append can't be awaited. Report a
     // failed persist to the console rather than leaving it as an unhandled rejection, and never
     // back into sink, which would recurse if the sink itself is what's failing.
-    sink.append({ time: Date.now(), level, message }).catch((err) => {
+    sink.append(entry).catch((err) => {
       console.error(`geode: log sink append failed: ${err}`);
     });
+    // Notify live listeners separately from persistence: logging must not break if a listener
+    // throws, and a listener shouldn't wait on the disk write to see the entry.
+    if (onEntry !== undefined) {
+      try {
+        onEntry(entry);
+      } catch (err) {
+        console.error(`geode: log listener failed: ${err}`);
+      }
+    }
   };
 
   return {

--- a/src/log/view.ts
+++ b/src/log/view.ts
@@ -4,35 +4,48 @@ import type { LogBus, LogEntry, LogSink } from "./log.ts";
 // LOG_VIEW_TYPE identifies geode's log pane to Obsidian's workspace leaf API.
 export const LOG_VIEW_TYPE = "geode-log-view";
 
+// renderLogView draws entries into containerEl, most recent first.
+function renderLogView(containerEl: HTMLElement, entries: LogEntry[]): void {
+  containerEl.empty();
+  containerEl.addClass("geode-log-view");
+
+  if (entries.length === 0) {
+    containerEl.createEl("p", { text: "No log entries yet.", cls: "setting-item-description" });
+    return;
+  }
+
+  const list = containerEl.createDiv({ cls: "geode-log-list" });
+  for (const entry of [...entries].reverse()) {
+    renderRow(list, entry);
+  }
+}
+
 // renderRow draws one entry into list, colour coded by level via a geode-log-row.is-<level> class.
-// A newest entry is prepended so the list stays most recent first without redrawing the rows
-// already shown; the initial backlog is appended in the order it is handed over.
-function renderRow(list: HTMLElement, entry: LogEntry, newest: boolean): void {
+function renderRow(list: HTMLElement, entry: LogEntry): void {
   const row = list.createDiv({ cls: `geode-log-row is-${entry.level}` });
   row.createSpan({ cls: "geode-log-time", text: new Date(entry.time).toLocaleString() });
   row.createSpan({ cls: "geode-log-level", text: entry.level.toUpperCase() });
   row.createSpan({ cls: "geode-log-message", text: entry.message });
-  if (newest) {
-    list.prepend(row);
-  }
 }
 
 // GeodeLogView renders geode's persisted log as a plain, most recent first list, updating live as
-// entries are logged. Read only: it has no way to write log entries, only display what the sink
-// already recorded and what the bus streams to it.
+// entries are logged. The pane is always a straight render of what the sink holds: every change
+// re-reads and redraws rather than mutating the DOM in place, so the pane can never drift from the
+// persisted log. Read only: it has no way to write log entries, only display what the sink
+// recorded.
 export class GeodeLogView extends ItemView {
   private sink: LogSink;
   private bus: LogBus;
-  private maxRows: number;
-  // Assigned in onOpen, which Obsidian always runs before any other view method.
-  private list!: HTMLElement;
-  private emptyEl: HTMLElement | null = null;
+  // The refresh coalescing pair, mirroring the plugin's vault state refresh: while a refresh is in
+  // flight, at most one more is queued, so a burst of entries collapses into a final render of the
+  // settled log instead of one render per entry.
+  private refreshInFlight: Promise<void> | null = null;
+  private refreshQueued = false;
 
-  constructor(leaf: WorkspaceLeaf, sink: LogSink, bus: LogBus, maxRows: number) {
+  constructor(leaf: WorkspaceLeaf, sink: LogSink, bus: LogBus) {
     super(leaf);
     this.sink = sink;
     this.bus = bus;
-    this.maxRows = maxRows;
   }
 
   getViewType(): string {
@@ -48,62 +61,48 @@ export class GeodeLogView extends ItemView {
   }
 
   async onOpen(): Promise<void> {
-    this.contentEl.addClass("geode-log-view");
     this.addAction("trash-2", "Clear", () => void this.clear());
-    this.list = this.contentEl.createDiv({ cls: "geode-log-list" });
-
-    this.setEntries(await this.sink.read());
-    // register runs the unsubscribe on pane close, so a closed view stops receiving entries.
-    this.register(this.bus.subscribe((entry) => this.addEntry(entry)));
+    // Subscribe before the first read, not after: an entry logged while that read is in flight
+    // then still triggers a refresh, rather than being missed until the pane is reopened. register
+    // runs the unsubscribe on pane close, so a closed view stops receiving entries.
+    this.register(this.bus.subscribe(() => void this.refresh()));
+    await this.refresh();
   }
 
-  // addEntry prepends a single newly logged entry, keeping the pane live without re-reading the
-  // sink or redrawing the rows already on screen.
-  private addEntry(entry: LogEntry): void {
-    renderRow(this.list, entry, true);
-    this.trim();
-    this.updateEmpty();
-  }
-
-  // clear empties the persisted log and the pane together.
+  // clear empties the persisted log, then re-renders from the sink like any other change, so the
+  // pane reflects whatever actually survived, including any entry that landed mid-clear.
   private async clear(): Promise<void> {
     await this.sink.clear();
-    this.setEntries([]);
+    await this.refresh();
   }
 
-  // setEntries redraws the whole list from scratch: the initial backlog, and the empty state after
-  // Clear. Live updates go through addEntry instead.
-  private setEntries(entries: LogEntry[]): void {
-    this.list.empty();
-    for (const entry of [...entries].reverse()) {
-      renderRow(this.list, entry, false);
+  // refresh re-reads the sink and redraws the pane. Concurrent calls coalesce so a burst of
+  // entries collapses into a single trailing render; the final render always runs after the last
+  // change settles, so the pane converges on the persisted log rather than a stale snapshot.
+  private async refresh(): Promise<void> {
+    if (this.refreshInFlight !== null) {
+      this.refreshQueued = true;
+      return this.refreshInFlight;
     }
-    this.trim();
-    this.updateEmpty();
+
+    let runQueued = false;
+    this.refreshInFlight = this.render();
+    try {
+      await this.refreshInFlight;
+      runQueued = this.refreshQueued;
+    } finally {
+      this.refreshInFlight = null;
+      this.refreshQueued = false;
+    }
+
+    if (runQueued) {
+      return this.refresh();
+    }
   }
 
-  // trim caps the rendered rows at maxRows, dropping the oldest, so a long lived pane can't grow
-  // the DOM past what the sink itself keeps on disk.
-  private trim(): void {
-    while (this.list.childElementCount > this.maxRows) {
-      this.list.lastElementChild?.remove();
-    }
-  }
-
-  // updateEmpty shows or hides the placeholder so it is present exactly when there are no rows.
-  private updateEmpty(): void {
-    const empty = this.list.childElementCount === 0;
-    if (empty && this.emptyEl === null) {
-      this.emptyEl = this.contentEl.createEl("p", {
-        text: "No log entries yet.",
-        cls: "setting-item-description",
-      });
-
-      return;
-    }
-    if (!empty && this.emptyEl !== null) {
-      this.emptyEl.remove();
-      this.emptyEl = null;
-    }
+  // render does the actual read and draw, split out so refresh can own the coalescing guard.
+  private async render(): Promise<void> {
+    const entries = await this.sink.read();
+    renderLogView(this.contentEl, entries);
   }
 }

--- a/src/log/view.ts
+++ b/src/log/view.ts
@@ -36,9 +36,8 @@ function renderRow(list: HTMLElement, entry: LogEntry): void {
 export class GeodeLogView extends ItemView {
   private sink: LogSink;
   private bus: LogBus;
-  // The refresh coalescing pair, mirroring the plugin's vault state refresh: while a refresh is in
-  // flight, at most one more is queued, so a burst of entries collapses into a final render of the
-  // settled log instead of one render per entry.
+  // The refresh coalescing pair: refreshInFlight guards the single running refresh, and
+  // refreshQueued records that another pass is owed because an entry arrived while one was running.
   private refreshInFlight: Promise<void> | null = null;
   private refreshQueued = false;
 
@@ -76,31 +75,37 @@ export class GeodeLogView extends ItemView {
     await this.refresh();
   }
 
-  // refresh re-reads the sink and redraws the pane. Concurrent calls coalesce so a burst of
-  // entries collapses into a single trailing render; the final render always runs after the last
-  // change settles, so the pane converges on the persisted log rather than a stale snapshot.
-  private async refresh(): Promise<void> {
+  // refresh re-reads the sink and redraws the pane. Concurrent calls coalesce onto the run already
+  // in flight: each marks that another pass is owed and awaits the same run, so a burst of entries
+  // collapses into a final render of the settled log rather than one render per entry.
+  private refresh(): Promise<void> {
     if (this.refreshInFlight !== null) {
       this.refreshQueued = true;
       return this.refreshInFlight;
     }
 
-    let runQueued = false;
-    this.refreshInFlight = this.render();
+    this.refreshInFlight = this.runRefresh();
+    return this.refreshInFlight;
+  }
+
+  // runRefresh reads and draws in a loop until no further pass was requested mid-render. The queued
+  // flag is reset before each read and checked immediately after, and the guard is released in the
+  // same synchronous tick as that final check, with no await in between. So an entry logged while a
+  // read is in flight always forces one more read: it either lands before this read's snapshot (and
+  // is drawn now) or sets the flag (and the loop runs again), never slipping through the gap as the
+  // run finishes.
+  private async runRefresh(): Promise<void> {
     try {
-      await this.refreshInFlight;
-      runQueued = this.refreshQueued;
+      do {
+        this.refreshQueued = false;
+        await this.render();
+      } while (this.refreshQueued);
     } finally {
       this.refreshInFlight = null;
-      this.refreshQueued = false;
-    }
-
-    if (runQueued) {
-      return this.refresh();
     }
   }
 
-  // render does the actual read and draw, split out so refresh can own the coalescing guard.
+  // render does the actual read and draw, split out so runRefresh can own the coalescing loop.
   private async render(): Promise<void> {
     const entries = await this.sink.read();
     renderLogView(this.contentEl, entries);

--- a/src/log/view.ts
+++ b/src/log/view.ts
@@ -1,45 +1,38 @@
 import { ItemView, type WorkspaceLeaf } from "obsidian";
-import type { LogEntry, LogSink } from "./log.ts";
+import type { LogBus, LogEntry, LogSink } from "./log.ts";
 
 // LOG_VIEW_TYPE identifies geode's log pane to Obsidian's workspace leaf API.
 export const LOG_VIEW_TYPE = "geode-log-view";
 
-// POLL_INTERVAL_MS is how often an open log view re-reads the sink, so entries logged while the
-// pane is sitting open still show up without a manual refresh.
-const POLL_INTERVAL_MS = 2000;
-
-// renderLogView draws entries into containerEl, most recent first.
-function renderLogView(containerEl: HTMLElement, entries: LogEntry[]): void {
-  containerEl.empty();
-  containerEl.addClass("geode-log-view");
-
-  if (entries.length === 0) {
-    containerEl.createEl("p", { text: "No log entries yet.", cls: "setting-item-description" });
-    return;
-  }
-
-  const list = containerEl.createDiv({ cls: "geode-log-list" });
-  for (const entry of [...entries].reverse()) {
-    renderRow(list, entry);
-  }
-}
-
 // renderRow draws one entry into list, colour coded by level via a geode-log-row.is-<level> class.
-function renderRow(list: HTMLElement, entry: LogEntry): void {
+// A newest entry is prepended so the list stays most recent first without redrawing the rows
+// already shown; the initial backlog is appended in the order it is handed over.
+function renderRow(list: HTMLElement, entry: LogEntry, newest: boolean): void {
   const row = list.createDiv({ cls: `geode-log-row is-${entry.level}` });
   row.createSpan({ cls: "geode-log-time", text: new Date(entry.time).toLocaleString() });
   row.createSpan({ cls: "geode-log-level", text: entry.level.toUpperCase() });
   row.createSpan({ cls: "geode-log-message", text: entry.message });
+  if (newest) {
+    list.prepend(row);
+  }
 }
 
-// GeodeLogView renders geode's persisted log as a plain, most recent first list. Read only: it
-// has no way to write log entries, only display what the sink already recorded.
+// GeodeLogView renders geode's persisted log as a plain, most recent first list, updating live as
+// entries are logged. Read only: it has no way to write log entries, only display what the sink
+// already recorded and what the bus streams to it.
 export class GeodeLogView extends ItemView {
   private sink: LogSink;
+  private bus: LogBus;
+  private maxRows: number;
+  // Assigned in onOpen, which Obsidian always runs before any other view method.
+  private list!: HTMLElement;
+  private emptyEl: HTMLElement | null = null;
 
-  constructor(leaf: WorkspaceLeaf, sink: LogSink) {
+  constructor(leaf: WorkspaceLeaf, sink: LogSink, bus: LogBus, maxRows: number) {
     super(leaf);
     this.sink = sink;
+    this.bus = bus;
+    this.maxRows = maxRows;
   }
 
   getViewType(): string {
@@ -55,20 +48,62 @@ export class GeodeLogView extends ItemView {
   }
 
   async onOpen(): Promise<void> {
-    this.addAction("refresh-cw", "Refresh", () => {
-      void this.refresh();
-    });
-    this.addAction("trash-2", "Clear", async () => {
-      await this.sink.clear();
-      await this.refresh();
-    });
-    await this.refresh();
-    this.registerInterval(window.setInterval(() => void this.refresh(), POLL_INTERVAL_MS));
+    this.contentEl.addClass("geode-log-view");
+    this.addAction("trash-2", "Clear", () => void this.clear());
+    this.list = this.contentEl.createDiv({ cls: "geode-log-list" });
+
+    this.setEntries(await this.sink.read());
+    // register runs the unsubscribe on pane close, so a closed view stops receiving entries.
+    this.register(this.bus.subscribe((entry) => this.addEntry(entry)));
   }
 
-  // refresh re-reads the sink and redraws the pane.
-  private async refresh(): Promise<void> {
-    const entries = await this.sink.read();
-    renderLogView(this.contentEl, entries);
+  // addEntry prepends a single newly logged entry, keeping the pane live without re-reading the
+  // sink or redrawing the rows already on screen.
+  private addEntry(entry: LogEntry): void {
+    renderRow(this.list, entry, true);
+    this.trim();
+    this.updateEmpty();
+  }
+
+  // clear empties the persisted log and the pane together.
+  private async clear(): Promise<void> {
+    await this.sink.clear();
+    this.setEntries([]);
+  }
+
+  // setEntries redraws the whole list from scratch: the initial backlog, and the empty state after
+  // Clear. Live updates go through addEntry instead.
+  private setEntries(entries: LogEntry[]): void {
+    this.list.empty();
+    for (const entry of [...entries].reverse()) {
+      renderRow(this.list, entry, false);
+    }
+    this.trim();
+    this.updateEmpty();
+  }
+
+  // trim caps the rendered rows at maxRows, dropping the oldest, so a long lived pane can't grow
+  // the DOM past what the sink itself keeps on disk.
+  private trim(): void {
+    while (this.list.childElementCount > this.maxRows) {
+      this.list.lastElementChild?.remove();
+    }
+  }
+
+  // updateEmpty shows or hides the placeholder so it is present exactly when there are no rows.
+  private updateEmpty(): void {
+    const empty = this.list.childElementCount === 0;
+    if (empty && this.emptyEl === null) {
+      this.emptyEl = this.contentEl.createEl("p", {
+        text: "No log entries yet.",
+        cls: "setting-item-description",
+      });
+
+      return;
+    }
+    if (!empty && this.emptyEl !== null) {
+      this.emptyEl.remove();
+      this.emptyEl = null;
+    }
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import type { App } from "obsidian";
 import { Plugin, setIcon, setTooltip } from "obsidian";
 import { createLogSink } from "./log/adapter";
-import { createLogger, type Logger, type LogSink } from "./log/log";
+import { createLogBus, createLogger, type LogBus, type Logger, type LogSink } from "./log/log";
 import { GeodeLogView, LOG_VIEW_TYPE } from "./log/view";
 import {
   DEFAULT_SETTINGS,
@@ -72,6 +72,7 @@ export default class GeodePlugin extends Plugin {
   settings: GeodeSettings = DEFAULT_SETTINGS;
   // Assigned in onload, which Obsidian always runs before any other plugin method.
   logger!: Logger;
+  private logBus!: LogBus;
   private logSink!: LogSink;
   private statusBarEl!: HTMLElement;
   private refreshTimer: number | undefined;
@@ -89,9 +90,13 @@ export default class GeodePlugin extends Plugin {
     await this.loadSettings();
 
     this.logSink = createLogSink(this.app.vault.adapter, this.manifest.dir, MAX_LOG_LINES);
-    this.logger = createLogger(this.logSink, LOG_MIN_LEVEL);
+    this.logBus = createLogBus();
+    this.logger = createLogger(this.logSink, LOG_MIN_LEVEL, this.logBus.emit);
 
-    this.registerView(LOG_VIEW_TYPE, (leaf) => new GeodeLogView(leaf, this.logSink));
+    this.registerView(
+      LOG_VIEW_TYPE,
+      (leaf) => new GeodeLogView(leaf, this.logSink, this.logBus, MAX_LOG_LINES),
+    );
     this.addCommand({
       id: "logs",
       name: "Logs",

--- a/src/main.ts
+++ b/src/main.ts
@@ -93,10 +93,7 @@ export default class GeodePlugin extends Plugin {
     this.logBus = createLogBus();
     this.logger = createLogger(this.logSink, LOG_MIN_LEVEL, this.logBus.emit);
 
-    this.registerView(
-      LOG_VIEW_TYPE,
-      (leaf) => new GeodeLogView(leaf, this.logSink, this.logBus, MAX_LOG_LINES),
-    );
+    this.registerView(LOG_VIEW_TYPE, (leaf) => new GeodeLogView(leaf, this.logSink, this.logBus));
     this.addCommand({
       id: "logs",
       name: "Logs",


### PR DESCRIPTION
Resolves [#69](https://github.com/8thpark/geode/issues/69)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces polling in the log pane with sink-ordered live updates.
- Adds an in-memory log bus and emits entries only after persistence succeeds.
- Subscribes the log view before its initial read and coalesces overlapping refresh requests.
- Re-reads the sink after clearing so the display reflects persisted state.
- Adds logger and log-bus unit coverage and updates project documentation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the subscription ordering fixes the opening race, sink-backed refresh fixes the clear race, and the synchronous transition from the final queue check to guard release closes the previously reported lost-update window.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/log/view.ts | Replaces interval polling with a pre-read subscription and a refresh loop that preserves updates arriving during asynchronous reads. |
| src/log/log.ts | Adds isolated pub-sub delivery and orders notifications after successful sink persistence. |
| src/log/log.test.ts | Covers persisted-entry notifications, level filtering, listener isolation, fan-out, and unsubscribe behavior. |
| src/main.ts | Creates one plugin-scoped log bus and wires it consistently into the logger and log view. |

<sub>Reviews (5): Last reviewed commit: ["Address comment"](https://github.com/8thpark/geode/commit/4941be8509ceba3973642bc5c3e0f4b37dcefb66) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48528042)</sub>

**Context used:**

- Knowledge Base — [Log module](https://app.greptile.com/8thpark/-/custom-context/knowledge-base/8thpark/geode/-/docs/log-module.md)

<!-- /greptile_comment -->