### PR TITLE
Storage → Bypass CORS with native requests

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import {
   normalizeSettings,
 } from "./settings/settings";
 import { GeodeSettingTab } from "./settings/tab";
+import { obsidianTransport } from "./storage/obsidian";
 import { createS3Client, probeConditionalWrites } from "./storage/storage";
 import { syncOnce } from "./sync/sync";
 import {
@@ -218,7 +219,7 @@ export default class GeodePlugin extends Plugin {
       return;
     }
 
-    const storage = createS3Client(this.settings, secretAccessKey);
+    const storage = createS3Client(this.settings, secretAccessKey, obsidianTransport);
 
     if (!this.conditionalWritesVerified) {
       const probe = await probeConditionalWrites(storage);

--- a/src/settings/tab.ts
+++ b/src/settings/tab.ts
@@ -8,6 +8,7 @@ import {
   Setting,
 } from "obsidian";
 import type GeodePlugin from "../main";
+import { obsidianTransport } from "../storage/obsidian";
 import { testConnection } from "../storage/storage";
 import {
   type ConnectionStatus,
@@ -476,7 +477,7 @@ export class GeodeSettingTab extends PluginSettingTab {
       this.plugin.logger.warn(`no secret found for ID "${testedSettings.secretId}"`);
     }
 
-    const result = await testConnection(testedSettings, secretAccessKey);
+    const result = await testConnection(testedSettings, secretAccessKey, obsidianTransport);
 
     if (!isCurrentConnectionResult(id, this.checkId, testedSettings, this.draft)) {
       return;

--- a/src/storage/errors.test.ts
+++ b/src/storage/errors.test.ts
@@ -1,7 +1,22 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { statusForHttp } from "./errors.ts";
+import { messageFor, statusForHttp } from "./errors.ts";
 import type { ResultStatus } from "./storage.ts";
+
+test("messageFor: quotes the raw detail from a caught error", () => {
+  const message = messageFor(new TypeError("Failed to fetch"));
+
+  assert.match(message, /Couldn't reach the storage endpoint/);
+  assert.match(message, /Failed to fetch/);
+  assert.match(message, /check your connection/);
+});
+
+test("messageFor: still guides when there is nothing to quote", () => {
+  const message = messageFor("not an error");
+
+  assert.match(message, /Couldn't reach the storage endpoint/);
+  assert.doesNotMatch(message, /\(/);
+});
 
 test("statusForHttp: classifies provider responses", () => {
   const cases: { code: number; want: ResultStatus }[] = [

--- a/src/storage/errors.ts
+++ b/src/storage/errors.ts
@@ -1,11 +1,32 @@
 import type { ResultStatus } from "./storage.ts";
 
-// messageFor converts a caught error into a plain message string.
+// messageFor turns an error thrown while dispatching a request into an actionable message. Such an
+// error means the request never reached the server, so the raw text ("Failed to fetch",
+// "net::ERR_NAME_NOT_RESOLVED") names a symptom, not a fix; the guidance points at the usual causes
+// while keeping the raw detail for the logs. The plugin dispatches through requestUrl, so a CORS
+// block is no longer among those causes (#156).
 export function messageFor(err: unknown): string {
+  const detail = detailFor(err);
+  if (detail === "") {
+    return (
+      "Couldn't reach the storage endpoint; check your connection and that the endpoint is " +
+      "correct"
+    );
+  }
+
+  return (
+    `Couldn't reach the storage endpoint (${detail}); check your connection and that the ` +
+    "endpoint is correct"
+  );
+}
+
+// detailFor extracts the raw message from a caught error, or "" when there is nothing to quote.
+function detailFor(err: unknown): string {
   if (err instanceof Error) {
     return err.message;
   }
-  return "Network error";
+
+  return "";
 }
 
 // statusForHttp maps HTTP 400 to the non-retryable client status and preserves known domain

--- a/src/storage/native.test.ts
+++ b/src/storage/native.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { nativeRequest, nativeResponse } from "./native.ts";
+
+test("nativeRequest: carries the url, method, and every signed header, and disables throw", async () => {
+  const request = new Request("https://acc.r2.cloudflarestorage.com/vault/notes/a.md", {
+    method: "PUT",
+    headers: {
+      authorization: "AWS4-HMAC-SHA256 Credential=abc",
+      "x-amz-date": "20260730T120000Z",
+      "x-amz-content-sha256": "deadbeef",
+    },
+    body: new Uint8Array([1]),
+  });
+
+  const param = await nativeRequest(request);
+
+  assert.equal(param.url, "https://acc.r2.cloudflarestorage.com/vault/notes/a.md");
+  assert.equal(param.method, "PUT");
+  assert.equal(param.throw, false);
+  assert.equal(param.headers?.authorization, "AWS4-HMAC-SHA256 Credential=abc");
+  assert.equal(param.headers?.["x-amz-date"], "20260730T120000Z");
+  assert.equal(param.headers?.["x-amz-content-sha256"], "deadbeef");
+});
+
+test("nativeRequest: a binary body survives as an ArrayBuffer of the same bytes", async () => {
+  const body = new Uint8Array([0, 1, 2, 254, 255]);
+  const request = new Request("https://s3.example.com/vault/blob", { method: "PUT", body });
+
+  const param = await nativeRequest(request);
+
+  assert.ok(param.body instanceof ArrayBuffer);
+  assert.deepEqual(new Uint8Array(param.body), body);
+});
+
+test("nativeRequest: a bodyless request sends no payload at all", async () => {
+  for (const method of ["GET", "HEAD", "DELETE"]) {
+    const request = new Request("https://s3.example.com/vault/key", { method });
+
+    const param = await nativeRequest(request);
+
+    assert.equal(param.body, undefined, method);
+  }
+});
+
+test("nativeResponse: classifies the status, treating any 2xx as ok", () => {
+  const cases: { status: number; ok: boolean }[] = [
+    { status: 200, ok: true },
+    { status: 204, ok: true },
+    { status: 400, ok: false },
+    { status: 403, ok: false },
+    { status: 500, ok: false },
+  ];
+
+  for (const { status, ok } of cases) {
+    const response = nativeResponse({ status, arrayBuffer: new ArrayBuffer(0), headers: {} });
+    assert.equal(response.ok, ok, `HTTP ${status}`);
+    assert.equal(response.status, status);
+  }
+});
+
+test("nativeResponse: reads the buffered body into bytes", () => {
+  const bytes = new Uint8Array([9, 8, 7]);
+
+  const response = nativeResponse({ status: 200, arrayBuffer: bytes.buffer, headers: {} });
+
+  assert.deepEqual(response.body, bytes);
+});
+
+test("nativeResponse: looks a header up case insensitively", () => {
+  const response = nativeResponse({
+    status: 200,
+    arrayBuffer: new ArrayBuffer(0),
+    headers: { etag: '"v1"' },
+  });
+
+  assert.equal(response.header("ETag"), '"v1"');
+  assert.equal(response.header("etag"), '"v1"');
+  assert.equal(response.header("missing"), null);
+});

--- a/src/storage/native.test.ts
+++ b/src/storage/native.test.ts
@@ -1,6 +1,39 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { nativeRequest, nativeResponse } from "./native.ts";
+import type { RequestUrlParam } from "obsidian";
+import { nativeRequest, nativeResponse, nativeTransport } from "./native.ts";
+
+test("nativeTransport: converts the request, dispatches it, and converts the response back", async () => {
+  const body = new Uint8Array([1, 2, 3]);
+  let seen: RequestUrlParam | undefined;
+  const dispatch = async (param: RequestUrlParam) => {
+    seen = param;
+    return {
+      status: 200,
+      arrayBuffer: body.buffer,
+      headers: { etag: '"v1"' },
+      json: null,
+      text: "",
+    };
+  };
+
+  const transport = nativeTransport(dispatch);
+  const response = await transport(
+    new Request("https://s3.example.com/vault/k", {
+      method: "PUT",
+      headers: { authorization: "sig" },
+      body,
+    }),
+  );
+
+  assert.equal(seen?.method, "PUT");
+  assert.equal(seen?.throw, false);
+  assert.equal(seen?.headers?.authorization, "sig");
+  assert.deepEqual(new Uint8Array(seen?.body as ArrayBuffer), body);
+  assert.equal(response.ok, true);
+  assert.deepEqual(response.body, body);
+  assert.equal(response.header("ETag"), '"v1"');
+});
 
 test("nativeRequest: carries the url, method, and every signed header, and disables throw", async () => {
   const request = new Request("https://acc.r2.cloudflarestorage.com/vault/notes/a.md", {

--- a/src/storage/native.ts
+++ b/src/storage/native.ts
@@ -1,5 +1,10 @@
 import type { RequestUrlParam, RequestUrlResponse } from "obsidian";
-import type { HttpResponse } from "./storage.ts";
+import type { HttpResponse, Transport } from "./storage.ts";
+
+// Dispatch sends a native request parameter and resolves its response. Obsidian's requestUrl
+// satisfies this shape; a test supplies a fake so the whole conversion, dispatch, and response
+// mapping can be exercised without a running Obsidian.
+export type Dispatch = (param: RequestUrlParam) => Promise<RequestUrlResponse>;
 
 // nativeRequest converts a signed request into the parameters for Obsidian's requestUrl, carrying
 // the SigV4 Authorization and x-amz-* headers through unchanged so the signature stays valid. throw
@@ -26,6 +31,14 @@ export function nativeResponse(
     body: new Uint8Array(response.arrayBuffer),
     header: (name) => headerOf(response.headers, name),
   };
+}
+
+// nativeTransport builds a Transport from a dispatcher: it converts the signed request, hands the
+// parameter to dispatch, and converts the response back. All of the transport's logic lives here so
+// a fake dispatch can exercise it without a running Obsidian; the plugin binds dispatch to
+// Obsidian's requestUrl.
+export function nativeTransport(dispatch: Dispatch): Transport {
+  return async (request) => nativeResponse(await dispatch(await nativeRequest(request)));
 }
 
 // bodyOf reads a signed request's body as an ArrayBuffer for requestUrl, returning undefined for

--- a/src/storage/native.ts
+++ b/src/storage/native.ts
@@ -1,0 +1,63 @@
+import type { RequestUrlParam, RequestUrlResponse } from "obsidian";
+import type { HttpResponse } from "./storage.ts";
+
+// nativeRequest converts a signed request into the parameters for Obsidian's requestUrl, carrying
+// the SigV4 Authorization and x-amz-* headers through unchanged so the signature stays valid. throw
+// is false so a rejected status comes back as a response for the storage layer to classify, rather
+// than throwing and being misread as the request never reaching the server.
+export async function nativeRequest(request: Request): Promise<RequestUrlParam> {
+  return {
+    url: request.url,
+    method: request.method,
+    headers: headersOf(request),
+    body: await bodyOf(request),
+    throw: false,
+  };
+}
+
+// nativeResponse converts a requestUrl response into the HttpResponse the storage layer consumes,
+// classifying any 2xx as ok and reading the already buffered body into bytes.
+export function nativeResponse(
+  response: Pick<RequestUrlResponse, "status" | "arrayBuffer" | "headers">,
+): HttpResponse {
+  return {
+    ok: response.status >= 200 && response.status < 300,
+    status: response.status,
+    body: new Uint8Array(response.arrayBuffer),
+    header: (name) => headerOf(response.headers, name),
+  };
+}
+
+// bodyOf reads a signed request's body as an ArrayBuffer for requestUrl, returning undefined for
+// the bodyless verbs (GET, HEAD, DELETE, and a copy PUT) so requestUrl sends no payload at all.
+async function bodyOf(request: Request): Promise<ArrayBuffer | undefined> {
+  const buffer = await request.arrayBuffer();
+  if (buffer.byteLength === 0) {
+    return undefined;
+  }
+
+  return buffer;
+}
+
+// headerOf looks a response header up case insensitively, since requestUrl lowercases the names it
+// returns while callers ask for them however they were sent (an "etag" for a server's "ETag").
+function headerOf(headers: Record<string, string>, name: string): string | null {
+  const lower = name.toLowerCase();
+  for (const key of Object.keys(headers)) {
+    if (key.toLowerCase() === lower) {
+      return headers[key];
+    }
+  }
+
+  return null;
+}
+
+// headersOf flattens a signed request's headers into the plain record requestUrl expects.
+function headersOf(request: Request): Record<string, string> {
+  const headers: Record<string, string> = {};
+  request.headers.forEach((value, key) => {
+    headers[key] = value;
+  });
+
+  return headers;
+}

--- a/src/storage/obsidian.ts
+++ b/src/storage/obsidian.ts
@@ -1,60 +1,15 @@
 import { requestUrl } from "obsidian";
+import { nativeRequest, nativeResponse } from "./native.ts";
 import type { HttpResponse } from "./storage.ts";
 
 // obsidianTransport dispatches a signed request through Obsidian's requestUrl, which issues a
 // native HTTP request outside the browser fetch stack and so is never blocked by CORS. This is the
 // transport the plugin uses at runtime; routing through the global fetch instead would make an R2
 // or S3 bucket reject the app's origin unless the user hand configured a CORS policy on it (#156).
-// throw is false so a rejected status comes back as a response for the storage layer to classify,
-// rather than throwing and being misread as the request never reaching the server.
+// The Request/response conversion lives in the pure native module so it can be tested without a
+// running Obsidian; this file is the thin glue that calls requestUrl.
 export async function obsidianTransport(request: Request): Promise<HttpResponse> {
-  const response = await requestUrl({
-    url: request.url,
-    method: request.method,
-    headers: headersOf(request),
-    body: await bodyOf(request),
-    throw: false,
-  });
+  const response = await requestUrl(await nativeRequest(request));
 
-  return {
-    ok: response.status >= 200 && response.status < 300,
-    status: response.status,
-    body: new Uint8Array(response.arrayBuffer),
-    header: (name) => headerOf(response.headers, name),
-  };
-}
-
-// bodyOf reads a signed request's body as an ArrayBuffer for requestUrl, returning undefined for
-// the bodyless verbs (GET, HEAD, DELETE, and a copy PUT) so requestUrl sends no payload at all.
-async function bodyOf(request: Request): Promise<ArrayBuffer | undefined> {
-  const buffer = await request.arrayBuffer();
-  if (buffer.byteLength === 0) {
-    return undefined;
-  }
-
-  return buffer;
-}
-
-// headerOf looks a response header up case insensitively, since requestUrl lowercases the names it
-// returns while callers ask for them however they were sent (an "etag" for a server's "ETag").
-function headerOf(headers: Record<string, string>, name: string): string | null {
-  const lower = name.toLowerCase();
-  for (const key of Object.keys(headers)) {
-    if (key.toLowerCase() === lower) {
-      return headers[key];
-    }
-  }
-
-  return null;
-}
-
-// headersOf flattens a signed request's headers into the plain record requestUrl expects, carrying
-// the SigV4 Authorization and x-amz-* headers through unchanged so the signature stays valid.
-function headersOf(request: Request): Record<string, string> {
-  const headers: Record<string, string> = {};
-  request.headers.forEach((value, key) => {
-    headers[key] = value;
-  });
-
-  return headers;
+  return nativeResponse(response);
 }

--- a/src/storage/obsidian.ts
+++ b/src/storage/obsidian.ts
@@ -1,15 +1,10 @@
 import { requestUrl } from "obsidian";
-import { nativeRequest, nativeResponse } from "./native.ts";
-import type { HttpResponse } from "./storage.ts";
+import { nativeTransport } from "./native.ts";
 
 // obsidianTransport dispatches a signed request through Obsidian's requestUrl, which issues a
 // native HTTP request outside the browser fetch stack and so is never blocked by CORS. This is the
 // transport the plugin uses at runtime; routing through the global fetch instead would make an R2
 // or S3 bucket reject the app's origin unless the user hand configured a CORS policy on it (#156).
-// The Request/response conversion lives in the pure native module so it can be tested without a
-// running Obsidian; this file is the thin glue that calls requestUrl.
-export async function obsidianTransport(request: Request): Promise<HttpResponse> {
-  const response = await requestUrl(await nativeRequest(request));
-
-  return nativeResponse(response);
-}
+// All of the conversion and dispatch logic lives in the pure native module and is tested there;
+// this file is only the binding of that transport to the real requestUrl.
+export const obsidianTransport = nativeTransport(requestUrl);

--- a/src/storage/obsidian.ts
+++ b/src/storage/obsidian.ts
@@ -1,0 +1,60 @@
+import { requestUrl } from "obsidian";
+import type { HttpResponse } from "./storage.ts";
+
+// obsidianTransport dispatches a signed request through Obsidian's requestUrl, which issues a
+// native HTTP request outside the browser fetch stack and so is never blocked by CORS. This is the
+// transport the plugin uses at runtime; routing through the global fetch instead would make an R2
+// or S3 bucket reject the app's origin unless the user hand configured a CORS policy on it (#156).
+// throw is false so a rejected status comes back as a response for the storage layer to classify,
+// rather than throwing and being misread as the request never reaching the server.
+export async function obsidianTransport(request: Request): Promise<HttpResponse> {
+  const response = await requestUrl({
+    url: request.url,
+    method: request.method,
+    headers: headersOf(request),
+    body: await bodyOf(request),
+    throw: false,
+  });
+
+  return {
+    ok: response.status >= 200 && response.status < 300,
+    status: response.status,
+    body: new Uint8Array(response.arrayBuffer),
+    header: (name) => headerOf(response.headers, name),
+  };
+}
+
+// bodyOf reads a signed request's body as an ArrayBuffer for requestUrl, returning undefined for
+// the bodyless verbs (GET, HEAD, DELETE, and a copy PUT) so requestUrl sends no payload at all.
+async function bodyOf(request: Request): Promise<ArrayBuffer | undefined> {
+  const buffer = await request.arrayBuffer();
+  if (buffer.byteLength === 0) {
+    return undefined;
+  }
+
+  return buffer;
+}
+
+// headerOf looks a response header up case insensitively, since requestUrl lowercases the names it
+// returns while callers ask for them however they were sent (an "etag" for a server's "ETag").
+function headerOf(headers: Record<string, string>, name: string): string | null {
+  const lower = name.toLowerCase();
+  for (const key of Object.keys(headers)) {
+    if (key.toLowerCase() === lower) {
+      return headers[key];
+    }
+  }
+
+  return null;
+}
+
+// headersOf flattens a signed request's headers into the plain record requestUrl expects, carrying
+// the SigV4 Authorization and x-amz-* headers through unchanged so the signature stays valid.
+function headersOf(request: Request): Record<string, string> {
+  const headers: Record<string, string> = {};
+  request.headers.forEach((value, key) => {
+    headers[key] = value;
+  });
+
+  return headers;
+}

--- a/src/storage/storage.itest.ts
+++ b/src/storage/storage.itest.ts
@@ -5,7 +5,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import { DEFAULT_SETTINGS, type GeodeSettings } from "../settings/settings.ts";
-import { createS3Client, testConnection } from "./storage.ts";
+import { createS3Client, fetchTransport, testConnection } from "./storage.ts";
 
 const SECRET_ACCESS_KEY = "geodedev";
 
@@ -19,13 +19,13 @@ const liveSettings: GeodeSettings = {
 };
 
 test("testConnection: succeeds against a real bucket", async () => {
-  const result = await testConnection(liveSettings, SECRET_ACCESS_KEY);
+  const result = await testConnection(liveSettings, SECRET_ACCESS_KEY, fetchTransport);
   assert.equal(result.ok, true);
   assert.equal(result.status, "ok");
 });
 
 test("putObject then getObject round trips the same bytes", async () => {
-  const client = createS3Client(liveSettings, SECRET_ACCESS_KEY);
+  const client = createS3Client(liveSettings, SECRET_ACCESS_KEY, fetchTransport);
   const body = new TextEncoder().encode("hello geode");
 
   const putResult = await client.putObject("notes/hello.md", body);
@@ -39,7 +39,7 @@ test("putObject then getObject round trips the same bytes", async () => {
 });
 
 test("getObject returns the object's etag for a later conditional put", async () => {
-  const client = createS3Client(liveSettings, SECRET_ACCESS_KEY);
+  const client = createS3Client(liveSettings, SECRET_ACCESS_KEY, fetchTransport);
   await client.putObject("etag-test/note.md", new TextEncoder().encode("v1"));
 
   const getResult = await client.getObject("etag-test/note.md");
@@ -48,7 +48,7 @@ test("getObject returns the object's etag for a later conditional put", async ()
 });
 
 test("putObject ifAbsent creates a missing key but is rejected once the key exists", async () => {
-  const client = createS3Client(liveSettings, SECRET_ACCESS_KEY);
+  const client = createS3Client(liveSettings, SECRET_ACCESS_KEY, fetchTransport);
   const key = `conditional-test/absent-${Date.now()}.md`;
 
   const first = await client.putObject(key, new TextEncoder().encode("v1"), { kind: "ifAbsent" });
@@ -62,7 +62,7 @@ test("putObject ifAbsent creates a missing key but is rejected once the key exis
 });
 
 test("putObject ifMatch succeeds with the current etag and is rejected once it goes stale", async () => {
-  const client = createS3Client(liveSettings, SECRET_ACCESS_KEY);
+  const client = createS3Client(liveSettings, SECRET_ACCESS_KEY, fetchTransport);
   const key = "conditional-test/match.md";
   try {
     await client.putObject(key, new TextEncoder().encode("v1"));
@@ -93,7 +93,7 @@ test("putObject ifMatch succeeds with the current etag and is rejected once it g
 });
 
 test("getObject on a missing key fails without a body", async () => {
-  const client = createS3Client(liveSettings, SECRET_ACCESS_KEY);
+  const client = createS3Client(liveSettings, SECRET_ACCESS_KEY, fetchTransport);
   const result = await client.getObject("does/not/exist.md");
   assert.equal(result.ok, false);
   assert.equal(result.status, "not_found");
@@ -101,7 +101,7 @@ test("getObject on a missing key fails without a body", async () => {
 });
 
 test("deleteObject removes an object", async () => {
-  const client = createS3Client(liveSettings, SECRET_ACCESS_KEY);
+  const client = createS3Client(liveSettings, SECRET_ACCESS_KEY, fetchTransport);
   await client.putObject("notes/to-delete.md", new TextEncoder().encode("bye"));
 
   const deleteResult = await client.deleteObject("notes/to-delete.md");
@@ -114,7 +114,7 @@ test("deleteObject removes an object", async () => {
 });
 
 test("copyObject duplicates the bytes under a new key, leaving the source intact", async () => {
-  const client = createS3Client(liveSettings, SECRET_ACCESS_KEY);
+  const client = createS3Client(liveSettings, SECRET_ACCESS_KEY, fetchTransport);
   const body = new TextEncoder().encode("copy me");
   await client.putObject("copy-test/source.md", body);
 
@@ -133,7 +133,7 @@ test("copyObject duplicates the bytes under a new key, leaving the source intact
 });
 
 test("copyObject round-trips a source key with SigV4-sensitive characters", async () => {
-  const client = createS3Client(liveSettings, SECRET_ACCESS_KEY);
+  const client = createS3Client(liveSettings, SECRET_ACCESS_KEY, fetchTransport);
   const key = "copy-test/Don't stop! (really).md";
   const body = new TextEncoder().encode("tricky source");
   await client.putObject(key, body);
@@ -150,7 +150,7 @@ test("copyObject round-trips a source key with SigV4-sensitive characters", asyn
 });
 
 test("copyObject of a missing source fails with not_found, never a phantom empty object", async () => {
-  const client = createS3Client(liveSettings, SECRET_ACCESS_KEY);
+  const client = createS3Client(liveSettings, SECRET_ACCESS_KEY, fetchTransport);
 
   const copyResult = await client.copyObject("copy-test/does-not-exist.md", "copy-test/nope.md");
   assert.equal(copyResult.ok, false);
@@ -161,7 +161,7 @@ test("copyObject of a missing source fails with not_found, never a phantom empty
 });
 
 test("listObjects returns only keys under the given prefix", async () => {
-  const client = createS3Client(liveSettings, SECRET_ACCESS_KEY);
+  const client = createS3Client(liveSettings, SECRET_ACCESS_KEY, fetchTransport);
   await client.putObject("list-test/a.md", new TextEncoder().encode("a"));
   await client.putObject("list-test/b.md", new TextEncoder().encode("b"));
   await client.putObject("list-test-other/c.md", new TextEncoder().encode("c"));
@@ -178,7 +178,7 @@ test("listObjects returns only keys under the given prefix", async () => {
 });
 
 test("listObjects with no prefix returns everything", async () => {
-  const client = createS3Client(liveSettings, SECRET_ACCESS_KEY);
+  const client = createS3Client(liveSettings, SECRET_ACCESS_KEY, fetchTransport);
   await client.putObject("unprefixed.md", new TextEncoder().encode("x"));
 
   const result = await client.listObjects();
@@ -195,7 +195,7 @@ test("listObjects with no prefix returns everything", async () => {
 });
 
 test("listObjects pages past the 1,000 key response cap", async () => {
-  const client = createS3Client(liveSettings, SECRET_ACCESS_KEY);
+  const client = createS3Client(liveSettings, SECRET_ACCESS_KEY, fetchTransport);
   const prefix = "paging-test/";
   const total = 1001;
 
@@ -228,7 +228,7 @@ test("listObjects pages past the 1,000 key response cap", async () => {
 });
 
 test("putObject/getObject round-trips a key containing a space and ampersand", async () => {
-  const client = createS3Client(liveSettings, SECRET_ACCESS_KEY);
+  const client = createS3Client(liveSettings, SECRET_ACCESS_KEY, fetchTransport);
   const body = new TextEncoder().encode("special chars");
 
   const putResult = await client.putObject("encode-test/Foo & Bar.md", body);
@@ -240,7 +240,7 @@ test("putObject/getObject round-trips a key containing a space and ampersand", a
 });
 
 test("putObject/getObject round-trips a key with SigV4-sensitive characters ! ' ( ) *", async () => {
-  const client = createS3Client(liveSettings, SECRET_ACCESS_KEY);
+  const client = createS3Client(liveSettings, SECRET_ACCESS_KEY, fetchTransport);
   const body = new TextEncoder().encode("sigv4 edge");
   const key = "encode-test/Don't forget! (draft) *.md";
 
@@ -266,7 +266,7 @@ test("putObject/getObject round-trips a key with SigV4-sensitive characters ! ' 
 });
 
 test("putObject/getObject round-trips a key containing a hash and percent", async () => {
-  const client = createS3Client(liveSettings, SECRET_ACCESS_KEY);
+  const client = createS3Client(liveSettings, SECRET_ACCESS_KEY, fetchTransport);
   const body = new TextEncoder().encode("edge cases");
 
   const putResult = await client.putObject("encode-test/100% #special.md", body);

--- a/src/storage/storage.test.ts
+++ b/src/storage/storage.test.ts
@@ -1,8 +1,20 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import { DEFAULT_SETTINGS, type GeodeSettings } from "../settings/settings.ts";
-import { probeConditionalWrites, type StorageClient, testConnection } from "./storage.ts";
+import {
+  probeConditionalWrites,
+  type StorageClient,
+  type Transport,
+  testConnection,
+} from "./storage.ts";
 import { parseListObjectsXml } from "./xml.ts";
+
+// stubTransport stands in for a real dispatcher in tests that only need testConnection to reach the
+// network step; it always fails as if the endpoint were unreachable, so no unit test touches the
+// network.
+const stubTransport: Transport = async () => {
+  throw new Error("unreachable in tests");
+};
 
 // honouringPut is a putObject that enforces ifAbsent the way a correct S3 server does: the first
 // write to a key lands, a later ifAbsent write to the same key is rejected as a conflict.
@@ -98,7 +110,7 @@ const missingFieldCases: {
 
 for (const { name, settings, secretAccessKey, want } of missingFieldCases) {
   test(`testConnection: ${name}`, async () => {
-    const result = await testConnection(settings, secretAccessKey);
+    const result = await testConnection(settings, secretAccessKey, stubTransport);
     assert.equal(result.ok, false);
     assert.equal(result.status, "auth");
     assert.equal(result.message, want);
@@ -113,7 +125,7 @@ test("testConnection: R2 with empty endpoint and region passes field check", asy
     accountId: "acc123",
   };
 
-  const result = await testConnection(settings, "shh");
+  const result = await testConnection(settings, "shh", stubTransport);
 
   assert.equal(result.ok, false);
   assert.ok(!result.message.startsWith("Fill in"));

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -44,6 +44,17 @@ export type GetResult = {
   etag: string | null;
 };
 
+// HttpResponse is the normalized reply a Transport returns: the HTTP status and the fully read
+// body, so the storage operations never touch a streaming Response and the fetch and requestUrl
+// transports are interchangeable behind one shape. Header looks a single response header up by
+// name, case insensitively, since the two transports disagree on header name casing.
+export type HttpResponse = {
+  ok: boolean;
+  status: number;
+  body: Uint8Array;
+  header: (name: string) => string | null;
+};
+
 // ListResult reports whether a bucket listing succeeded. Objects is empty when ok is false.
 export type ListResult = {
   ok: boolean;
@@ -95,8 +106,19 @@ export type StorageClient = {
   listObjects: (prefix?: string) => Promise<ListResult>;
 };
 
-// createS3Client returns a StorageClient backed by the S3 compatible endpoint in settings.
-export function createS3Client(settings: GeodeSettings, secretAccessKey: string): StorageClient {
+// Transport sends an already signed request and returns its response, rejecting only when the
+// request never completes (offline, a failed DNS lookup, a refused connection). The plugin injects
+// a transport backed by Obsidian's requestUrl, which issues a native request and so is never
+// subject to CORS; tests and any non Obsidian caller inject fetchTransport.
+export type Transport = (request: Request) => Promise<HttpResponse>;
+
+// createS3Client returns a StorageClient backed by the S3 compatible endpoint in settings, sending
+// every request through the given transport.
+export function createS3Client(
+  settings: GeodeSettings,
+  secretAccessKey: string,
+  transport: Transport,
+): StorageClient {
   const client = new AwsClient({
     accessKeyId: settings.accessKeyId,
     secretAccessKey,
@@ -106,12 +128,28 @@ export function createS3Client(settings: GeodeSettings, secretAccessKey: string)
   const baseUrl = `${endpointFor(settings)}/${settings.bucket}`;
 
   return {
-    putObject: (key, body, condition) => s3PutObject(client, baseUrl, key, body, condition),
-    getObject: (key) => s3GetObject(client, baseUrl, key),
+    putObject: (key, body, condition) =>
+      s3PutObject(client, transport, baseUrl, key, body, condition),
+    getObject: (key) => s3GetObject(client, transport, baseUrl, key),
     copyObject: (sourceKey, destKey) =>
-      s3CopyObject(client, baseUrl, settings.bucket, sourceKey, destKey),
-    deleteObject: (key) => s3DeleteObject(client, baseUrl, key),
-    listObjects: (prefix) => s3ListObjects(client, baseUrl, prefix),
+      s3CopyObject(client, transport, baseUrl, settings.bucket, sourceKey, destKey),
+    deleteObject: (key) => s3DeleteObject(client, transport, baseUrl, key),
+    listObjects: (prefix) => s3ListObjects(client, transport, baseUrl, prefix),
+  };
+}
+
+// fetchTransport dispatches a signed request through the global fetch. It is the transport for
+// tests and any environment without Obsidian; the plugin uses a requestUrl backed transport so its
+// requests are not subject to CORS.
+export async function fetchTransport(request: Request): Promise<HttpResponse> {
+  const response = await fetch(request);
+  const buffer = await response.arrayBuffer();
+
+  return {
+    ok: response.ok,
+    status: response.status,
+    body: new Uint8Array(buffer),
+    header: (name) => response.headers.get(name),
   };
 }
 
@@ -174,6 +212,7 @@ export async function probeConditionalWrites(client: StorageClient): Promise<Con
 export async function testConnection(
   settings: GeodeSettings,
   secretAccessKey: string,
+  transport: Transport,
 ): Promise<ConnectionResult> {
   const missing = missingFieldFor(settings, secretAccessKey);
   if (missing !== "") {
@@ -188,9 +227,9 @@ export async function testConnection(
   });
   const url = `${endpointFor(settings)}/${settings.bucket}`;
 
-  let response: Response;
+  let response: HttpResponse;
   try {
-    response = await client.fetch(url, { method: "HEAD" });
+    response = await send(client, transport, url, { method: "HEAD" });
   } catch (err) {
     return { ok: false, status: "network", message: messageFor(err) };
   }
@@ -203,7 +242,7 @@ export async function testConnection(
     };
   }
 
-  return probeConditionalWrites(createS3Client(settings, secretAccessKey));
+  return probeConditionalWrites(createS3Client(settings, secretAccessKey, transport));
 }
 
 // conditionHeaders converts a PutCondition into the HTTP precondition headers an S3 compatible
@@ -259,15 +298,16 @@ function missingFieldFor(settings: GeodeSettings, secretAccessKey: string): stri
 // actually backed up, so the body is inspected and a failure surfaced rather than swallowed.
 async function s3CopyObject(
   client: AwsClient,
+  transport: Transport,
   baseUrl: string,
   bucket: string,
   sourceKey: string,
   destKey: string,
 ): Promise<CopyResult> {
   const source = `/${bucket}/${encodeKey(sourceKey)}`;
-  let response: Response;
+  let response: HttpResponse;
   try {
-    response = await client.fetch(`${baseUrl}/${encodeKey(destKey)}`, {
+    response = await send(client, transport, `${baseUrl}/${encodeKey(destKey)}`, {
       method: "PUT",
       headers: { "x-amz-copy-source": source },
     });
@@ -282,7 +322,7 @@ async function s3CopyObject(
       message: `Storage rejected the copy (${response.status})`,
     };
   }
-  const body = await response.text();
+  const body = new TextDecoder().decode(response.body);
   if (body.includes("<Error")) {
     return { ok: false, status: "server", message: "Storage rejected the copy (200 error body)" };
   }
@@ -292,12 +332,13 @@ async function s3CopyObject(
 // s3DeleteObject removes key from the bucket.
 async function s3DeleteObject(
   client: AwsClient,
+  transport: Transport,
   baseUrl: string,
   key: string,
 ): Promise<DeleteResult> {
-  let response: Response;
+  let response: HttpResponse;
   try {
-    response = await client.fetch(`${baseUrl}/${encodeKey(key)}`, {
+    response = await send(client, transport, `${baseUrl}/${encodeKey(key)}`, {
       method: "DELETE",
     });
   } catch (err) {
@@ -315,10 +356,15 @@ async function s3DeleteObject(
 }
 
 // s3GetObject reads the bytes stored at key.
-async function s3GetObject(client: AwsClient, baseUrl: string, key: string): Promise<GetResult> {
-  let response: Response;
+async function s3GetObject(
+  client: AwsClient,
+  transport: Transport,
+  baseUrl: string,
+  key: string,
+): Promise<GetResult> {
+  let response: HttpResponse;
   try {
-    response = await client.fetch(`${baseUrl}/${encodeKey(key)}`, {
+    response = await send(client, transport, `${baseUrl}/${encodeKey(key)}`, {
       method: "GET",
     });
   } catch (err) {
@@ -340,13 +386,13 @@ async function s3GetObject(client: AwsClient, baseUrl: string, key: string): Pro
       etag: null,
     };
   }
-  const buffer = await response.arrayBuffer();
+
   return {
     ok: true,
     status: "ok",
     message: "",
-    body: new Uint8Array(buffer),
-    etag: response.headers.get("etag"),
+    body: response.body,
+    etag: response.header("etag"),
   };
 }
 
@@ -355,6 +401,7 @@ async function s3GetObject(client: AwsClient, baseUrl: string, key: string): Pro
 // and returns every key. Stopping early would make unlisted keys look like remote deletions.
 async function s3ListObjects(
   client: AwsClient,
+  transport: Transport,
   baseUrl: string,
   prefix: string | undefined,
 ): Promise<ListResult> {
@@ -370,9 +417,9 @@ async function s3ListObjects(
       url += `&continuation-token=${encodeComponent(continuationToken)}`;
     }
 
-    let response: Response;
+    let response: HttpResponse;
     try {
-      response = await client.fetch(url, { method: "GET" });
+      response = await send(client, transport, url, { method: "GET" });
     } catch (err) {
       return {
         ok: false,
@@ -391,7 +438,7 @@ async function s3ListObjects(
       };
     }
 
-    const page = parseListObjectsXml(await response.text());
+    const page = parseListObjectsXml(new TextDecoder().decode(response.body));
     objects.push(...page.objects);
     continuationToken = page.nextContinuationToken;
   } while (continuationToken !== undefined);
@@ -403,16 +450,17 @@ async function s3ListObjects(
 // only lands if its precondition still holds; a 412 from the server surfaces as "conflict".
 async function s3PutObject(
   client: AwsClient,
+  transport: Transport,
   baseUrl: string,
   key: string,
   body: Uint8Array,
   condition: PutCondition | undefined,
 ): Promise<PutResult> {
-  let response: Response;
+  let response: HttpResponse;
   try {
     // Uint8Array<ArrayBufferLike> vs DOM's ArrayBufferView<ArrayBuffer> is a TS lib mismatch,
     // not a real runtime issue; every JS engine accepts a Uint8Array as a fetch body.
-    response = await client.fetch(`${baseUrl}/${encodeKey(key)}`, {
+    response = await send(client, transport, `${baseUrl}/${encodeKey(key)}`, {
       method: "PUT",
       body: body as BodyInit,
       headers: conditionHeaders(condition),
@@ -429,4 +477,18 @@ async function s3PutObject(
     };
   }
   return { ok: true, status: "ok", message: "" };
+}
+
+// send signs the request with the client's credentials, then hands the signed request to the
+// transport. Signing is environment agnostic (aws4fetch uses WebCrypto); only the transport, and
+// so whether the request is subject to CORS, differs between the plugin runtime and tests.
+async function send(
+  client: AwsClient,
+  transport: Transport,
+  url: string,
+  init: RequestInit,
+): Promise<HttpResponse> {
+  const signed = await client.sign(url, init);
+
+  return transport(signed);
 }

--- a/src/sync/sync.itest.ts
+++ b/src/sync/sync.itest.ts
@@ -9,7 +9,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
 import { DEFAULT_SETTINGS, type GeodeSettings } from "../settings/settings.ts";
-import { createS3Client, type StorageClient } from "../storage/storage.ts";
+import { createS3Client, fetchTransport, type StorageClient } from "../storage/storage.ts";
 import { nodeVault } from "../vault/fs.ts";
 import {
   createObsidianLocalWriter,
@@ -35,7 +35,7 @@ const liveSettings: GeodeSettings = {
   accessKeyId: "geodedev",
 };
 
-const storage = createS3Client(liveSettings, SECRET);
+const storage = createS3Client(liveSettings, SECRET, fetchTransport);
 
 const STATE_PATH = ".obsidian/plugins/geode/state.json";
 


### PR DESCRIPTION
Resolves [#156](https://github.com/8thpark/geode/issues/156)

## Problem

- Testing a connection against an R2 bucket failed with an opaque `connection test failed: Failed to fetch`, because plugin requests went through the browser `fetch` and were blocked by CORS
- The same opaque error covers both a CORS block and a genuine network failure, leaving the user with nothing to act on

## Why

- Users own their storage, so needing to configure CORS just to sync is friction we can remove entirely
- Sync should be something you never think about; when it does fail, the message should tell you what to fix, not just that it broke

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR routes storage traffic through Obsidian’s native request API to bypass browser CORS restrictions.
- Introduces normalized request and response adapters for native and fetch transports.
- Injects the native transport into connection testing and synchronization at runtime.
- Improves network-error guidance and adds unit coverage for native request conversion.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with the previously reported test-coverage gap still outstanding.

The native adapter now has focused conversion tests, but production binds it to Obsidian requestUrl while end-to-end storage integration continues to run through fetchTransport.

**Files Needing Attention:** src/storage/obsidian.ts, src/storage/native.test.ts, src/storage/storage.itest.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/storage/native.ts | Adds pure conversion between signed Fetch requests, Obsidian request parameters, and normalized storage responses. |
| src/storage/obsidian.ts | Binds the pure native transport adapter to Obsidian’s requestUrl API. |
| src/storage/storage.ts | Makes transport injectable and routes all signed S3 operations through the normalized transport boundary. |
| src/main.ts | Injects the native transport into runtime synchronization. |
| src/settings/tab.ts | Injects the native transport into settings connection checks. |
| src/storage/native.test.ts | Covers request conversion, binary and empty bodies, status normalization, response bytes, and case-insensitive headers. |

<sub>Reviews (3): Last reviewed commit: ["Address lack of test coverage"](https://github.com/8thpark/geode/commit/dc889bc961b5f1029c484dc97085b50a026c49c1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48604723)</sub>

<!-- /greptile_comment -->