### PR TITLE
[#79] Settings → Normalize custom endpoint scheme

### DIFF
--- a/src/settings/settings.test.ts
+++ b/src/settings/settings.test.ts
@@ -254,6 +254,26 @@ const endpointCases: { name: string; input: GeodeSettings; want: string }[] = [
     input: { ...DEFAULT_SETTINGS, provider: "custom", endpoint: "https://s3.example.com" },
     want: "https://s3.example.com",
   },
+  {
+    name: "custom with no scheme is prefixed with https",
+    input: { ...DEFAULT_SETTINGS, provider: "custom", endpoint: "s3.example.com" },
+    want: "https://s3.example.com",
+  },
+  {
+    name: "custom with uppercase scheme is left alone",
+    input: { ...DEFAULT_SETTINGS, provider: "custom", endpoint: "HTTP://s3.example.com" },
+    want: "HTTP://s3.example.com",
+  },
+  {
+    name: "custom with trailing slash is stripped",
+    input: { ...DEFAULT_SETTINGS, provider: "custom", endpoint: "https://s3.example.com/" },
+    want: "https://s3.example.com",
+  },
+  {
+    name: "custom with surrounding whitespace is trimmed",
+    input: { ...DEFAULT_SETTINGS, provider: "custom", endpoint: "  https://s3.example.com  " },
+    want: "https://s3.example.com",
+  },
 ];
 
 for (const { name, input, want } of endpointCases) {

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -71,7 +71,10 @@ export function normalizeEndpoint(endpoint: string): string {
   }
 
   // Require an explicit scheme to prevent generic network errors
-  if (!normalized.startsWith("http://") && !normalized.startsWith("https://")) {
+  const hasScheme =
+    normalized.toLowerCase().startsWith("http://") ||
+    normalized.toLowerCase().startsWith("https://");
+  if (!hasScheme) {
     normalized = `https://${normalized}`;
   }
 

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -42,13 +42,33 @@ export function draftForDisplay(
   return currentDraft;
 }
 
+// normalizeEndpoint ensures the endpoint has an explicit scheme and no trailing slash.
+export function normalizeEndpoint(endpoint: string): string {
+  let normalized = endpoint.trim();
+  if (!normalized) {
+    return "";
+  }
+
+  // Require an explicit scheme to prevent generic network errors
+  if (!normalized.startsWith("http://") && !normalized.startsWith("https://")) {
+    normalized = `https://${normalized}`;
+  }
+
+  // Strip trailing slashes to prevent double-slash SigV4 canonical path issues
+  while (normalized.endsWith("/")) {
+    normalized = normalized.slice(0, -1);
+  }
+
+  return normalized;
+}
+
 // endpointFor returns the storage endpoint URL to use for the given settings.
 export function endpointFor(settings: GeodeSettings): string {
   if (settings.provider === "r2") {
     return `https://${settings.accountId}.r2.cloudflarestorage.com`;
   }
 
-  return settings.endpoint;
+  return normalizeEndpoint(settings.endpoint);
 }
 
 // hasConnectionConfig reports whether settings have enough filled in to attempt a connection.


### PR DESCRIPTION
Fixes #79

- Adds `normalizeEndpoint` to ensure custom endpoints always have an explicit `http://` or `https://` scheme (preventing generic fetch network errors).  
- Strips trailing slashes to prevent double-slash SigV4 canonical path 403 errors.  
- Verified via local build (`npm run build` passes).  

This turns both common user input mistakes into either a working request or a clear, named problem.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR normalizes custom storage endpoints before use.
- Detects HTTP and HTTPS schemes case-insensitively.
- Adds HTTPS when the scheme is omitted.
- Trims surrounding whitespace and trailing slashes.
- Adds unit coverage for each normalization case.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the case-insensitive scheme check fixes the previously reported malformed double-scheme URL behavior.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/settings/settings.ts | Adds endpoint normalization and fixes the previously reported case-sensitive scheme detection. |
| src/settings/settings.test.ts | Adds focused coverage for absent and uppercase schemes, trailing slashes, and surrounding whitespace. |

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/normalize-c..."](https://github.com/8thpark/geode/commit/09855f079c3bf8b9aa9bd2f7859ac7e7c9237443) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48796484)</sub>

<!-- /greptile_comment -->