### PR TITLE
Signed releases via GitHub Action

### DIFF
--- a/.github/workflows/backfill-attestation.yml
+++ b/.github/workflows/backfill-attestation.yml
@@ -1,0 +1,43 @@
+name: Backfill Release Attestation
+
+# One-off, manually triggered. Signs the bytes of a release that was published before the signed
+# pipeline existed. It attests the *already published* assets rather than rebuilding them, so the
+# attestation covers exactly what people downloaded. That means the provenance says "this workflow
+# attests these bytes", not "built them from this source" — the honest thing for a retroactive
+# signature. The attestation lives in GitHub's store keyed by digest, so nothing about the existing
+# release is re-cut; `gh attestation verify` finds it by content hash.
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to attest (its published bytes)"
+        required: true
+        default: "0.1.0-beta.1"
+
+permissions:
+  contents: read
+  id-token: write
+  attestations: write
+
+jobs:
+  attest:
+    name: Attest published assets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download published release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          mkdir -p "dist/$TAG"
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" \
+            --pattern manifest.json --pattern main.js --pattern styles.css \
+            --dir "dist/$TAG"
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: |
+            dist/${{ inputs.tag }}/manifest.json
+            dist/${{ inputs.tag }}/main.js
+            dist/${{ inputs.tag }}/styles.css

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,65 @@
+name: Release
+
+# Fires when a release tag is pushed. The pattern is a coarse filter (any X.Y.Z shaped tag, with an
+# optional -beta.N suffix): the authoritative check is `build:release`, which validates the tag
+# against manifest.json and fails the build on any mismatch, so the trigger stays simple and the
+# script stays the one source of truth. Tags are never prefixed with `v` (see CONTRIBUTING.md).
+on:
+  push:
+    tags:
+      - "*.*.*"
+
+# id-token + attestations are what keyless Sigstore signing needs; contents lets us create the
+# release. No long-lived signing key exists to leak.
+permissions:
+  contents: write
+  id-token: write
+  attestations: write
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+      - run: npm ci
+
+      # Validates tag ↔ manifest, builds, and secretlint-scans the exact bytes being shipped.
+      - name: Build release artifacts
+        run: npm run build:release -- --tag "${GITHUB_REF_NAME}"
+
+      # Keyless provenance over the three shipped files, recorded in the public transparency log.
+      # Anyone can verify with: gh attestation verify main.js --repo 8thpark/geode
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: |
+            dist/${{ github.ref_name }}/manifest.json
+            dist/${{ github.ref_name }}/main.js
+            dist/${{ github.ref_name }}/styles.css
+
+      # Draft, not published: the generated notes are a skeleton for a human to rewrite before
+      # launching. A -beta.N tag is marked pre-release so it never becomes "Latest" (BRAT still
+      # installs it). Editing notes and publishing later is metadata only, so the attestation over
+      # the asset bytes stays valid.
+      - name: Create draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          prerelease=""
+          case "$TAG" in
+            *-beta.*) prerelease="--prerelease" ;;
+          esac
+          gh release create "$TAG" \
+            --draft \
+            --title "$TAG" \
+            --generate-notes \
+            $prerelease \
+            "dist/$TAG/manifest.json" \
+            "dist/$TAG/main.js" \
+            "dist/$TAG/styles.css"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,3 +135,24 @@ and the public API should not be considered stable; we aim to avoid churn, but e
 
 The version number is duplicated in `package.json` and `manifest.json`; bump both together for
 every release. The README's version badge reads `package.json`, and Obsidian reads `manifest.json`.
+
+## Releasing
+
+Releases are cut by pushing a tag; a workflow does the mechanical work and leaves you a draft to
+launch. The steps:
+
+1. Bump `package.json` and `manifest.json` to the new version (they must agree, `check-versions`
+   enforces it), open a PR, merge to `main`.
+2. Tag the merged commit and push it, no `v` prefix: `git tag 0.1.0 && git push origin 0.1.0`.
+   A `-beta.N` suffix marks a pre-release, e.g. `0.1.0-beta.2`.
+3. The tag push triggers [`release.yml`](./.github/workflows/release.yml), which rebuilds the
+   artifacts from the tagged commit (validating the tag against `manifest.json` and secret-scanning
+   the exact bytes), signs them with keyless [build provenance](https://docs.github.com/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds),
+   and creates a **draft** GitHub release with the assets attached and generated notes as a
+   skeleton. A `-beta.N` tag is marked pre-release automatically.
+4. Open the draft, rewrite the generated notes into real release notes, then publish. Editing notes
+   and publishing is metadata only, so it never invalidates the signature over the asset bytes.
+
+There is no long-lived signing key: provenance is signed keylessly against the workflow's GitHub
+identity and recorded in a public transparency log. See [SECURITY.md](./SECURITY.md) for how anyone
+verifies a downloaded release.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,13 +10,18 @@ shipped; every report is appreciated, even the false alarms.
 
 ## Verifying a Release
 
-Every release artifact is signed with keyless [build provenance](https://docs.github.com/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds):
-there is no long-lived signing key, the signature is tied to the GitHub workflow and commit that
-built it, and it's recorded in a public transparency log. To confirm a downloaded file is genuine:
+Release artifacts are signed with keyless [build provenance](https://docs.github.com/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds):
+there is no long-lived signing key, the signature is tied to the GitHub Actions workflow that
+produced it, and it's recorded in a public transparency log. To check a downloaded file:
 
 ```bash
 gh attestation verify main.js --repo 8thpark/geode
 ```
 
-Run it against each downloaded asset (`main.js`, `manifest.json`, `styles.css`). A pass means the
-bytes came from this repository's release workflow at the tagged commit, untouched since.
+Run it against each downloaded asset (`main.js`, `manifest.json`, `styles.css`). A pass proves the
+file is byte-identical to what this repository's automation signed, and unmodified since.
+
+For releases from `0.1.0` onward the attestation is stronger: the artifacts are built from source in
+the release workflow, so the provenance ties them to the exact commit they came from. `0.1.0-beta.1`
+predates that pipeline and was signed retroactively over its already published bytes, so its
+attestation proves authenticity and integrity, not a build from source.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,3 +7,16 @@ rather than a public issue, so there's time for a fix before the details are out
 Include whatever detail you can (steps to reproduce are gold). You'll get an acknowledgement
 within 7 days, and a fix or a plan within 90. Please hold off on public disclosure until a fix has
 shipped; every report is appreciated, even the false alarms.
+
+## Verifying a Release
+
+Every release artifact is signed with keyless [build provenance](https://docs.github.com/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds):
+there is no long-lived signing key, the signature is tied to the GitHub workflow and commit that
+built it, and it's recorded in a public transparency log. To confirm a downloaded file is genuine:
+
+```bash
+gh attestation verify main.js --repo 8thpark/geode
+```
+
+Run it against each downloaded asset (`main.js`, `manifest.json`, `styles.css`). A pass means the
+bytes came from this repository's release workflow at the tagged commit, untouched since.


### PR DESCRIPTION
Resolves [#164](https://github.com/8thpark/geode/issues/164)

## Problem

- Release artifacts shipped unsigned, so anyone installing `main.js`, `manifest.json`, or `styles.css` had no way to confirm the bytes came from this repository untampered
- Releases were built and uploaded by hand, with no repeatable, auditable pipeline

## Why

- Security is a first class citizen; provenance ties every artifact to the exact commit and workflow that built it, with no long lived signing key to leak
- A draft based flow keeps a human gate for release notes while the pipeline handles the building and signing

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an automated, keyless release-signing process.
- Builds and attests tagged release artifacts before creating a draft GitHub release.
- Adds a one-off workflow for attesting previously published assets.
- Documents the release process and verification guarantees.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/backfill-attestation.yml | Adds a manually dispatched workflow that downloads existing release assets and creates attestations for their current bytes. |
| .github/workflows/release.yml | Adds the tag-triggered build, attestation, and draft-release pipeline. |
| CONTRIBUTING.md | Documents versioning and the new draft-based release procedure. |
| SECURITY.md | Documents artifact verification and distinguishes source-built releases from the retroactively attested legacy release. |

<sub>Reviews (2): Last reviewed commit: ["Address comment"](https://github.com/8thpark/geode/commit/4e3c0734ca6965ae92ee02fc757113e51d2bf47b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48803728)</sub>

<!-- /greptile_comment -->