### PR TITLE
Address OpenSSF issues with signed releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,17 +9,20 @@ on:
     tags:
       - "*.*.*"
 
-# id-token + attestations are what keyless Sigstore signing needs; contents lets us create the
-# release. No long-lived signing key exists to leak.
+# Least privilege at the top: read only. The single job below elevates to exactly what it needs.
 permissions:
-  contents: write
-  id-token: write
-  attestations: write
+  contents: read
 
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    # id-token + attestations are what keyless Sigstore signing needs; contents lets us create the
+    # release. Scoped to the job, not the workflow. No long-lived signing key exists to leak.
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
@@ -35,12 +38,23 @@ jobs:
       # Keyless provenance over the three shipped files, recorded in the public transparency log.
       # Anyone can verify with: gh attestation verify main.js --repo 8thpark/geode
       - name: Attest build provenance
+        id: attest
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: |
             dist/${{ github.ref_name }}/manifest.json
             dist/${{ github.ref_name }}/main.js
             dist/${{ github.ref_name }}/styles.css
+
+      # Ship the Sigstore bundle (the signed provenance for all three artifacts) as a release asset,
+      # not just in GitHub's attestation store. It lets anyone verify the release offline, and OSSF
+      # Scorecard's Signed-Releases check reads release assets rather than the attestation store, so
+      # the `.sigstore.json` asset is what earns that check.
+      - name: Stage provenance bundle
+        env:
+          BUNDLE: ${{ steps.attest.outputs.bundle-path }}
+          TAG: ${{ github.ref_name }}
+        run: cp "$BUNDLE" "dist/$TAG/geode-$TAG.sigstore.json"
 
       # Draft, not published: the generated notes are a skeleton for a human to rewrite before
       # launching. A -beta.N tag is marked pre-release so it never becomes "Latest" (BRAT still
@@ -62,4 +76,5 @@ jobs:
             $prerelease \
             "dist/$TAG/manifest.json" \
             "dist/$TAG/main.js" \
-            "dist/$TAG/styles.css"
+            "dist/$TAG/styles.css" \
+            "dist/$TAG/geode-$TAG.sigstore.json"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,8 +148,9 @@ launch. The steps:
 3. The tag push triggers [`release.yml`](./.github/workflows/release.yml), which rebuilds the
    artifacts from the tagged commit (validating the tag against `manifest.json` and secret-scanning
    the exact bytes), signs them with keyless [build provenance](https://docs.github.com/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds),
-   and creates a **draft** GitHub release with the assets attached and generated notes as a
-   skeleton. A `-beta.N` tag is marked pre-release automatically.
+   and creates a **draft** GitHub release with the assets, the signed provenance bundle
+   (`geode-<version>.sigstore.json`), and generated notes as a skeleton attached. A `-beta.N` tag is
+   marked pre-release automatically.
 4. Open the draft, rewrite the generated notes into real release notes, then publish. Editing notes
    and publishing is metadata only, so it never invalidates the signature over the asset bytes.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,6 +21,13 @@ gh attestation verify main.js --repo 8thpark/geode
 Run it against each downloaded asset (`main.js`, `manifest.json`, `styles.css`). A pass proves the
 file is byte-identical to what this repository's automation signed, and unmodified since.
 
+Each release also ships the signed provenance as a `geode-<version>.sigstore.json` asset, so you can
+verify offline without hitting GitHub's API:
+
+```bash
+gh attestation verify main.js --bundle geode-0.1.0.sigstore.json --repo 8thpark/geode
+```
+
 For releases from `0.1.0` onward the attestation is stronger: the artifacts are built from source in
 the release workflow, so the provenance ties them to the exact commit they came from. `0.1.0-beta.1`
 predates that pipeline and was signed retroactively over its already published bytes, so its


### PR DESCRIPTION
Relates to [#164](https://github.com/8thpark/geode/issues/164)

## Problem

- OpenSSF Scorecard scored `Signed-Releases` at `0/10`: its probes read release assets only and never query GitHub's attestation store, so our keyless attestations were invisible to it
- The release workflow held `contents: write` at the top level, dragging `Token-Permissions` to `0/10`

## Why

- Security is a first class citizen here; the provenance now travels with each release rather than living only behind GitHub's API, which is both stronger and legible to external scanners
- Least privilege on the workflow token is a cheap, permanent reduction in blast radius

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds downloadable Sigstore provenance bundles to signed draft releases.
- Scopes elevated GitHub token permissions to the release job.
- Stages the generated multi-artifact provenance bundle and uploads it with release assets.
- Documents the bundled provenance and offline verification workflow.

<h3>Confidence Score: 5/5</h3>

The pull request appears safe to merge, with no actionable defects identified.

The attestation action exposes the referenced bundle output, the release build creates the destination directory before staging, and the resulting bundle is attached alongside all three attested artifacts.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Correctly scopes release permissions, captures the attestation bundle output, stages it under a versioned filename, and uploads it with both stable and beta releases. |
| CONTRIBUTING.md | Updates the release procedure to accurately describe the newly attached provenance bundle. |
| SECURITY.md | Documents offline verification using the downloadable Sigstore bundle with syntax consistent with the generated release asset. |

<sub>Reviews (1): Last reviewed commit: ["Address OSSF issues"](https://github.com/8thpark/geode/commit/699ca37ed6a2cbe68beb3b105f483b2b5267f70b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48814211)</sub>

<!-- /greptile_comment -->