### PR TITLE
Release → Ship per asset provenance bundles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,26 +35,41 @@ jobs:
       - name: Build release artifacts
         run: npm run build:release -- --tag "${GITHUB_REF_NAME}"
 
-      # Keyless provenance over the three shipped files, recorded in the public transparency log.
-      # Anyone can verify with: gh attestation verify main.js --repo 8thpark/geode
-      - name: Attest build provenance
-        id: attest
+      # Keyless provenance, one attestation per shipped file, recorded in the public transparency
+      # log. Anyone can verify online with: gh attestation verify main.js --repo 8thpark/geode
+      - name: Attest manifest.json
+        id: attest-manifest
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
-          subject-path: |
-            dist/${{ github.ref_name }}/manifest.json
-            dist/${{ github.ref_name }}/main.js
-            dist/${{ github.ref_name }}/styles.css
+          subject-path: dist/${{ github.ref_name }}/manifest.json
 
-      # Ship the Sigstore bundle (the signed provenance for all three artifacts) as a release asset,
-      # not just in GitHub's attestation store. It lets anyone verify the release offline, and OSSF
-      # Scorecard's Signed-Releases check reads release assets rather than the attestation store, so
-      # the `.sigstore.json` asset is what earns that check.
-      - name: Stage provenance bundle
+      - name: Attest main.js
+        id: attest-mainjs
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: dist/${{ github.ref_name }}/main.js
+
+      - name: Attest styles.css
+        id: attest-styles
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: dist/${{ github.ref_name }}/styles.css
+
+      # Ship each file's Sigstore bundle as its own `<asset>.sigstore.json` release asset, not only
+      # in GitHub's attestation store. Each is a single valid bundle, so it verifies directly with
+      # `gh attestation verify <asset> --bundle <asset>.sigstore.json`, and OSSF Scorecard's
+      # Signed-Releases check (which reads release assets, not the store) credits the suffix. Paths
+      # come in via env so nothing gets interpolated straight into the shell.
+      - name: Stage provenance bundles
         env:
-          BUNDLE: ${{ steps.attest.outputs.bundle-path }}
           TAG: ${{ github.ref_name }}
-        run: cp "$BUNDLE" "dist/$TAG/geode-$TAG.sigstore.json"
+          MANIFEST_BUNDLE: ${{ steps.attest-manifest.outputs.bundle-path }}
+          MAINJS_BUNDLE: ${{ steps.attest-mainjs.outputs.bundle-path }}
+          STYLES_BUNDLE: ${{ steps.attest-styles.outputs.bundle-path }}
+        run: |
+          cp "$MANIFEST_BUNDLE" "dist/$TAG/manifest.json.sigstore.json"
+          cp "$MAINJS_BUNDLE" "dist/$TAG/main.js.sigstore.json"
+          cp "$STYLES_BUNDLE" "dist/$TAG/styles.css.sigstore.json"
 
       # Draft, not published: the generated notes are a skeleton for a human to rewrite before
       # launching. A -beta.N tag is marked pre-release so it never becomes "Latest" (BRAT still
@@ -77,4 +92,6 @@ jobs:
             "dist/$TAG/manifest.json" \
             "dist/$TAG/main.js" \
             "dist/$TAG/styles.css" \
-            "dist/$TAG/geode-$TAG.sigstore.json"
+            "dist/$TAG/manifest.json.sigstore.json" \
+            "dist/$TAG/main.js.sigstore.json" \
+            "dist/$TAG/styles.css.sigstore.json"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,8 +148,8 @@ launch. The steps:
 3. The tag push triggers [`release.yml`](./.github/workflows/release.yml), which rebuilds the
    artifacts from the tagged commit (validating the tag against `manifest.json` and secret-scanning
    the exact bytes), signs them with keyless [build provenance](https://docs.github.com/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds),
-   and creates a **draft** GitHub release with the assets, the signed provenance bundle
-   (`geode-<version>.sigstore.json`), and generated notes as a skeleton attached. A `-beta.N` tag is
+   and creates a **draft** GitHub release with the assets, a per-asset signed provenance bundle
+   (`<asset>.sigstore.json`), and generated notes as a skeleton attached. A `-beta.N` tag is
    marked pre-release automatically.
 4. Open the draft, rewrite the generated notes into real release notes, then publish. Editing notes
    and publishing is metadata only, so it never invalidates the signature over the asset bytes.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,11 +21,11 @@ gh attestation verify main.js --repo 8thpark/geode
 Run it against each downloaded asset (`main.js`, `manifest.json`, `styles.css`). A pass proves the
 file is byte-identical to what this repository's automation signed, and unmodified since.
 
-Each release also ships the signed provenance as a `geode-<version>.sigstore.json` asset, so you can
-verify offline without hitting GitHub's API:
+Each release also ships a per-asset signed provenance bundle (`main.js.sigstore.json` and so on), so
+you can verify against the shipped bundle rather than fetching the attestation from GitHub's API:
 
 ```bash
-gh attestation verify main.js --bundle geode-0.1.0.sigstore.json --repo 8thpark/geode
+gh attestation verify main.js --bundle main.js.sigstore.json --repo 8thpark/geode
 ```
 
 For releases from `0.1.0` onward the attestation is stronger: the artifacts are built from source in


### PR DESCRIPTION
Relates to [#164](https://github.com/8thpark/geode/issues/164)

## Problem

- The release workflow attached the provenance for all three artifacts as one combined `.sigstore.json` blob, which `gh attestation verify --bundle` cannot parse because it reads that file as a single Sigstore bundle
- That left the shipped bundle usable only as an OSSF Scorecard suffix match, not something anyone could actually verify

## Why

- A provenance file you cannot verify is a hollow suffix match, exactly the box ticking we set out to avoid; per asset bundles verify directly with `gh attestation verify` and still earn the Signed-Releases credit

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Splits release provenance into independently verifiable per-asset Sigstore bundles.
- Attests `manifest.json`, `main.js`, and `styles.css` separately.
- Uploads each bundle beside its corresponding release asset.
- Updates contributor and security documentation with the new bundle names and verification command.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the workflow and documentation consistently adopting per-asset provenance bundles.

Each built artifact is attested separately, its corresponding bundle is staged under a matching filename, and all three artifact-bundle pairs are uploaded to the draft release.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Replaces the combined provenance bundle with three correctly mapped per-asset attestation bundles and uploads all of them with the draft release. |
| CONTRIBUTING.md | Updates the documented release process to describe per-asset provenance bundles. |
| SECURITY.md | Updates bundle-based verification instructions to use the bundle corresponding to the downloaded asset. |

<sub>Reviews (1): Last reviewed commit: ["Update workflow with issues solved local..."](https://github.com/8thpark/geode/commit/a390b647a12dfc2dcd3a8ca3545bb0f55b180261) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48822662)</sub>

<!-- /greptile_comment -->