### PR TITLE
Sync → Fix a permanent wedge on a manifestless first sync

### DIFF
--- a/src/sync/sync.itest.ts
+++ b/src/sync/sync.itest.ts
@@ -398,6 +398,45 @@ test("sync: a deleted manifest with surviving objects refuses a first sync inste
   }
 });
 
+test("sync: a deleted manifest over a divergent object conflicts instead of wedging the sync", async () => {
+  // A and B share a synced note, then the manifest alone is deleted (a lifecycle rule, manual
+  // cleanup) and B edits the note before its next sync. B sees objects and no manifest, so the
+  // path it is about to push already exists remotely holding different bytes. Before the fix that
+  // push's ifAbsent precondition failed, the 412 read as another device syncing, and B was told to
+  // sync again forever: nothing changed between attempts, so every retry failed identically.
+  await resetRemote();
+  const a = newDevice();
+  const b = newDevice();
+  const now = Date.parse("2026-07-14T11:00:00.000Z");
+  try {
+    await writeLocal(a, "ten/note.md", "from A");
+    assert.equal((await sync(a)).ok, true);
+    assert.equal((await sync(b)).ok, true);
+
+    await storage.deleteObject(MANIFEST_KEY);
+    await writeLocal(b, "ten/note.md", "B's own edit");
+
+    const outcome = await sync(b, now);
+    assert.equal(outcome.ok, true);
+
+    // The surviving object keeps the path on both sides, B's edit survives as a conflict copy, and
+    // the manifest B wrote describes both, so A converges on the same view rather than orphaning
+    // anything.
+    const copyPath = conflictCopyPath("ten/note.md", now);
+    assert.equal(await readLocal(b, "ten/note.md"), "from A");
+    assert.equal(await readLocal(b, copyPath), "B's own edit");
+    assert.equal((await sync(a)).ok, true);
+    assert.equal(await readLocal(a, "ten/note.md"), "from A");
+    assert.equal(await readLocal(a, copyPath), "B's own edit");
+
+    // And the pass that used to wedge is now genuinely idle on both devices.
+    assert.equal((await sync(b)).ok, true);
+    assert.equal((await sync(a)).ok, true);
+  } finally {
+    cleanup(a, b);
+  }
+});
+
 test("sync: an edit on one device and a delete on another preserves the edit as a copy, no phantom pull failure", async () => {
   await resetRemote();
   const a = newDevice();

--- a/src/sync/sync.test.ts
+++ b/src/sync/sync.test.ts
@@ -233,6 +233,82 @@ test("syncOnce: an interrupted first sync's own uploads never block the retry", 
   assert.equal(objects.has(MANIFEST_KEY), true);
 });
 
+test("syncOnce: a missing manifest over divergent bytes conflicts instead of wedging the sync", async () => {
+  // The manifest is gone (a lifecycle rule, a second vault on the same bucket) but the object at
+  // a.md survived, holding bytes this vault has never seen. Before the fix the empty remote view
+  // made that path an ifAbsent push, the surviving object rejected it with a 412, and the pass read
+  // that as another device syncing and told the user to sync again: nothing about either side
+  // changed, so every retry hit the identical 412, a permanent wedge whose message named the one
+  // action that could not work. Planning against what the bucket really holds makes it a conflict.
+  const { storage, objects } = fakeStorage({ "a.md": "theirs" });
+  const reader = fakeReader({ "a.md": "ours" });
+  const { writer, files } = fakeLocalWriter();
+  files.set("a.md", "ours");
+
+  const outcome = await syncOnce(empty, reader, writer, storage, 1);
+
+  assert.equal(outcome.ok, true);
+  // Neither version was lost: the surviving object keeps the path, the local edit lives on under
+  // the conflict copy, both on disk and in the bucket, and a manifest now describes all of it.
+  const copy = conflictCopyPath("a.md", 1);
+  assert.equal(files.get("a.md"), "theirs");
+  assert.equal(files.get(copy), "ours");
+  assert.equal(objects.get("a.md"), "theirs");
+  assert.equal(objects.get(copy), "ours");
+  assert.equal(objects.has(MANIFEST_KEY), true);
+});
+
+test("syncOnce: an unreadable survivor on a first sync is reported, never guessed at as absent", async () => {
+  const { storage, objects } = fakeStorage({ "a.md": "theirs" });
+  const inner = storage.getObject;
+  storage.getObject = async (key) => {
+    if (key !== "a.md") {
+      return inner(key);
+    }
+    return {
+      ok: false,
+      status: "server",
+      message: "Storage rejected the read (500)",
+      body: null,
+      etag: null,
+    };
+  };
+  const reader = fakeReader({ "a.md": "ours" });
+  const { writer } = fakeLocalWriter();
+
+  const outcome = await syncOnce(empty, reader, writer, storage, 1);
+
+  assert.deepEqual(outcome, {
+    ok: false,
+    message: "Storage rejected the read (500)",
+    failures: [{ path: "a.md", message: "Storage rejected the read (500)" }],
+    snapshot: null,
+  });
+  // The survivor was left alone and no manifest was written over a view we could not read.
+  assert.equal(objects.get("a.md"), "theirs");
+  assert.equal(objects.has(MANIFEST_KEY), false);
+});
+
+test("syncOnce: a survivor deleted between the listing and the read is treated as gone", async () => {
+  // Another device removed the object in the window between the two calls. That is the absence the
+  // missing manifest already implied, so the pass proceeds and pushes the local file.
+  const { storage, objects } = fakeStorage({ "a.md": "theirs" });
+  const inner = storage.getObject;
+  storage.getObject = async (key) => {
+    if (key === "a.md") {
+      objects.delete(key);
+    }
+    return inner(key);
+  };
+  const reader = fakeReader({ "a.md": "ours" });
+  const { writer } = fakeLocalWriter();
+
+  const outcome = await syncOnce(empty, reader, writer, storage, 1);
+
+  assert.equal(outcome.ok, true);
+  assert.equal(objects.get("a.md"), "ours");
+});
+
 test("syncOnce: a failed bucket listing on a first sync is reported, never guessed at as empty", async () => {
   const { storage } = fakeStorage();
   storage.listObjects = async () => ({

--- a/src/sync/sync.ts
+++ b/src/sync/sync.ts
@@ -4,6 +4,7 @@ import {
   decodeSnapshot,
   encodeSnapshot,
   type FileState,
+  hashBytes,
   type Reader,
   type Snapshot,
   takeSnapshot,
@@ -187,9 +188,17 @@ export async function syncOnce(
   // cleanup, or partial restore can remove the manifest while file objects survive (#109). The
   // pass below would build a manifest purely from local files, leaving every surviving object
   // invisible: never pulled, never listed, orphaned forever. Refuse loudly instead when the
-  // bucket holds objects no local file accounts for. Objects that do match a local path are safe
-  // to proceed over — an interrupted first sync leaves exactly those, and each push's own
-  // precondition adopts identical bytes and refuses divergent ones.
+  // bucket holds objects no local file accounts for.
+  //
+  // Objects that do match a local path are safe to proceed over, but only once the plan knows
+  // what they hold. The empty snapshot a missing manifest implies claims the bucket has nothing
+  // at that key, so the path plans as an ifAbsent push the surviving object can only reject; the
+  // 412 reads as concurrency and aborts the pass telling the user to sync again, and since
+  // nothing about either side changes, every retry reproduces it exactly: a permanent wedge whose
+  // error message names the one action that cannot work. Reading those objects instead makes the
+  // plan honest, and the ordinary machinery does the rest: identical bytes need no action at all,
+  // divergent bytes are a conflict, and neither side's version is lost.
+  let remoteView = remote.snapshot;
   if (remote.firstSync) {
     const listed = await storage.listObjects();
     if (!listed.ok) {
@@ -208,9 +217,19 @@ export async function syncOnce(
         snapshot: null,
       };
     }
+    const survivors = await bucketView(listed.objects, local, storage);
+    if (!survivors.ok) {
+      return {
+        ok: false,
+        message: survivors.failure.message,
+        failures: [survivors.failure],
+        snapshot: null,
+      };
+    }
+    remoteView = survivors.snapshot;
   }
 
-  const actions = planSync(ancestor, local, remote.snapshot);
+  const actions = planSync(ancestor, local, remoteView);
   const executed = await executeSyncPlan(
     actions,
     local,
@@ -218,7 +237,7 @@ export async function syncOnce(
     localWriter,
     storage,
     now,
-    remote.snapshot,
+    remoteView,
   );
 
   // A failed file precondition means the plan's remote snapshot is no longer current. Do not
@@ -242,7 +261,7 @@ export async function syncOnce(
   // keeps the entry the bucket really holds; the manifest is uploaded even when some actions
   // failed, so one bad file never leaves the rest of the pass's pushes invisible to every other
   // device (#87).
-  const manifest = manifestAfterSync(local, remote.snapshot, executed.completed, now);
+  const manifest = manifestAfterSync(local, remoteView, executed.completed, now);
   const final = adoptLiveStats(manifest, await takeSnapshot(reader, local));
   const manifestBody = new TextEncoder().encode(encodeSnapshot(final));
 
@@ -286,4 +305,48 @@ export async function syncOnce(
   }
 
   return { ok: true, snapshot: final, changeCount: actions.length };
+}
+
+// bucketView returns the remote snapshot a first sync should plan against: what the bucket really
+// holds, read from the objects that outlived the manifest, rather than the empty snapshot a missing
+// manifest implies. Only keys with a local file at the same path are read; anything else is either
+// geode's own bookkeeping or an orphan the caller has already refused over. The objects are fetched
+// and hashed because a plan needs content identity, not just a key: an ETag is a provider specific
+// opaque string and a listed size cannot tell two same length edits apart. That costs one GET per
+// surviving object, on a path only ever taken when a bucket has lost its manifest, and no more than
+// the failed conditional PUT plus its verifying GET that the same objects cost before. mtime is 0
+// because a remote object has no local mtime to speak of: any entry that survives into the manifest
+// therefore misses takeSnapshot's stat check next pass and is rehashed, the safe direction to err
+// in, and adoptLiveStats replaces it with the live entry wherever the content already agrees.
+async function bucketView(
+  objects: ObjectMeta[],
+  local: Snapshot,
+  storage: StorageClient,
+): Promise<{ ok: true; snapshot: Snapshot } | { ok: false; failure: SyncFailure }> {
+  const localByPath = byPath(local.files);
+  const files: FileState[] = [];
+
+  for (const object of objects) {
+    if (object.key.startsWith(RESERVED_PREFIX) || !localByPath.has(object.key)) {
+      continue;
+    }
+    const fetched = await storage.getObject(object.key);
+    if (!fetched.ok || fetched.body === null) {
+      // Listed a moment ago and gone now means another device deleted it in between, which is
+      // exactly the absence the missing manifest already implied; anything else is a real failure
+      // and must not be read as "the bucket holds nothing here", the guess that orphans files.
+      if (fetched.status === "not_found") {
+        continue;
+      }
+      return { ok: false, failure: { path: object.key, message: fetched.message } };
+    }
+    files.push({
+      path: object.key,
+      size: fetched.body.length,
+      mtime: 0,
+      hash: await hashBytes(fetched.body),
+    });
+  }
+
+  return { ok: true, snapshot: { files } };
 }


### PR DESCRIPTION
## Problem

- A bucket that has lost its manifest but still holds a file whose bytes differ from the local copy at that path wedges sync permanently
- The pass plans a create only push, the surviving object rejects it, and the failure is read as another device syncing, so the user is told to sync again
- Nothing on either side changes between attempts, so every retry fails identically; reachable through a bucket lifecycle rule or two vaults sharing one bucket

## Why

- A sync that only a human can unstick is the opposite of never thinking about it, and the error named the one action that could not work
- No edit is ever lost is the standing promise, and a conflict copy is how the rest of the engine already keeps it

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes manifestless first syncs when surviving remote objects overlap local paths.
- Reconstructs the first-sync remote snapshot by fetching and hashing surviving objects.
- Reuses existing conflict handling to preserve divergent local content as conflict copies.
- Fails safely when a surviving object cannot be read and treats a concurrently deleted object as absent.
- Adds unit and integration coverage for divergent survivors, read failures, deletion races, convergence, and idle retries.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or security issues identified.

The reconstructed snapshot uses hashes of the actual surviving bytes, existing execution safeguards revalidate remote state, failures abort without publishing an incomplete manifest, and the resulting view is used consistently through planning and manifest projection.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/sync/sync.ts | Reconstructs the remote view for manifestless first syncs and consistently passes it through planning, execution, and manifest generation; no actionable defect identified. |
| src/sync/sync.test.ts | Adds focused orchestration tests covering divergent content, unreadable survivors, and deletion between listing and fetching. |
| src/sync/sync.itest.ts | Adds end-to-end coverage showing divergent content is preserved as a conflict copy and both devices converge. |

<sub>Reviews (1): Last reviewed commit: ["Fix issue"](https://github.com/8thpark/geode/commit/e3663c69915127ca9f20890b95e815b6cd253fef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48830459)</sub>

<!-- /greptile_comment -->