### PR TITLE
Storage → Bound every request with a deadline

### DIFF
--- a/src/storage/deadline.test.ts
+++ b/src/storage/deadline.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { timeoutFor, withDeadline } from "./deadline.ts";
+import type { HttpResponse, Transport } from "./storage.ts";
+
+// okResponse is the reply a transport hands back when the request lands, with the fields no test
+// here inspects filled in emptily.
+const okResponse: HttpResponse = {
+  ok: true,
+  status: 200,
+  body: new Uint8Array(),
+  header: () => null,
+};
+
+// probe is the signed request the tests dispatch; its contents are irrelevant to the deadline.
+function probe(): Request {
+  return new Request("https://s3.example.com/vault/k", { method: "GET" });
+}
+
+test("withDeadline: hands back the response when the transport answers in time", async () => {
+  const transport: Transport = async () => okResponse;
+
+  const response = await withDeadline(transport, probe(), 1_000);
+
+  assert.equal(response.status, 200);
+});
+
+test("withDeadline: rejects when the transport never settles", async () => {
+  // The wedge this whole module exists for: requestUrl opens a connection, the provider stalls, and
+  // the promise is never settled by anyone.
+  const transport: Transport = () => new Promise<HttpResponse>(() => {});
+
+  await assert.rejects(withDeadline(transport, probe(), 10), /request timed out after 0s/);
+});
+
+test("withDeadline: passes a transport's own rejection through untouched", async () => {
+  const transport: Transport = async () => {
+    throw new Error("net::ERR_NAME_NOT_RESOLVED");
+  };
+
+  await assert.rejects(withDeadline(transport, probe(), 1_000), /ERR_NAME_NOT_RESOLVED/);
+});
+
+test("withDeadline: a transport that settles late is still handled, not left unhandled", async () => {
+  // Promise.race subscribes to the loser too, so this rejection lands on a handler rather than
+  // taking the process down as an unhandled rejection.
+  let fail: (err: Error) => void = () => {};
+  const transport: Transport = () =>
+    new Promise<HttpResponse>((_, reject) => {
+      fail = reject;
+    });
+
+  await assert.rejects(withDeadline(transport, probe(), 10));
+  fail(new Error("arrived after the deadline"));
+  await new Promise((resolve) => setTimeout(resolve, 10));
+});
+
+test("timeoutFor: scales the budget with the size of the body", () => {
+  const cases: { name: string; bytes: number; want: number }[] = [
+    { name: "a bodyless request gets the base budget", bytes: 0, want: 60_000 },
+    { name: "a small note rounds up to one megabyte", bytes: 4_000, want: 70_000 },
+    { name: "exactly one megabyte stays at one allowance", bytes: 1_000_000, want: 70_000 },
+    { name: "a 10 MB attachment gets ten allowances", bytes: 10_000_000, want: 160_000 },
+    { name: "a 100 MB attachment gets a hundred", bytes: 100_000_000, want: 1_060_000 },
+  ];
+
+  for (const c of cases) {
+    assert.equal(timeoutFor(c.bytes), c.want, c.name);
+  }
+});

--- a/src/storage/deadline.ts
+++ b/src/storage/deadline.ts
@@ -1,0 +1,45 @@
+import type { HttpResponse, Transport } from "./storage.ts";
+
+// BASE_TIMEOUT_MS is the budget every request gets before any allowance for its body: generous
+// enough for a slow provider to answer a listing or a small note, short enough that a stalled
+// connection surfaces as an error the user can act on rather than a sync that never ends.
+const BASE_TIMEOUT_MS = 60_000;
+
+const BYTES_PER_MB = 1_000_000;
+
+// TIMEOUT_MS_PER_MB extends the budget by a megabyte's worth of upload time so a large attachment
+// on a slow uplink is not cut off part way through a transfer that was going to succeed. The
+// implied floor is roughly 0.1 MB/s. A single put carries the whole object today, so the allowance
+// is what keeps big files syncable until they are uploaded in chunks (#55).
+const TIMEOUT_MS_PER_MB = 10_000;
+
+// timeoutFor returns how long a request carrying bytes of body is allowed to take.
+export function timeoutFor(bytes: number): number {
+  return BASE_TIMEOUT_MS + Math.ceil(bytes / BYTES_PER_MB) * TIMEOUT_MS_PER_MB;
+}
+
+// withDeadline sends request through transport and rejects if no response has arrived within ms.
+// Obsidian's requestUrl accepts no AbortSignal, so the losing request cannot be cancelled and keeps
+// running, detached, until the platform gives up on it; settling the promise is the whole point.
+// A dispatch that never settles leaves the plugin's in flight sync guard set forever, so every
+// later sync silently no-ops and the status bar sits on "syncing" until Obsidian restarts.
+export async function withDeadline(
+  transport: Transport,
+  request: Request,
+  ms: number,
+): Promise<HttpResponse> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  // Promise.race subscribes to both promises, so a transport that rejects after the deadline has
+  // already won is still handled and never surfaces as an unhandled rejection.
+  const deadline = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(new Error(`request timed out after ${Math.round(ms / 1000)}s`));
+    }, ms);
+  });
+
+  try {
+    return await Promise.race([transport(request), deadline]);
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/storage/deadline.ts
+++ b/src/storage/deadline.ts
@@ -7,13 +7,15 @@ const BASE_TIMEOUT_MS = 60_000;
 
 const BYTES_PER_MB = 1_000_000;
 
-// TIMEOUT_MS_PER_MB extends the budget by a megabyte's worth of upload time so a large attachment
-// on a slow uplink is not cut off part way through a transfer that was going to succeed. The
-// implied floor is roughly 0.1 MB/s. A single put carries the whole object today, so the allowance
-// is what keeps big files syncable until they are uploaded in chunks (#55).
+// TIMEOUT_MS_PER_MB extends the budget by a megabyte's worth of transfer time so a large attachment
+// on a slow link is not cut off part way through a transfer that was going to succeed, whether it is
+// a put streaming up or a get streaming down. The implied floor is roughly 0.1 MB/s. A single
+// request carries the whole object today, so the allowance is what keeps big files syncable until
+// they move in chunks (#55).
 const TIMEOUT_MS_PER_MB = 10_000;
 
-// timeoutFor returns how long a request carrying bytes of body is allowed to take.
+// timeoutFor returns how long a request moving bytes of body, in either direction, is allowed to
+// take.
 export function timeoutFor(bytes: number): number {
   return BASE_TIMEOUT_MS + Math.ceil(bytes / BYTES_PER_MB) * TIMEOUT_MS_PER_MB;
 }

--- a/src/storage/storage.test.ts
+++ b/src/storage/storage.test.ts
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import { DEFAULT_SETTINGS, type GeodeSettings } from "../settings/settings.ts";
 import {
+  createS3Client,
+  type HttpResponse,
   probeConditionalWrites,
   type StorageClient,
   type Transport,
@@ -217,6 +219,78 @@ test("probeConditionalWrites: a rejecting cleanup does not mask a passing probe"
 
   assert.equal(result.ok, true);
   assert.equal(result.status, "ok");
+});
+
+// deadlineSettings are just enough config for createS3Client to sign and dispatch; no request in
+// these tests ever reaches a network, they only exercise how long the deadline waits.
+const deadlineSettings: GeodeSettings = {
+  ...DEFAULT_SETTINGS,
+  provider: "custom",
+  endpoint: "https://s3.example.com",
+  region: "us-east-1",
+  bucket: "vault",
+  accessKeyId: "AKIA123",
+};
+
+// stallingTransport never settles and resolves dispatched the moment it is called, which is right
+// after the request is signed and the deadline timer is already scheduled. Awaiting dispatched is
+// how a test knows the (mocked) timer exists before it ticks the clock.
+function stallingTransport(): { transport: Transport; dispatched: Promise<void> } {
+  let signal: () => void = () => {};
+  const dispatched = new Promise<void>((resolve) => {
+    signal = resolve;
+  });
+  const transport: Transport = () => {
+    signal();
+    return new Promise<HttpResponse>(() => {});
+  };
+  return { transport, dispatched };
+}
+
+test("getObject: a large object's read deadline scales past the base budget", async (t) => {
+  // A 10 MB read earns 60s base + 10 allowances = 160s. Before the fix it got the bare 60s because
+  // a GET carries no request body, so a slow attachment download was cut off part way through.
+  const { transport, dispatched } = stallingTransport();
+  const client = createS3Client(deadlineSettings, "shh", transport);
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+
+  let settled = false;
+  const read = client.getObject("big.bin", 10_000_000);
+  read.then(() => {
+    settled = true;
+  });
+  await dispatched;
+
+  t.mock.timers.tick(60_000);
+  await Promise.resolve();
+  assert.equal(settled, false, "a 10 MB read must outlast the 60s base budget");
+
+  t.mock.timers.tick(100_000);
+  const result = await read;
+  assert.equal(result.ok, false);
+  assert.match(result.message, /timed out/);
+});
+
+test("getObject: a read with no known size falls back to the base budget", async (t) => {
+  const { transport, dispatched } = stallingTransport();
+  const client = createS3Client(deadlineSettings, "shh", transport);
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+
+  let settled = false;
+  const read = client.getObject("small.md");
+  read.then(() => {
+    settled = true;
+  });
+  await dispatched;
+
+  t.mock.timers.tick(59_999);
+  await Promise.resolve();
+  assert.equal(settled, false, "the base budget has not elapsed yet");
+
+  t.mock.timers.tick(1);
+  const result = await read;
+  assert.equal(result.ok, false);
+  assert.match(result.message, /timed out/);
 });
 
 test("parseListObjectsXml decodes XML entities in object keys", () => {

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -101,7 +101,7 @@ export type ResultStatus =
 // client can satisfy this same shape without changing anything that depends on it.
 export type StorageClient = {
   putObject: (key: string, body: Uint8Array, condition?: PutCondition) => Promise<PutResult>;
-  getObject: (key: string) => Promise<GetResult>;
+  getObject: (key: string, expectedBytes?: number) => Promise<GetResult>;
   copyObject: (sourceKey: string, destKey: string) => Promise<CopyResult>;
   deleteObject: (key: string) => Promise<DeleteResult>;
   listObjects: (prefix?: string) => Promise<ListResult>;
@@ -133,7 +133,7 @@ export function createS3Client(
   return {
     putObject: (key, body, condition) =>
       s3PutObject(client, transport, baseUrl, key, body, condition),
-    getObject: (key) => s3GetObject(client, transport, baseUrl, key),
+    getObject: (key, expectedBytes) => s3GetObject(client, transport, baseUrl, key, expectedBytes),
     copyObject: (sourceKey, destKey) =>
       s3CopyObject(client, transport, baseUrl, settings.bucket, sourceKey, destKey),
     deleteObject: (key) => s3DeleteObject(client, transport, baseUrl, key),
@@ -368,18 +368,27 @@ async function s3DeleteObject(
   return { ok: true, status: "ok", message: "" };
 }
 
-// s3GetObject reads the bytes stored at key.
+// s3GetObject reads the bytes stored at key. expectedBytes is the object's known size from the
+// manifest entry the caller is reading against; it scales the deadline the same way a put's body
+// does, so a large attachment on a slow link is not cut off part way through the download. It
+// defaults to zero for the few reads with no size to hand (the manifest itself), which get the base
+// budget.
 async function s3GetObject(
   client: AwsClient,
   transport: Transport,
   baseUrl: string,
   key: string,
+  expectedBytes = 0,
 ): Promise<GetResult> {
   let response: HttpResponse;
   try {
-    response = await send(client, transport, `${baseUrl}/${encodeKey(key)}`, {
-      method: "GET",
-    });
+    response = await send(
+      client,
+      transport,
+      `${baseUrl}/${encodeKey(key)}`,
+      { method: "GET" },
+      expectedBytes,
+    );
   } catch (err) {
     return {
       ok: false,
@@ -503,8 +512,14 @@ async function send(
   transport: Transport,
   url: string,
   init: RequestInit,
+  expectedResponseBytes = 0,
 ): Promise<HttpResponse> {
   const signed = await client.sign(url, init);
 
-  return withDeadline(transport, signed, timeoutFor(bytesOf(init)));
+  // Only one direction ever carries bytes here: a put streams its body up, a get streams the object
+  // back down, a copy moves nothing through the client. The deadline scales with whichever transfer
+  // is non-empty so neither a large upload nor a large download is cut off mid-flight.
+  const transferBytes = Math.max(bytesOf(init), expectedResponseBytes);
+
+  return withDeadline(transport, signed, timeoutFor(transferBytes));
 }

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -1,5 +1,6 @@
 import { AwsClient } from "aws4fetch";
 import { endpointFor, type GeodeSettings, regionFor } from "../settings/settings.ts";
+import { timeoutFor, withDeadline } from "./deadline.ts";
 import { encodeComponent, encodeKey } from "./encode.ts";
 import { messageFor, statusForHttp } from "./errors.ts";
 import { parseListObjectsXml } from "./xml.ts";
@@ -107,9 +108,11 @@ export type StorageClient = {
 };
 
 // Transport sends an already signed request and returns its response, rejecting only when the
-// request never completes (offline, a failed DNS lookup, a refused connection). The plugin injects
-// a transport backed by Obsidian's requestUrl, which issues a native request and so is never
-// subject to CORS; tests and any non Obsidian caller inject fetchTransport.
+// request never completes (offline, a failed DNS lookup, a refused connection). A transport need
+// not bound its own runtime: send dispatches every request under a deadline, so a stalled
+// connection rejects there rather than hanging forever. The plugin injects a transport backed by
+// Obsidian's requestUrl, which issues a native request and so is never subject to CORS; tests and
+// any non Obsidian caller inject fetchTransport.
 export type Transport = (request: Request) => Promise<HttpResponse>;
 
 // createS3Client returns a StorageClient backed by the S3 compatible endpoint in settings, sending
@@ -243,6 +246,16 @@ export async function testConnection(
   }
 
   return probeConditionalWrites(createS3Client(settings, secretAccessKey, transport));
+}
+
+// bytesOf reports the size of a request body so its deadline can scale with it. Only a put carries
+// one, and it is always the Uint8Array s3PutObject passes through.
+function bytesOf(init: RequestInit): number {
+  if (init.body instanceof Uint8Array) {
+    return init.body.byteLength;
+  }
+
+  return 0;
 }
 
 // conditionHeaders converts a PutCondition into the HTTP precondition headers an S3 compatible
@@ -480,8 +493,11 @@ async function s3PutObject(
 }
 
 // send signs the request with the client's credentials, then hands the signed request to the
-// transport. Signing is environment agnostic (aws4fetch uses WebCrypto); only the transport, and
-// so whether the request is subject to CORS, differs between the plugin runtime and tests.
+// transport under a deadline. Signing is environment agnostic (aws4fetch uses WebCrypto); only the
+// transport, and so whether the request is subject to CORS, differs between the plugin runtime and
+// tests. The deadline is applied here rather than at each transport binding because this is the one
+// dispatch point every storage operation goes through, so no future transport can be injected
+// without one.
 async function send(
   client: AwsClient,
   transport: Transport,
@@ -490,5 +506,5 @@ async function send(
 ): Promise<HttpResponse> {
   const signed = await client.sign(url, init);
 
-  return transport(signed);
+  return withDeadline(transport, signed, timeoutFor(bytesOf(init)));
 }

--- a/src/sync/execute.ts
+++ b/src/sync/execute.ts
@@ -221,7 +221,7 @@ async function executeAction(
     if (drift !== null) {
       return { concurrent: false, failures: [drift] };
     }
-    const result = await storage.getObject(action.path);
+    const result = await storage.getObject(action.path, remoteByPath.get(action.path)?.size);
     if (!result.ok || result.body === null) {
       return failedAction(action.path, result.message, false);
     }
@@ -261,7 +261,7 @@ async function executeAction(
     if (drift !== null) {
       return { concurrent: false, failures: [drift] };
     }
-    const result = await storage.getObject(action.path);
+    const result = await storage.getObject(action.path, remoteByPath.get(action.path)?.size);
     if (!result.ok || result.body === null) {
       return failedAction(action.path, result.message, false);
     }
@@ -314,7 +314,7 @@ async function executeAction(
     return { concurrent, failures };
   }
 
-  const result = await storage.getObject(action.path);
+  const result = await storage.getObject(action.path, remoteByPath.get(action.path)?.size);
   if (!result.ok || result.body === null) {
     failures.push({ path: action.path, message: result.message });
     return { concurrent, failures };
@@ -352,7 +352,7 @@ async function putCondition(
   if (expected === undefined) {
     return { ok: true, kind: "put", condition: { kind: "ifAbsent" } };
   }
-  const fetched = await storage.getObject(path);
+  const fetched = await storage.getObject(path, expected.size);
   if (!fetched.ok || fetched.body === null) {
     if (fetched.status === "not_found") {
       return { ok: true, kind: "put", condition: { kind: "ifAbsent" } };
@@ -407,7 +407,7 @@ async function checkRemoteDrift(
   if (expected === undefined) {
     return null;
   }
-  const fetched = await storage.getObject(path);
+  const fetched = await storage.getObject(path, expected.size);
   if (!fetched.ok || fetched.body === null) {
     if (fetched.status === "not_found") {
       return successfulAction();
@@ -429,7 +429,9 @@ async function remoteMatches(
   bytes: Uint8Array,
   storage: StorageClient,
 ): Promise<boolean> {
-  const fetched = await storage.getObject(path);
+  // The local bytes are the best estimate of the remote object's size for the deadline: a match
+  // means they are identical, and a mismatch still budgets close enough to bound the download.
+  const fetched = await storage.getObject(path, bytes.byteLength);
   if (!fetched.ok || fetched.body === null) {
     return false;
   }

--- a/src/sync/sync.ts
+++ b/src/sync/sync.ts
@@ -330,7 +330,7 @@ async function bucketView(
     if (object.key.startsWith(RESERVED_PREFIX) || !localByPath.has(object.key)) {
       continue;
     }
-    const fetched = await storage.getObject(object.key);
+    const fetched = await storage.getObject(object.key, object.size);
     if (!fetched.ok || fetched.body === null) {
       // Listed a moment ago and gone now means another device deleted it in between, which is
       // exactly the absence the missing manifest already implied; anything else is a real failure


### PR DESCRIPTION
## Problem

- A storage request that opens a connection and then stalls never settles, so a sync never finishes and its in flight guard is never cleared; every later sync silently does nothing until Obsidian is restarted
- Obsidian's `requestUrl` accepts no `AbortSignal` and no timeout, so nothing bounded how long a request could hang
- The status bar sits on `syncing` forever, which reads as busy rather than broken

## Why

- Silence is supposed to mean everything is fine, so a sync that looks busy forever is the worst possible failure mode
- The wedge is permanent for the session and invisible, so a user has no signal that their edits have stopped leaving the device
- A bounded request is the smallest fix that makes the failure recoverable, and leaves retry and offline queueing to their own work

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bounds every storage request with a deadline and scales transfer budgets using known object sizes.
- Adds the reusable deadline calculation and transport race.
- Propagates expected download sizes through storage and sync operations.
- Adds unit coverage for stalled requests and size-scaled GET deadlines.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/storage/deadline.ts | Adds the base and size-scaled timeout calculation plus transport deadline handling. |
| src/storage/storage.ts | Applies deadlines at the shared dispatch boundary and accepts expected response sizes for GET requests. |
| src/sync/execute.ts | Supplies remote or local size estimates to object downloads throughout action execution and drift checks. |
| src/sync/sync.ts | Uses listed object sizes when reading remote survivors during bucket reconstruction. |
| src/storage/deadline.test.ts | Covers successful, rejected, stalled, and late-settling transports plus timeout scaling. |
| src/storage/storage.test.ts | Verifies large known-size reads receive extended deadlines while unknown-size reads use the base budget. |

<sub>Reviews (2): Last reviewed commit: ["Address comments"](https://github.com/8thpark/geode/commit/b93e481b4b6cf456afe84ec70461068746d4afad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48835067)</sub>

**Context used:**

- Knowledge Base — [Storage module](https://app.greptile.com/8thpark/-/custom-context/knowledge-base/8thpark/geode/-/docs/storage-module.md)
- Knowledge Base — [Sync flow](https://app.greptile.com/8thpark/-/custom-context/knowledge-base/8thpark/geode/-/docs/sync-flow.md)

<!-- /greptile_comment -->