### PR TITLE
Snapshot → Bound reads by in-flight bytes

### DIFF
--- a/src/sync/fake.ts
+++ b/src/sync/fake.ts
@@ -55,6 +55,13 @@ export function fakeReader(files: Record<string, string>): Reader {
       }
       return new TextEncoder().encode(content);
     },
+    size: async (path) => {
+      const content = files[path];
+      if (content === undefined) {
+        return 0;
+      }
+      return content.length;
+    },
   };
 }
 

--- a/src/vault/fs.ts
+++ b/src/vault/fs.ts
@@ -62,7 +62,8 @@ export function nodeVault(root: string): { vault: Vault; adapter: DataAdapter } 
       if (!existsSync(abs(root, path))) {
         return null;
       }
-      return { path } as unknown as TFile;
+      const s = statSync(abs(root, path));
+      return { path, stat: { size: s.size, mtime: s.mtimeMs } } as unknown as TFile;
     },
     readBinary: async (file: TFile): Promise<ArrayBuffer> => {
       const buf = await readFile(abs(root, file.path));

--- a/src/vault/obsidian.ts
+++ b/src/vault/obsidian.ts
@@ -70,6 +70,13 @@ export function createObsidianReader(vault: Vault): Reader {
       const buffer = await vault.readBinary(file);
       return new Uint8Array(buffer);
     },
+    size: async (path) => {
+      const file = vault.getFileByPath(path);
+      if (file === null) {
+        return 0;
+      }
+      return file.stat.size;
+    },
   };
 }
 

--- a/src/vault/vault.test.ts
+++ b/src/vault/vault.test.ts
@@ -206,3 +206,57 @@ test("takeSnapshot: concurrency is bounded by the limit", async () => {
   assert.equal(snapshot.files.length, 10);
   assert.ok(peakInflight <= 2, `expected at most 2 concurrent reads, got ${peakInflight}`);
 });
+
+test("takeSnapshot: in-flight bytes are bounded by the byte budget", async () => {
+  const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+  const size = 100;
+  const files: Record<string, { content: string; mtime: number }> = {};
+  for (let i = 0; i < 10; i++) {
+    files[`${i}.md`] = { content: "x".repeat(size), mtime: 1 };
+  }
+
+  let inflightBytes = 0;
+  let peakBytes = 0;
+  const reader: Reader = {
+    fileExists: async (path) => {
+      return files[path] !== undefined;
+    },
+    listFiles: async () => {
+      const list: FileInfo[] = [];
+      for (const [path, file] of Object.entries(files)) {
+        list.push({ path, size: file.content.length, mtime: file.mtime });
+      }
+      return list;
+    },
+    readFile: async (path) => {
+      const file = files[path];
+      if (file === undefined) {
+        throw new Error(`no such file: ${path}`);
+      }
+      inflightBytes += file.content.length;
+      if (inflightBytes > peakBytes) {
+        peakBytes = inflightBytes;
+      }
+      await delay(10);
+      inflightBytes -= file.content.length;
+
+      return new TextEncoder().encode(file.content);
+    },
+  };
+
+  // A high file-count cap so the byte budget, not the worker count, is what binds: a 250 byte
+  // budget admits two 100 byte reads at once and holds the rest until one releases.
+  const snapshot = await takeSnapshot(reader, empty, 10, 250);
+
+  assert.equal(snapshot.files.length, 10);
+  assert.ok(peakBytes <= 250, `expected at most 250 in-flight bytes, got ${peakBytes}`);
+});
+
+test("takeSnapshot: a file larger than the whole byte budget is still read", async () => {
+  const { reader } = fakeReader({ "big.bin": { content: "x".repeat(1000), mtime: 1 } });
+
+  const snapshot = await takeSnapshot(reader, empty, 8, 100);
+
+  assert.equal(snapshot.files.length, 1);
+  assert.equal(snapshot.files[0].path, "big.bin");
+});

--- a/src/vault/vault.test.ts
+++ b/src/vault/vault.test.ts
@@ -39,6 +39,13 @@ function fakeReader(files: Record<string, { content: string; mtime: number }>): 
       }
       return new TextEncoder().encode(file.content);
     },
+    size: async (path) => {
+      const file = files[path];
+      if (file === undefined) {
+        return 0;
+      }
+      return file.content.length;
+    },
   };
   return { reader, readCount: () => reads };
 }
@@ -199,6 +206,13 @@ test("takeSnapshot: concurrency is bounded by the limit", async () => {
       }
       return new TextEncoder().encode(file.content);
     },
+    size: async (path) => {
+      const file = files[path];
+      if (file === undefined) {
+        return 0;
+      }
+      return file.content.length;
+    },
   };
 
   const snapshot = await takeSnapshot(reader, empty, 2);
@@ -241,6 +255,13 @@ test("takeSnapshot: in-flight bytes are bounded by the byte budget", async () =>
       inflightBytes -= file.content.length;
 
       return new TextEncoder().encode(file.content);
+    },
+    size: async (path) => {
+      const file = files[path];
+      if (file === undefined) {
+        return 0;
+      }
+      return file.content.length;
     },
   };
 
@@ -286,6 +307,9 @@ test("takeSnapshot: a small read does not jump a queued large read", async () =>
 
       return new Uint8Array(sizes[path]);
     },
+    size: async (path) => {
+      return sizes[path];
+    },
   };
 
   const snapshot = takeSnapshot(reader, empty, 3, 100);
@@ -300,7 +324,7 @@ test("takeSnapshot: a small read does not jump a queued large read", async () =>
   );
 });
 
-test("takeSnapshot: reads that grow past their listed size complete without wedging", async () => {
+test("takeSnapshot: growth since listing is bounded by the fresh size", async () => {
   const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
   const files: Record<string, { listed: number; actual: number; mtime: number }> = {};
   for (let i = 0; i < 6; i++) {
@@ -313,8 +337,8 @@ test("takeSnapshot: reads that grow past their listed size complete without wedg
     fileExists: async (path) => {
       return files[path] !== undefined;
     },
-    // Every file lists as 10 bytes but reads as 400. Admitting on the listed size then charging the
-    // real size drives the budget negative; the pass must recover from that, not deadlock on it.
+    // Every file lists as 10 bytes but has since grown to 400. Reserving on the listed 10 would let
+    // several read at once and blow past the budget; reserving on the fresh size read now must not.
     listFiles: async () => {
       const list: FileInfo[] = [];
       for (const [path, file] of Object.entries(files)) {
@@ -336,11 +360,19 @@ test("takeSnapshot: reads that grow past their listed size complete without wedg
 
       return new Uint8Array(file.actual);
     },
+    size: async (path) => {
+      const file = files[path];
+      if (file === undefined) {
+        return 0;
+      }
+      return file.actual;
+    },
   };
 
-  const snapshot = await takeSnapshot(reader, empty, 2, 500);
+  // A 500 byte budget with a generous count cap: on the stale listed size of 10 all six would read
+  // at once (2400 bytes resident); on the fresh size of 400 only one fits at a time.
+  const snapshot = await takeSnapshot(reader, empty, 6, 500);
 
-  // The count cap of 2 still bounds residency to two reads even when every listed size was wrong.
   assert.equal(snapshot.files.length, 6);
-  assert.ok(peakBytes <= 800, `expected at most two 400 byte reads resident, got ${peakBytes}`);
+  assert.ok(peakBytes <= 500, `expected in-flight bytes within the 500 budget, got ${peakBytes}`);
 });

--- a/src/vault/vault.test.ts
+++ b/src/vault/vault.test.ts
@@ -260,3 +260,87 @@ test("takeSnapshot: a file larger than the whole byte budget is still read", asy
   assert.equal(snapshot.files.length, 1);
   assert.equal(snapshot.files[0].path, "big.bin");
 });
+
+test("takeSnapshot: a small read does not jump a queued large read", async () => {
+  const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+  let releaseHog: () => void = () => {};
+  const hogGate = new Promise<void>((resolve) => {
+    releaseHog = resolve;
+  });
+  const sizes: Record<string, number> = { hog: 60, big: 60, small: 10 };
+  const started: string[] = [];
+  const reader: Reader = {
+    fileExists: async () => true,
+    // hog fills most of the budget and is held open; big cannot fit and queues; small then arrives
+    // and, with fair admission, must wait behind big rather than slipping into the gap hog left.
+    listFiles: async () => [
+      { path: "hog", size: 60, mtime: 1 },
+      { path: "big", size: 60, mtime: 1 },
+      { path: "small", size: 10, mtime: 1 },
+    ],
+    readFile: async (path) => {
+      started.push(path);
+      if (path === "hog") {
+        await hogGate;
+      }
+
+      return new Uint8Array(sizes[path]);
+    },
+  };
+
+  const snapshot = takeSnapshot(reader, empty, 3, 100);
+  await delay(20);
+  releaseHog();
+  const result = await snapshot;
+
+  assert.equal(result.files.length, 3);
+  assert.ok(
+    started.indexOf("big") < started.indexOf("small"),
+    `expected big to start before small, got ${started.join(",")}`,
+  );
+});
+
+test("takeSnapshot: reads that grow past their listed size complete without wedging", async () => {
+  const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+  const files: Record<string, { listed: number; actual: number; mtime: number }> = {};
+  for (let i = 0; i < 6; i++) {
+    files[`${i}.bin`] = { listed: 10, actual: 400, mtime: 1 };
+  }
+
+  let inflightBytes = 0;
+  let peakBytes = 0;
+  const reader: Reader = {
+    fileExists: async (path) => {
+      return files[path] !== undefined;
+    },
+    // Every file lists as 10 bytes but reads as 400. Admitting on the listed size then charging the
+    // real size drives the budget negative; the pass must recover from that, not deadlock on it.
+    listFiles: async () => {
+      const list: FileInfo[] = [];
+      for (const [path, file] of Object.entries(files)) {
+        list.push({ path, size: file.listed, mtime: file.mtime });
+      }
+      return list;
+    },
+    readFile: async (path) => {
+      const file = files[path];
+      if (file === undefined) {
+        throw new Error(`no such file: ${path}`);
+      }
+      inflightBytes += file.actual;
+      if (inflightBytes > peakBytes) {
+        peakBytes = inflightBytes;
+      }
+      await delay(10);
+      inflightBytes -= file.actual;
+
+      return new Uint8Array(file.actual);
+    },
+  };
+
+  const snapshot = await takeSnapshot(reader, empty, 2, 500);
+
+  // The count cap of 2 still bounds residency to two reads even when every listed size was wrong.
+  assert.equal(snapshot.files.length, 6);
+  assert.ok(peakBytes <= 800, `expected at most two 400 byte reads resident, got ${peakBytes}`);
+});

--- a/src/vault/vault.ts
+++ b/src/vault/vault.ts
@@ -40,13 +40,17 @@ export type FileState = {
   hash: string;
 };
 
-// Reader lists files present in the vault right now, reads their bytes, and answers whether a
-// path currently exists, so a failed read on a present file is never mistaken for absence. The
-// real implementation wraps Obsidian's Vault API (see obsidian.ts); tests use an in-memory fake.
+// Reader lists files present in the vault right now, reads their bytes, answers whether a path
+// currently exists (so a failed read on a present file is never mistaken for absence), and reports
+// a single path's current size on demand — fresher than the listing, so a snapshot can reserve
+// memory against what it is about to read rather than a size that may have grown since. A vanished
+// path reports size 0, letting the read that follows raise the real disappearance error. The real
+// implementation wraps Obsidian's Vault API (see obsidian.ts); tests use an in-memory fake.
 export type Reader = {
   fileExists: (path: string) => Promise<boolean>;
   listFiles: () => Promise<FileInfo[]>;
   readFile: (path: string) => Promise<Uint8Array>;
+  size: (path: string) => Promise<number>;
 };
 
 // Snapshot is every file geode saw the last time it took a snapshot.
@@ -197,9 +201,9 @@ export function isSnapshot(value: unknown): value is Snapshot {
 // rereading content — the same stat gated hashing rsync, git, and Syncthing all use, since mtime
 // and size alone aren't reliable enough to trust as identity, but are cheap enough to skip a
 // rehash when neither has moved. Reads run at most concurrency at a time and hold at most
-// byteBudget bytes of read content across them — reconciled to each file's real size, since a file
-// can grow between listing and read — so neither a vault of many files nor a vault of large
-// attachments drives unbounded memory pressure; a stat gated skip reads nothing and costs neither.
+// byteBudget bytes of read content across them, so neither a vault of many files nor a vault of
+// large attachments drives unbounded memory pressure; a stat gated skip reads nothing and costs
+// neither budget.
 export async function takeSnapshot(
   reader: Reader,
   previous: Snapshot,
@@ -216,9 +220,11 @@ export async function takeSnapshot(
       return known;
     }
 
-    // Reserve the listed size to gain admission, then charge the true size once the bytes are in
-    // hand, so a file that grew since listing counts against the budget for what it actually holds.
-    const hold = await budget.acquire(file.size);
+    // Reserve against the size read now, not the one listed at the start of the pass, so a file
+    // that has since grown cannot slip past the budget on a stale, smaller number; resize then
+    // corrects for any change in the narrow window between this probe and the read itself.
+    const reserved = await reader.size(file.path);
+    const hold = await budget.acquire(reserved);
     try {
       const bytes = await reader.readFile(file.path);
       hold.resize(bytes.length);
@@ -238,12 +244,12 @@ export async function takeSnapshot(
 }
 
 // byteSemaphore caps the bytes held by in-flight readers to budget. acquire reserves the caller's
-// estimate and resolves once it fits, returning a hold whose resize reconciles that estimate to the
+// size and resolves once it fits, returning a hold whose resize reconciles that reservation to the
 // bytes actually read and whose release hands the room back. Waiters are admitted strictly in
 // arrival order — a later small read never jumps a queued large one — and a file larger than the
 // whole budget is admitted only when nothing else is held, so it runs alone rather than blocking
-// forever. The count cap in takeSnapshot remains the hard ceiling: this only tightens the common
-// case where files are far smaller than the budget.
+// forever. The bound holds only as far as the reserved size is honest, which is why takeSnapshot
+// reserves against a freshly read size rather than a stale listed one.
 function byteSemaphore(budget: number): { acquire: (bytes: number) => Promise<Hold> } {
   let available = budget;
   const waiters: Array<{ need: number; wake: () => void }> = [];

--- a/src/vault/vault.ts
+++ b/src/vault/vault.ts
@@ -200,10 +200,14 @@ export function isSnapshot(value: unknown): value is Snapshot {
 // file whose size and mtime both match the previous snapshot reuses that hash instead of
 // rereading content — the same stat gated hashing rsync, git, and Syncthing all use, since mtime
 // and size alone aren't reliable enough to trust as identity, but are cheap enough to skip a
-// rehash when neither has moved. Reads run at most concurrency at a time and hold at most
-// byteBudget bytes of read content across them, so neither a vault of many files nor a vault of
-// large attachments drives unbounded memory pressure; a stat gated skip reads nothing and costs
-// neither budget.
+// rehash when neither has moved. Reads run at most concurrency at a time and reserve against a
+// size read just before each read, so a vault of large attachments serialises rather than piling
+// full files into memory at once; a stat gated skip reads nothing and reserves nothing.
+//
+// The byte bound is not absolute. size and readFile are separate operations, so a file that grows
+// in the window between them still allocates its whole buffer past the reservation, and no whole
+// file reader can prevent that without a streaming read the mobile platform does not offer. The
+// concurrency cap is the hard backstop: at most that many buffers are ever resident at once.
 export async function takeSnapshot(
   reader: Reader,
   previous: Snapshot,

--- a/src/vault/vault.ts
+++ b/src/vault/vault.ts
@@ -6,6 +6,12 @@ import { endpointFor, type GeodeSettings, regionFor } from "../settings/settings
 // version field predates the marker and is this same format, version 1.
 export const SNAPSHOT_VERSION = 1;
 
+// SNAPSHOT_BYTE_BUDGET caps how many bytes takeSnapshot buffers across its concurrent reads, low
+// enough that a vault of large attachments cannot pile eight full files into memory at once and
+// breach a mobile memory ceiling mid snapshot. A single file larger than this is still read (it
+// has to be, there is no streaming read on the platform), just never alongside another.
+const SNAPSHOT_BYTE_BUDGET = 64 * 1024 * 1024;
+
 // Change describes one path whose state differs between two snapshots.
 export type Change = {
   path: string;
@@ -183,31 +189,93 @@ export function isSnapshot(value: unknown): value is Snapshot {
 // file whose size and mtime both match the previous snapshot reuses that hash instead of
 // rereading content — the same stat gated hashing rsync, git, and Syncthing all use, since mtime
 // and size alone aren't reliable enough to trust as identity, but are cheap enough to skip a
-// rehash when neither has moved. Concurrency is bounded by limit to avoid unbounded memory
-// pressure on large vaults.
+// rehash when neither has moved. Reads run at most concurrency at a time and hold at most
+// byteBudget bytes across them, so neither a vault of many files nor a vault of large attachments
+// drives unbounded memory pressure; a stat gated skip reads nothing and so costs neither budget.
 export async function takeSnapshot(
   reader: Reader,
   previous: Snapshot,
   concurrency = 8,
+  byteBudget = SNAPSHOT_BYTE_BUDGET,
 ): Promise<Snapshot> {
   const previousByPath = byPath(previous.files);
   const liveFiles = await reader.listFiles();
+  const budget = byteSemaphore(byteBudget);
 
   const files = await mapWithConcurrency(liveFiles, concurrency, async (file) => {
     const known = previousByPath.get(file.path);
     if (known !== undefined && known.size === file.size && known.mtime === file.mtime) {
       return known;
     }
-    const bytes = await reader.readFile(file.path);
-    return {
-      path: file.path,
-      size: file.size,
-      mtime: file.mtime,
-      hash: await hashBytes(bytes),
-    };
+
+    await budget.acquire(file.size);
+    try {
+      const bytes = await reader.readFile(file.path);
+
+      return {
+        path: file.path,
+        size: file.size,
+        mtime: file.mtime,
+        hash: await hashBytes(bytes),
+      };
+    } finally {
+      budget.release(file.size);
+    }
   });
 
   return { files };
+}
+
+// byteSemaphore caps the bytes held by in-flight readers to budget: acquire resolves once the file
+// fits, release hands the room back and wakes the longest waiter it now satisfies. Waiters wake in
+// arrival order, so an early large read never starves behind later small ones. A file bigger than
+// the whole budget is clamped to it and admitted alone, since blocking it forever would wedge every
+// snapshot it appears in.
+function byteSemaphore(budget: number): {
+  acquire: (bytes: number) => Promise<void>;
+  release: (bytes: number) => void;
+} {
+  let available = budget;
+  const waiters: Array<{ need: number; wake: () => void }> = [];
+
+  function clamp(bytes: number): number {
+    if (bytes > budget) {
+      return budget;
+    }
+
+    return bytes;
+  }
+
+  function drain(): void {
+    while (waiters.length > 0) {
+      const next = waiters[0];
+      if (next.need > available) {
+        return;
+      }
+      waiters.shift();
+      available -= next.need;
+      next.wake();
+    }
+  }
+
+  return {
+    acquire: (bytes: number): Promise<void> => {
+      const need = clamp(bytes);
+      if (need <= available) {
+        available -= need;
+
+        return Promise.resolve();
+      }
+
+      return new Promise<void>((resolve) => {
+        waiters.push({ need, wake: resolve });
+      });
+    },
+    release: (bytes: number): void => {
+      available += clamp(bytes);
+      drain();
+    },
+  };
 }
 
 // mapWithConcurrency runs fn over each item with at most limit concurrent invocations, preserving

--- a/src/vault/vault.ts
+++ b/src/vault/vault.ts
@@ -62,6 +62,13 @@ export type Store = {
   write: (snapshot: Snapshot) => Promise<void>;
 };
 
+// Hold is a live byteSemaphore reservation: resize reconciles it to the bytes actually read, since
+// a file can grow between listing and read, and release returns them to the budget.
+type Hold = {
+  release: () => void;
+  resize: (bytes: number) => void;
+};
+
 // byPath builds a lookup from path to file state, for matching a live file against what the
 // previous snapshot last saw at that same path. Exported for sync.ts, which needs the same
 // lookup to compare a local snapshot against a remote one.
@@ -190,8 +197,9 @@ export function isSnapshot(value: unknown): value is Snapshot {
 // rereading content — the same stat gated hashing rsync, git, and Syncthing all use, since mtime
 // and size alone aren't reliable enough to trust as identity, but are cheap enough to skip a
 // rehash when neither has moved. Reads run at most concurrency at a time and hold at most
-// byteBudget bytes across them, so neither a vault of many files nor a vault of large attachments
-// drives unbounded memory pressure; a stat gated skip reads nothing and so costs neither budget.
+// byteBudget bytes of read content across them — reconciled to each file's real size, since a file
+// can grow between listing and read — so neither a vault of many files nor a vault of large
+// attachments drives unbounded memory pressure; a stat gated skip reads nothing and costs neither.
 export async function takeSnapshot(
   reader: Reader,
   previous: Snapshot,
@@ -208,9 +216,12 @@ export async function takeSnapshot(
       return known;
     }
 
-    await budget.acquire(file.size);
+    // Reserve the listed size to gain admission, then charge the true size once the bytes are in
+    // hand, so a file that grew since listing counts against the budget for what it actually holds.
+    const hold = await budget.acquire(file.size);
     try {
       const bytes = await reader.readFile(file.path);
+      hold.resize(bytes.length);
 
       return {
         path: file.path,
@@ -219,37 +230,37 @@ export async function takeSnapshot(
         hash: await hashBytes(bytes),
       };
     } finally {
-      budget.release(file.size);
+      hold.release();
     }
   });
 
   return { files };
 }
 
-// byteSemaphore caps the bytes held by in-flight readers to budget: acquire resolves once the file
-// fits, release hands the room back and wakes the longest waiter it now satisfies. Waiters wake in
-// arrival order, so an early large read never starves behind later small ones. A file bigger than
-// the whole budget is clamped to it and admitted alone, since blocking it forever would wedge every
-// snapshot it appears in.
-function byteSemaphore(budget: number): {
-  acquire: (bytes: number) => Promise<void>;
-  release: (bytes: number) => void;
-} {
+// byteSemaphore caps the bytes held by in-flight readers to budget. acquire reserves the caller's
+// estimate and resolves once it fits, returning a hold whose resize reconciles that estimate to the
+// bytes actually read and whose release hands the room back. Waiters are admitted strictly in
+// arrival order — a later small read never jumps a queued large one — and a file larger than the
+// whole budget is admitted only when nothing else is held, so it runs alone rather than blocking
+// forever. The count cap in takeSnapshot remains the hard ceiling: this only tightens the common
+// case where files are far smaller than the budget.
+function byteSemaphore(budget: number): { acquire: (bytes: number) => Promise<Hold> } {
   let available = budget;
   const waiters: Array<{ need: number; wake: () => void }> = [];
 
-  function clamp(bytes: number): number {
-    if (bytes > budget) {
-      return budget;
+  function admits(need: number): boolean {
+    if (need <= available) {
+      return true;
     }
 
-    return bytes;
+    // Nothing else is resident, so an oversized read is let through alone rather than wedged.
+    return available === budget;
   }
 
   function drain(): void {
     while (waiters.length > 0) {
       const next = waiters[0];
-      if (next.need > available) {
+      if (!admits(next.need)) {
         return;
       }
       waiters.shift();
@@ -258,22 +269,37 @@ function byteSemaphore(budget: number): {
     }
   }
 
-  return {
-    acquire: (bytes: number): Promise<void> => {
-      const need = clamp(bytes);
-      if (need <= available) {
-        available -= need;
+  function hold(reserved: number): Hold {
+    let held = reserved;
 
-        return Promise.resolve();
+    return {
+      release: (): void => {
+        available += held;
+        held = 0;
+        drain();
+      },
+      resize: (bytes: number): void => {
+        const freed = held - bytes;
+        available += freed;
+        held = bytes;
+        if (freed > 0) {
+          drain();
+        }
+      },
+    };
+  }
+
+  return {
+    acquire: (bytes: number): Promise<Hold> => {
+      if (waiters.length === 0 && admits(bytes)) {
+        available -= bytes;
+
+        return Promise.resolve(hold(bytes));
       }
 
-      return new Promise<void>((resolve) => {
-        waiters.push({ need, wake: resolve });
+      return new Promise<Hold>((resolve) => {
+        waiters.push({ need: bytes, wake: () => resolve(hold(bytes)) });
       });
-    },
-    release: (bytes: number): void => {
-      available += clamp(bytes);
-      drain();
     },
   };
 }


### PR DESCRIPTION
## Problem

- A snapshot reads up to eight files at once and buffers each whole in memory, so concurrency is bounded by file count rather than bytes
- A vault holding several large attachments can therefore pile eight full files into memory at once and breach a mobile memory ceiling, killing the app mid sync

## Why

- Turns the worst case from eight large files resident at once into one, the difference between a sync that survives large attachments and one that is jetsammed
- Keeps to the vision test: we would point this at our own vault of large notes and attachments without fear of a silent mid sync kill

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bounds snapshot read concurrency by estimated in-flight bytes.
- Adds a FIFO byte semaphore while retaining the existing file-count concurrency cap.
- Probes each file’s size immediately before reserving capacity and reading it.
- Adds size support to the Obsidian, filesystem, and fake reader implementations.
- Adds coverage for byte limits, oversized files, FIFO admission, and growth since the initial listing.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because file growth between the size probe and full-buffer read can still defeat the intended memory bound.

The semaphore reserves capacity from `reader.size()`, but `readFile()` allocates the complete buffer before `hold.resize()` accounts for growth, so multiple files changing in that interval can still exceed the configured byte budget.

**Files Needing Attention:** src/vault/vault.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/vault/vault.ts | Adds byte-budgeted snapshot reads and FIFO admission, but the previously reported probe-to-read growth race remains. |
| src/vault/obsidian.ts | Extends the Obsidian reader with file-size metadata used for snapshot reservations. |
| src/vault/fs.ts | Populates filesystem-backed TFile metadata so the new size reader works in the Node harness. |
| src/vault/vault.test.ts | Adds focused tests for byte-bound admission, oversized reads, FIFO ordering, and stale listing sizes. |
| src/sync/fake.ts | Updates the fake reader to satisfy the expanded Reader interface. |

<sub>Reviews (4): Last reviewed commit: ["Address comment"](https://github.com/8thpark/geode/commit/3148d99f39561069aa62a022097016a7966495c9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48844432)</sub>

<!-- /greptile_comment -->