### PR TITLE
Storage → Treat 409 as a conflict, not a generic server error

### DIFF
--- a/src/storage/errors.test.ts
+++ b/src/storage/errors.test.ts
@@ -24,6 +24,7 @@ test("statusForHttp: classifies provider responses", () => {
     { code: 401, want: "auth" },
     { code: 403, want: "auth" },
     { code: 404, want: "not_found" },
+    { code: 409, want: "conflict" },
     { code: 412, want: "conflict" },
     { code: 429, want: "server" },
     { code: 500, want: "server" },

--- a/src/storage/errors.ts
+++ b/src/storage/errors.ts
@@ -31,6 +31,9 @@ function detailFor(err: unknown): string {
 
 // statusForHttp maps HTTP 400 to the non-retryable client status and preserves known domain
 // statuses; unrecognised codes, including 5xx and 429, fall through to retryable server status.
+// 409 joins 412 as "conflict": real Amazon S3 returns 409 (rather than 412) when a conditional
+// write loses a race against another in-flight write to the same key, so both codes mean the
+// same thing to a caller: another writer won, retry the compare-and-swap.
 export function statusForHttp(code: number): ResultStatus {
   if (code === 400) {
     return "client";
@@ -41,7 +44,7 @@ export function statusForHttp(code: number): ResultStatus {
   if (code === 403 || code === 401) {
     return "auth";
   }
-  if (code === 412) {
+  if (code === 412 || code === 409) {
     return "conflict";
   }
   return "server";

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -469,7 +469,8 @@ async function s3ListObjects(
 }
 
 // s3PutObject writes body to key, creating or overwriting it. When condition is set, the write
-// only lands if its precondition still holds; a 412 from the server surfaces as "conflict".
+// only lands if its precondition still holds; a 412, or a 409 from a provider that reports a
+// losing race that way, surfaces as "conflict".
 async function s3PutObject(
   client: AwsClient,
   transport: Transport,


### PR DESCRIPTION
## Problem

- `statusForHttp` only maps HTTP `412` to `conflict`, so a `409` response is classified as a generic `server` error
- Real Amazon S3 returns `409`, not `412`, when a conditional write loses a race against another in flight write to the same key
- Dormant on Cloudflare R2, which only ever returns `412`, but already reachable through the `custom` provider and far more likely once Amazon S3 ships as a first class provider
- A `409` during the connection probe fails setup with a confusing error instead of confirming conditional writes are honoured, and a `409` mid sync reports a generic storage failure instead of the safe "another device synced, sync again" path

## Why

- Keeps setup and sync behaviour correct on providers that report contended conditional writes with `409`, instead of surfacing an unclear generic failure
- Small, targeted fix that closes off a confusing failure mode ahead of Amazon S3 support landing

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR recognizes HTTP 409 responses as storage conflicts alongside 412 responses.
- Updates the centralized HTTP status mapping.
- Adds unit coverage for the new 409 classification.
- Clarifies conditional-write documentation for S3-compatible providers.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The status mapping change consistently routes 409 responses through the existing conflict handling used for contended conditional writes, and the new behavior is covered by a focused unit test.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/storage/errors.ts | Maps HTTP 409 to the existing conflict result status alongside 412. |
| src/storage/errors.test.ts | Adds table-driven coverage confirming that HTTP 409 is classified as a conflict. |
| src/storage/storage.ts | Updates conditional-write documentation to describe both supported conflict response codes. |

<sub>Reviews (1): Last reviewed commit: ["Fix 409 issue"](https://github.com/8thpark/geode/commit/9bcfeaa21c73eef8fceffe1a0f0cc825cda0b012) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49207785)</sub>

<!-- /greptile_comment -->