### PR TITLE
Sync → Hash pushed bytes at upload time

### DIFF
--- a/src/sync/execute.test.ts
+++ b/src/sync/execute.test.ts
@@ -708,7 +708,7 @@ test("executeSyncPlan: conflict with hash mismatch on remote restore is reported
   const remote = snapshot(file("a.md", await hashOf("correct content")));
   const now = Date.parse("2026-07-14T10:00:00.000Z");
 
-  const { failures } = await executeSyncPlan(
+  const { failures, completed, pushedFiles } = await executeSyncPlan(
     [{ kind: "conflict", path: "a.md", deletedSide: "none" }],
     empty,
     reader,
@@ -728,4 +728,15 @@ test("executeSyncPlan: conflict with hash mismatch on remote restore is reported
   assert.equal(files.get("a.md"), undefined);
   assert.equal(files.get(conflictCopyPath("a.md", now)), "local edit");
   assert.equal(objects.get(conflictCopyPath("a.md", now)), "local edit");
+  // The action is reported failed, never completed, but the copy really did land in the bucket:
+  // pushedFiles must still carry it, or the manifest built from it would never know it's there.
+  assert.deepEqual(completed, []);
+  assert.deepEqual(pushedFiles, [
+    {
+      path: conflictCopyPath("a.md", now),
+      size: "local edit".length,
+      mtime: now,
+      hash: await hashOf("local edit"),
+    },
+  ]);
 });

--- a/src/sync/execute.test.ts
+++ b/src/sync/execute.test.ts
@@ -16,7 +16,7 @@ test("executeSyncPlan: push reads the local file and puts it remotely", async ()
   const { writer, files } = fakeLocalWriter();
   const { storage, objects } = fakeStorage();
 
-  const { failures } = await executeSyncPlan(
+  const { failures, pushedFiles } = await executeSyncPlan(
     [{ kind: "push", path: "a.md" }],
     empty,
     reader,
@@ -28,6 +28,38 @@ test("executeSyncPlan: push reads the local file and puts it remotely", async ()
   assert.deepEqual(failures, []);
   assert.equal(objects.get("a.md"), "hello");
   assert.equal(files.size, 0);
+  assert.deepEqual(pushedFiles, [{ path: "a.md", size: 5, mtime: 1, hash: await hashOf("hello") }]);
+});
+
+test("executeSyncPlan: a push records the bytes it actually uploaded, not the pre push snapshot's hash", async () => {
+  // a.md was edited again after the local snapshot this pass planned from, but before the push
+  // read its bytes: the race that used to leave the manifest naming the stale snapshot hash while
+  // the bucket held the newer content, which every other device's verifyFetch then rejected until
+  // this device happened to sync again.
+  const reader = fakeReader({ "a.md": "edited after snapshot" });
+  const local = snapshot(file("a.md", await hashOf("as snapshotted")));
+  const { writer } = fakeLocalWriter();
+  const { storage, objects } = fakeStorage();
+
+  const { failures, pushedFiles } = await executeSyncPlan(
+    [{ kind: "push", path: "a.md" }],
+    local,
+    reader,
+    writer,
+    storage,
+    1,
+  );
+
+  assert.deepEqual(failures, []);
+  assert.equal(objects.get("a.md"), "edited after snapshot");
+  assert.deepEqual(pushedFiles, [
+    {
+      path: "a.md",
+      size: "edited after snapshot".length,
+      mtime: 1,
+      hash: await hashOf("edited after snapshot"),
+    },
+  ]);
 });
 
 test("executeSyncPlan: pushDelete trashes the remote object before removing its live key", async () => {
@@ -302,7 +334,7 @@ test("executeSyncPlan: a conflict renames the local copy, pushes it to storage, 
   const remote = snapshot(file("a.md", await hashOf("remote edit")));
   const now = Date.parse("2026-07-14T10:00:00.000Z");
 
-  const { failures } = await executeSyncPlan(
+  const { failures, pushedFiles } = await executeSyncPlan(
     [{ kind: "conflict", path: "a.md", deletedSide: "none" }],
     empty,
     reader,
@@ -319,6 +351,16 @@ test("executeSyncPlan: a conflict renames the local copy, pushes it to storage, 
   // claims a remote object that doesn't exist, and every other device fails forever trying to
   // pull it.
   assert.equal(objects.get(conflictCopyPath("a.md", now)), "local edit");
+  // Recorded at the hash of the copy's own bytes, the same race a push closes: the conflict copy
+  // is read fresh at execution time, never assumed from a pre-sync snapshot.
+  assert.deepEqual(pushedFiles, [
+    {
+      path: conflictCopyPath("a.md", now),
+      size: "local edit".length,
+      mtime: now,
+      hash: await hashOf("local edit"),
+    },
+  ]);
 });
 
 test("executeSyncPlan: a conflict with nothing local to preserve just pulls the remote version, never reading a deleted local file", async () => {

--- a/src/sync/execute.ts
+++ b/src/sync/execute.ts
@@ -12,15 +12,16 @@ const MANIFEST_MISSING_HASH_MESSAGE = "manifest missing expected hash for this p
 const REMOTE_ETAG_MESSAGE = "remote object has no etag";
 
 // ExecuteResult reports what executeSyncPlan carried out: completed holds every action fully
-// applied, failed the actions that weren't, failures the per file detail of why, and concurrent
-// whether a file precondition proved the remote snapshot stale. failed is carried separately
-// from failures because a conflict's failure can name its copy path rather than the action's own
-// path.
+// applied, failed the actions that weren't, failures the per file detail of why, concurrent
+// whether a file precondition proved the remote snapshot stale, and pushedFiles the FileState of
+// every path a completed action actually wrote to the bucket, hashed from those exact bytes so
+// the manifest built from it never names content the bucket doesn't hold.
 export type ExecuteResult = {
   completed: SyncAction[];
   concurrent: boolean;
   failed: SyncAction[];
   failures: SyncFailure[];
+  pushedFiles: FileState[];
 };
 
 // LocalWriter applies changes decided by a sync to the local vault. The real implementation
@@ -40,6 +41,7 @@ export type SyncFailure = {
 type ActionResult = {
   concurrent: boolean;
   failures: SyncFailure[];
+  pushed: FileState[];
 };
 
 type PutConditionResult =
@@ -67,6 +69,7 @@ export async function executeSyncPlan(
   let concurrent = false;
   const failed: SyncAction[] = [];
   const failures: SyncFailure[] = [];
+  const pushedFiles: FileState[] = [];
   const localByPath = byPath(local.files);
   const remoteByPath = byPath(remote.files);
 
@@ -82,6 +85,9 @@ export async function executeSyncPlan(
     );
     if (actionResult.failures.length === 0) {
       completed.push(action);
+      for (const file of actionResult.pushed) {
+        pushedFiles.push(file);
+      }
       continue;
     }
     failed.push(action);
@@ -96,7 +102,7 @@ export async function executeSyncPlan(
     }
   }
 
-  return { completed, concurrent, failed, failures };
+  return { completed, concurrent, failed, failures, pushedFiles };
 }
 
 // applyLocalWrite runs one localWriter mutation, converting a thrown I/O error into a SyncFailure
@@ -169,10 +175,11 @@ async function executeAction(
     }
     const checked = await putCondition(action.path, bytes, remoteByPath.get(action.path), storage);
     if (!checked.ok) {
-      return { concurrent: checked.concurrent, failures: [checked.failure] };
+      return { concurrent: checked.concurrent, failures: [checked.failure], pushed: [] };
     }
+    const pushed = await pushedFile(action.path, bytes, now);
     if (checked.kind === "done") {
-      return successfulAction();
+      return successfulAction([pushed]);
     }
     const result = await storage.putObject(action.path, bytes, checked.condition);
     if (!result.ok) {
@@ -181,12 +188,12 @@ async function executeAction(
       }
       const matches = await remoteMatches(action.path, bytes, storage);
       if (matches) {
-        return successfulAction();
+        return successfulAction([pushed]);
       }
       return failedAction(action.path, result.message, true);
     }
 
-    return successfulAction();
+    return successfulAction([pushed]);
   }
 
   if (action.kind === "pushDelete") {
@@ -219,7 +226,7 @@ async function executeAction(
   if (action.kind === "pull") {
     const drift = await checkLocalDrift(reader, action.path, localByPath.get(action.path));
     if (drift !== null) {
-      return { concurrent: false, failures: [drift] };
+      return { concurrent: false, failures: [drift], pushed: [] };
     }
     const result = await storage.getObject(action.path, remoteByPath.get(action.path)?.size);
     if (!result.ok || result.body === null) {
@@ -228,13 +235,13 @@ async function executeAction(
     const body = result.body;
     const integrity = await verifyFetch(action.path, body, remoteByPath.get(action.path));
     if (integrity !== null) {
-      return { concurrent: false, failures: [integrity] };
+      return { concurrent: false, failures: [integrity], pushed: [] };
     }
     const failure = await applyLocalWrite(action.path, () =>
       localWriter.writeFile(action.path, body),
     );
     if (failure !== null) {
-      return { concurrent: false, failures: [failure] };
+      return { concurrent: false, failures: [failure], pushed: [] };
     }
 
     return successfulAction();
@@ -243,11 +250,11 @@ async function executeAction(
   if (action.kind === "pullDelete") {
     const drift = await checkLocalDrift(reader, action.path, localByPath.get(action.path));
     if (drift !== null) {
-      return { concurrent: false, failures: [drift] };
+      return { concurrent: false, failures: [drift], pushed: [] };
     }
     const failure = await applyLocalWrite(action.path, () => localWriter.deleteFile(action.path));
     if (failure !== null) {
-      return { concurrent: false, failures: [failure] };
+      return { concurrent: false, failures: [failure], pushed: [] };
     }
 
     return successfulAction();
@@ -259,7 +266,7 @@ async function executeAction(
   if (action.deletedSide === "local") {
     const drift = await checkLocalDrift(reader, action.path, localByPath.get(action.path));
     if (drift !== null) {
-      return { concurrent: false, failures: [drift] };
+      return { concurrent: false, failures: [drift], pushed: [] };
     }
     const result = await storage.getObject(action.path, remoteByPath.get(action.path)?.size);
     if (!result.ok || result.body === null) {
@@ -268,13 +275,13 @@ async function executeAction(
     const body = result.body;
     const integrity = await verifyFetch(action.path, body, remoteByPath.get(action.path));
     if (integrity !== null) {
-      return { concurrent: false, failures: [integrity] };
+      return { concurrent: false, failures: [integrity], pushed: [] };
     }
     const failure = await applyLocalWrite(action.path, () =>
       localWriter.writeFile(action.path, body),
     );
     if (failure !== null) {
-      return { concurrent: false, failures: [failure] };
+      return { concurrent: false, failures: [failure], pushed: [] };
     }
 
     return successfulAction();
@@ -298,32 +305,35 @@ async function executeAction(
     localWriter.renameFile(action.path, copyPath),
   );
   if (renameFailure !== null) {
-    return { concurrent: false, failures: [renameFailure] };
+    return { concurrent: false, failures: [renameFailure], pushed: [] };
   }
   const failures: SyncFailure[] = [];
+  const pushedFiles: FileState[] = [];
   let concurrent = false;
-  const pushed = await storage.putObject(copyPath, localBytes, { kind: "ifAbsent" });
-  if (!pushed.ok) {
-    failures.push({ path: copyPath, message: pushed.message });
-    concurrent = pushed.status === "conflict";
+  const copyResult = await storage.putObject(copyPath, localBytes, { kind: "ifAbsent" });
+  if (!copyResult.ok) {
+    failures.push({ path: copyPath, message: copyResult.message });
+    concurrent = copyResult.status === "conflict";
+  } else {
+    pushedFiles.push(await pushedFile(copyPath, localBytes, now));
   }
 
   // deletedSide "remote": there is nothing at this path remotely to pull, the rename above
   // already vacated it locally, and that is the correct final state, not a failure to report.
   if (action.deletedSide === "remote") {
-    return { concurrent, failures };
+    return { concurrent, failures, pushed: pushedFiles };
   }
 
   const result = await storage.getObject(action.path, remoteByPath.get(action.path)?.size);
   if (!result.ok || result.body === null) {
     failures.push({ path: action.path, message: result.message });
-    return { concurrent, failures };
+    return { concurrent, failures, pushed: pushedFiles };
   }
   const body = result.body;
   const integrity = await verifyFetch(action.path, body, remoteByPath.get(action.path));
   if (integrity !== null) {
     failures.push(integrity);
-    return { concurrent, failures };
+    return { concurrent, failures, pushed: pushedFiles };
   }
   const writeFailure = await applyLocalWrite(action.path, () =>
     localWriter.writeFile(action.path, body),
@@ -332,12 +342,20 @@ async function executeAction(
     failures.push(writeFailure);
   }
 
-  return { concurrent, failures };
+  return { concurrent, failures, pushed: pushedFiles };
 }
 
 // failedAction returns one failed action result with its concurrency classification.
 function failedAction(path: string, message: string, concurrent: boolean): ActionResult {
-  return { concurrent, failures: [{ path, message }] };
+  return { concurrent, failures: [{ path, message }], pushed: [] };
+}
+
+// pushedFile returns the FileState for bytes just written to path in the bucket, hashed fresh
+// from those exact bytes rather than reused from a pre-push snapshot, so a file edited in the
+// window between the snapshot and this read is never recorded in the manifest as content the
+// bucket doesn't actually hold.
+async function pushedFile(path: string, bytes: Uint8Array, mtime: number): Promise<FileState> {
+  return { path, size: bytes.length, mtime, hash: await hashBytes(bytes) };
 }
 
 // putCondition returns the precondition that keeps a file PUT tied to the remote snapshot this
@@ -439,9 +457,10 @@ async function remoteMatches(
   return (await hashBytes(fetched.body)) === (await hashBytes(bytes));
 }
 
-// successfulAction returns the zero failure result for a completed action.
-function successfulAction(): ActionResult {
-  return { concurrent: false, failures: [] };
+// successfulAction returns the zero failure result for a completed action, pushed carrying the
+// FileState of any bytes it wrote to the bucket, empty for an action that pushed nothing.
+function successfulAction(pushed: FileState[] = []): ActionResult {
+  return { concurrent: false, failures: [], pushed };
 }
 
 // localFailureMessage turns whatever a local vault operation threw into a SyncFailure message.

--- a/src/sync/execute.ts
+++ b/src/sync/execute.ts
@@ -14,8 +14,9 @@ const REMOTE_ETAG_MESSAGE = "remote object has no etag";
 // ExecuteResult reports what executeSyncPlan carried out: completed holds every action fully
 // applied, failed the actions that weren't, failures the per file detail of why, concurrent
 // whether a file precondition proved the remote snapshot stale, and pushedFiles the FileState of
-// every path a completed action actually wrote to the bucket, hashed from those exact bytes so
-// the manifest built from it never names content the bucket doesn't hold.
+// every path actually written to the bucket, hashed from those exact bytes. pushedFiles is not
+// limited to completed actions: a conflict's copy push can succeed even when the rest of that
+// same action later fails, and the copy still needs to reach the manifest.
 export type ExecuteResult = {
   completed: SyncAction[];
   concurrent: boolean;
@@ -83,11 +84,14 @@ export async function executeSyncPlan(
       storage,
       now,
     );
+    // A conflict's copy push can succeed even when the rest of the action later fails (the pull,
+    // its integrity check, or the local write), so pushed is gathered regardless of outcome: it
+    // names only bytes actually written to the bucket, never contingent on the action as a whole.
+    for (const file of actionResult.pushed) {
+      pushedFiles.push(file);
+    }
     if (actionResult.failures.length === 0) {
       completed.push(action);
-      for (const file of actionResult.pushed) {
-        pushedFiles.push(file);
-      }
       continue;
     }
     failed.push(action);

--- a/src/sync/plan.test.ts
+++ b/src/sync/plan.test.ts
@@ -110,35 +110,46 @@ test("trashKeyFor: parks the path under the reserved trash prefix behind a times
   );
 });
 
-test("manifestAfterSync: a push records the local snapshot's entry", () => {
-  const local = snapshot(file("a.md", "h2"));
+test("manifestAfterSync: a push records the pushed file's entry", () => {
   const remote = snapshot(file("a.md", "h1"), file("b.md", "h3"));
+  const pushed = [file("a.md", "h2")];
 
-  const result = manifestAfterSync(local, remote, [{ kind: "push", path: "a.md" }], 1);
+  const result = manifestAfterSync(remote, [{ kind: "push", path: "a.md" }], pushed, 1);
 
   assert.deepEqual(result, snapshot(file("a.md", "h2"), file("b.md", "h3")));
 });
 
+test("manifestAfterSync: a push whose bytes drifted past the snapshot still records what was actually uploaded", () => {
+  // The snapshot saw h1, but the file changed again before the push read it, so h2 is what
+  // actually reached the bucket. The manifest must never fall back to the stale snapshot hash
+  // here, or every other device's verifyFetch rejects h2's real bytes until this device syncs
+  // again, indefinitely if it never does.
+  const remote = snapshot(file("a.md", "h1"));
+  const pushed = [file("a.md", "h2")];
+
+  const result = manifestAfterSync(remote, [{ kind: "push", path: "a.md" }], pushed, 1);
+
+  assert.deepEqual(result, snapshot(file("a.md", "h2")));
+});
+
 test("manifestAfterSync: a pushDelete removes the entry", () => {
-  const local = empty;
   const remote = snapshot(file("a.md", "h1"), file("b.md", "h3"));
 
-  const result = manifestAfterSync(local, remote, [{ kind: "pushDelete", path: "a.md" }], 1);
+  const result = manifestAfterSync(remote, [{ kind: "pushDelete", path: "a.md" }], [], 1);
 
   assert.deepEqual(result, snapshot(file("b.md", "h3")));
 });
 
 test("manifestAfterSync: pull and pullDelete leave the bucket, and so the manifest, untouched", () => {
-  const local = empty;
   const remote = snapshot(file("a.md", "h1"));
 
   const result = manifestAfterSync(
-    local,
     remote,
     [
       { kind: "pull", path: "a.md" },
       { kind: "pullDelete", path: "b.md" },
     ],
+    [],
     1,
   );
 
@@ -147,44 +158,42 @@ test("manifestAfterSync: pull and pullDelete leave the bucket, and so the manife
 
 test("manifestAfterSync: a content conflict keeps the remote entry and adds the pushed copy", () => {
   const now = Date.parse("2026-07-14T10:00:00.000Z");
-  const local = snapshot(file("a.md", "h2"));
   const remote = snapshot(file("a.md", "h3"));
+  const copyPath = "a (conflicted copy 2026-07-14T10-00-00-000Z).md";
+  const pushed = [{ ...file("a.md", "h2"), path: copyPath }];
 
   const result = manifestAfterSync(
-    local,
     remote,
     [{ kind: "conflict", path: "a.md", deletedSide: "none" }],
+    pushed,
     now,
   );
 
-  const copyPath = "a (conflicted copy 2026-07-14T10-00-00-000Z).md";
   assert.deepEqual(result, snapshot(file("a.md", "h3"), { ...file("a.md", "h2"), path: copyPath }));
 });
 
 test("manifestAfterSync: a remote deletion conflict records only the pushed copy", () => {
   const now = Date.parse("2026-07-14T10:00:00.000Z");
-  const local = snapshot(file("a.md", "h2"));
-  const remote = empty;
+  const copyPath = "a (conflicted copy 2026-07-14T10-00-00-000Z).md";
+  const pushed = [{ ...file("a.md", "h2"), path: copyPath }];
 
   const result = manifestAfterSync(
-    local,
-    remote,
+    empty,
     [{ kind: "conflict", path: "a.md", deletedSide: "remote" }],
+    pushed,
     now,
   );
 
-  const copyPath = "a (conflicted copy 2026-07-14T10-00-00-000Z).md";
   assert.deepEqual(result, snapshot({ ...file("a.md", "h2"), path: copyPath }));
 });
 
 test("manifestAfterSync: a local deletion conflict pushes nothing, the remote entry stands", () => {
-  const local = empty;
   const remote = snapshot(file("a.md", "h2"));
 
   const result = manifestAfterSync(
-    local,
     remote,
     [{ kind: "conflict", path: "a.md", deletedSide: "local" }],
+    [],
     1,
   );
 

--- a/src/sync/plan.test.ts
+++ b/src/sync/plan.test.ts
@@ -114,7 +114,7 @@ test("manifestAfterSync: a push records the pushed file's entry", () => {
   const remote = snapshot(file("a.md", "h1"), file("b.md", "h3"));
   const pushed = [file("a.md", "h2")];
 
-  const result = manifestAfterSync(remote, [{ kind: "push", path: "a.md" }], pushed, 1);
+  const result = manifestAfterSync(remote, [{ kind: "push", path: "a.md" }], pushed);
 
   assert.deepEqual(result, snapshot(file("a.md", "h2"), file("b.md", "h3")));
 });
@@ -127,7 +127,7 @@ test("manifestAfterSync: a push whose bytes drifted past the snapshot still reco
   const remote = snapshot(file("a.md", "h1"));
   const pushed = [file("a.md", "h2")];
 
-  const result = manifestAfterSync(remote, [{ kind: "push", path: "a.md" }], pushed, 1);
+  const result = manifestAfterSync(remote, [{ kind: "push", path: "a.md" }], pushed);
 
   assert.deepEqual(result, snapshot(file("a.md", "h2")));
 });
@@ -135,9 +135,19 @@ test("manifestAfterSync: a push whose bytes drifted past the snapshot still reco
 test("manifestAfterSync: a pushDelete removes the entry", () => {
   const remote = snapshot(file("a.md", "h1"), file("b.md", "h3"));
 
-  const result = manifestAfterSync(remote, [{ kind: "pushDelete", path: "a.md" }], [], 1);
+  const result = manifestAfterSync(remote, [{ kind: "pushDelete", path: "a.md" }], []);
 
   assert.deepEqual(result, snapshot(file("b.md", "h3")));
+});
+
+test("manifestAfterSync: a failed pushDelete leaves the entry standing", () => {
+  // A pushDelete that never completed (the trash copy or the delete itself failed) must not be
+  // taken as evidence the object is gone: it may still be sitting there untouched.
+  const remote = snapshot(file("a.md", "h1"));
+
+  const result = manifestAfterSync(remote, [], []);
+
+  assert.deepEqual(result, remote);
 });
 
 test("manifestAfterSync: pull and pullDelete leave the bucket, and so the manifest, untouched", () => {
@@ -150,7 +160,6 @@ test("manifestAfterSync: pull and pullDelete leave the bucket, and so the manife
       { kind: "pullDelete", path: "b.md" },
     ],
     [],
-    1,
   );
 
   assert.deepEqual(result, remote);
@@ -159,29 +168,42 @@ test("manifestAfterSync: pull and pullDelete leave the bucket, and so the manife
 test("manifestAfterSync: a content conflict keeps the remote entry and adds the pushed copy", () => {
   const now = Date.parse("2026-07-14T10:00:00.000Z");
   const remote = snapshot(file("a.md", "h3"));
-  const copyPath = "a (conflicted copy 2026-07-14T10-00-00-000Z).md";
+  const copyPath = conflictCopyPath("a.md", now);
   const pushed = [{ ...file("a.md", "h2"), path: copyPath }];
 
   const result = manifestAfterSync(
     remote,
     [{ kind: "conflict", path: "a.md", deletedSide: "none" }],
     pushed,
-    now,
   );
 
   assert.deepEqual(result, snapshot(file("a.md", "h3"), { ...file("a.md", "h2"), path: copyPath }));
 });
 
+test("manifestAfterSync: a conflict's pushed copy is recorded even when the action itself is absent from completed", () => {
+  // Reproduces the gap from #177: a conflict's copy push can succeed while the rest of the action
+  // (the pull, its integrity check, or the local write) later fails, so the action never appears
+  // in completed. The copy still landed in the bucket, and pushed must be enough on its own to
+  // land it in the manifest, or the object sits there forever, invisible to every other device.
+  const now = Date.parse("2026-07-14T10:00:00.000Z");
+  const remote = snapshot(file("a.md", "h1"));
+  const copyPath = conflictCopyPath("a.md", now);
+  const pushed = [{ ...file("a.md", "h2"), path: copyPath }];
+
+  const result = manifestAfterSync(remote, [], pushed);
+
+  assert.deepEqual(result, snapshot(file("a.md", "h1"), { ...file("a.md", "h2"), path: copyPath }));
+});
+
 test("manifestAfterSync: a remote deletion conflict records only the pushed copy", () => {
   const now = Date.parse("2026-07-14T10:00:00.000Z");
-  const copyPath = "a (conflicted copy 2026-07-14T10-00-00-000Z).md";
+  const copyPath = conflictCopyPath("a.md", now);
   const pushed = [{ ...file("a.md", "h2"), path: copyPath }];
 
   const result = manifestAfterSync(
     empty,
     [{ kind: "conflict", path: "a.md", deletedSide: "remote" }],
     pushed,
-    now,
   );
 
   assert.deepEqual(result, snapshot({ ...file("a.md", "h2"), path: copyPath }));
@@ -194,7 +216,6 @@ test("manifestAfterSync: a local deletion conflict pushes nothing, the remote en
     remote,
     [{ kind: "conflict", path: "a.md", deletedSide: "local" }],
     [],
-    1,
   );
 
   assert.deepEqual(result, remote);

--- a/src/sync/plan.ts
+++ b/src/sync/plan.ts
@@ -1,4 +1,10 @@
-import { byPath, type Change, diffSnapshots, type Snapshot } from "../vault/vault.ts";
+import {
+  byPath,
+  type Change,
+  diffSnapshots,
+  type FileState,
+  type Snapshot,
+} from "../vault/vault.ts";
 
 // MANIFEST_KEY is the well known remote object holding the last synced snapshot, geode's source
 // of truth for "what does the other side think exists". Reserved: never treated as a real vault
@@ -40,21 +46,23 @@ export function conflictCopyPath(path: string, now: number): string {
 }
 
 // manifestAfterSync returns the snapshot of what the bucket holds once every action in the plan
-// has succeeded: remote as it was read, minus pushed deletions, plus pushed files and conflict
-// copies recorded at the local snapshot's entry. It is computed from the plan rather than
-// re-snapshotted from disk so the manifest can never record content the bucket does not have
+// has succeeded: remote as it was read, minus pushed deletions, plus every file and conflict copy
+// pushed, each recorded at the hash executeSyncPlan hashed from the bytes it actually uploaded
+// (pushed), never a pre-push snapshot. A file edited in the window between the snapshot and the
+// push's own read would otherwise leave the manifest naming older content than the bucket really
+// holds, which every other device's verifyFetch then rejects as a hash mismatch until this device
+// happens to sync again — indefinitely, if it stays offline. It is computed from the plan rather
+// than re-snapshotted from disk so the manifest can never record content the bucket does not have
 // (#84): a file that changed while the plan ran keeps its bucket entry, and the next sync sees
-// the drift as a local change and pushes it. The one race left, a push whose bytes drifted past
-// the local snapshot before they were read, only ever understates the bucket, and the next pass
-// simply pushes again.
+// the drift as a local change and pushes it.
 export function manifestAfterSync(
-  local: Snapshot,
   remote: Snapshot,
   actions: SyncAction[],
+  pushed: FileState[],
   now: number,
 ): Snapshot {
   const files = byPath(remote.files);
-  const localByPath = byPath(local.files);
+  const pushedByPath = byPath(pushed);
 
   for (const action of actions) {
     // pull and pullDelete only change the local vault; the bucket is untouched.
@@ -66,11 +74,11 @@ export function manifestAfterSync(
       continue;
     }
     if (action.kind === "push") {
-      // A push is only ever planned for a file present in the local snapshot, so the guard is
-      // narrowing, not a real branch; a miss would mean planSync broke that invariant.
-      const pushed = localByPath.get(action.path);
-      if (pushed !== undefined) {
-        files.set(action.path, pushed);
+      // A completed push always reports the file it uploaded, so a miss here would mean
+      // executeSyncPlan broke that invariant.
+      const entry = pushedByPath.get(action.path);
+      if (entry !== undefined) {
+        files.set(action.path, entry);
       }
       continue;
     }
@@ -80,10 +88,10 @@ export function manifestAfterSync(
     if (action.deletedSide === "local") {
       continue;
     }
-    const copied = localByPath.get(action.path);
-    if (copied !== undefined) {
-      const copyPath = conflictCopyPath(action.path, now);
-      files.set(copyPath, { ...copied, path: copyPath });
+    const copyPath = conflictCopyPath(action.path, now);
+    const entry = pushedByPath.get(copyPath);
+    if (entry !== undefined) {
+      files.set(copyPath, entry);
     }
   }
 

--- a/src/sync/plan.ts
+++ b/src/sync/plan.ts
@@ -45,54 +45,30 @@ export function conflictCopyPath(path: string, now: number): string {
   return `${path.slice(0, lastDot)} (conflicted copy ${stamp})${path.slice(lastDot)}`;
 }
 
-// manifestAfterSync returns the snapshot of what the bucket holds once every action in the plan
-// has succeeded: remote as it was read, minus pushed deletions, plus every file and conflict copy
-// pushed, each recorded at the hash executeSyncPlan hashed from the bytes it actually uploaded
-// (pushed), never a pre-push snapshot. A file edited in the window between the snapshot and the
-// push's own read would otherwise leave the manifest naming older content than the bucket really
-// holds, which every other device's verifyFetch then rejects as a hash mismatch until this device
-// happens to sync again — indefinitely, if it stays offline. It is computed from the plan rather
-// than re-snapshotted from disk so the manifest can never record content the bucket does not have
-// (#84): a file that changed while the plan ran keeps its bucket entry, and the next sync sees
-// the drift as a local change and pushes it.
+// manifestAfterSync returns the snapshot of what the bucket holds once the pass has run: remote
+// as it was read, minus every path a completed pushDelete removed, plus an entry for every
+// FileState pushed carries, keyed by the exact bytes executeSyncPlan actually wrote to the bucket
+// rather than a pre-push snapshot or an action's own success. A conflict's copy push can succeed
+// even when the conflict as a whole later fails to restore the remote version (the pull, its
+// integrity check, or the local write can each fail on their own); the copy still landed in the
+// bucket, and pushed carries its entry regardless, so leaving it out here would strand that
+// object, invisible to every other device, until this same device happened to sync again,
+// indefinitely if it never did. completed is only consulted for pushDelete, since a failed
+// pushDelete means the live object may still be there and its entry must stand.
 export function manifestAfterSync(
   remote: Snapshot,
-  actions: SyncAction[],
+  completed: SyncAction[],
   pushed: FileState[],
-  now: number,
 ): Snapshot {
   const files = byPath(remote.files);
-  const pushedByPath = byPath(pushed);
 
-  for (const action of actions) {
-    // pull and pullDelete only change the local vault; the bucket is untouched.
-    if (action.kind === "pull" || action.kind === "pullDelete") {
-      continue;
-    }
+  for (const action of completed) {
     if (action.kind === "pushDelete") {
       files.delete(action.path);
-      continue;
     }
-    if (action.kind === "push") {
-      // A completed push always reports the file it uploaded, so a miss here would mean
-      // executeSyncPlan broke that invariant.
-      const entry = pushedByPath.get(action.path);
-      if (entry !== undefined) {
-        files.set(action.path, entry);
-      }
-      continue;
-    }
-    // conflict: a local deletion pushes nothing, the remote entry stands as is. The other two
-    // sides push the local edit under its conflict copy name; the original path is already
-    // correct in remote (present for deletedSide "none", absent for "remote").
-    if (action.deletedSide === "local") {
-      continue;
-    }
-    const copyPath = conflictCopyPath(action.path, now);
-    const entry = pushedByPath.get(copyPath);
-    if (entry !== undefined) {
-      files.set(copyPath, entry);
-    }
+  }
+  for (const entry of pushed) {
+    files.set(entry.path, entry);
   }
 
   return { files: [...files.values()] };

--- a/src/sync/sync.test.ts
+++ b/src/sync/sync.test.ts
@@ -676,6 +676,37 @@ test("syncOnce: a failed push doesn't discard the progress of the rest of the pa
   assert.equal(bPushes, 1);
 });
 
+test("syncOnce: a conflict's copy push survives into the uploaded manifest even when the restore fails", async () => {
+  // Reproduces #177: the copy push succeeds, but the manifest claims a remote version that isn't
+  // actually there, so the restore's GET 404s and the conflict is reported failed overall. The
+  // copy still landed in the bucket; if the manifest this pass uploads doesn't name it, the object
+  // sits there forever, invisible to every other device, until this same one syncs again.
+  const ancestor = snapshot({ path: "a.md", size: 4, mtime: 1, hash: await hashOf("a v1") });
+  const remoteManifest = encodeSnapshot(
+    snapshot({ path: "a.md", size: 4, mtime: 1, hash: await hashOf("a v2") }),
+  );
+  const { storage, objects } = fakeStorage({ [MANIFEST_KEY]: remoteManifest });
+  const reader = fakeReader({ "a.md": "a local" });
+  const { writer } = fakeLocalWriter();
+  const now = 1;
+  const copyPath = conflictCopyPath("a.md", now);
+
+  const outcome = await syncOnce(ancestor, reader, writer, storage, now);
+
+  assert.ok(!outcome.ok);
+  assert.deepEqual(outcome.failures, [
+    { path: "a.md", message: "Storage rejected the read (404)" },
+  ]);
+  // The copy really did reach the bucket.
+  assert.equal(objects.get(copyPath), "a local");
+  // The uploaded manifest names it, even though the conflict as a whole is reported failed.
+  const manifestBody = objects.get(MANIFEST_KEY);
+  assert.ok(manifestBody !== undefined);
+  const manifest = JSON.parse(manifestBody) as Snapshot;
+  const hashes = new Map(manifest.files.map((f) => [f.path, f.hash]));
+  assert.equal(hashes.get(copyPath), await hashOf("a local"));
+});
+
 test("syncOnce: the failure message counts files, not operation failures", async () => {
   // A conflict whose copy push and pull both fail reports two operation failures for one vault
   // path. The user facing message must count the one file, not the two operations.

--- a/src/sync/sync.ts
+++ b/src/sync/sync.ts
@@ -257,14 +257,15 @@ export async function syncOnce(
   // bucket never received, the edit would then never upload (state.json already agrees with the
   // manifest), and another device could later push the stale bucket copy back over it (#84). The
   // re-snapshot here only refreshes stats, so a mid sync edit keeps its bucket entry and reads as
-  // a local change on the next pass. Only completed actions feed in, so a failed action's path
-  // keeps the entry the bucket really holds; the manifest is uploaded even when some actions
-  // failed, so one bad file never leaves the rest of the pass's pushes invisible to every other
-  // device (#87). Pushed files are recorded at the hash executed.pushedFiles carries, hashed from
-  // the bytes executeSyncPlan actually uploaded rather than this local snapshot, so an edit landing
-  // between the snapshot and the push's own read is never left naming stale content another
-  // device's verifyFetch would then reject until this device happens to sync again.
-  const manifest = manifestAfterSync(remoteView, executed.completed, executed.pushedFiles, now);
+  // a local change on the next pass. completed is only consulted for pushDelete, so a failed
+  // delete's path keeps the entry the bucket really holds; every pushed entry is recorded at the
+  // hash executed.pushedFiles carries, hashed from the bytes executeSyncPlan actually wrote to the
+  // bucket rather than this local snapshot or the owning action's own success, so neither an edit
+  // landing between the snapshot and a push's own read nor a conflict's copy succeeding while its
+  // restore fails ever leaves the manifest silent about content the bucket really holds. The
+  // manifest is uploaded even when some actions failed, so one bad file never leaves the rest of
+  // the pass's pushes invisible to every other device (#87).
+  const manifest = manifestAfterSync(remoteView, executed.completed, executed.pushedFiles);
   const final = adoptLiveStats(manifest, await takeSnapshot(reader, local));
   const manifestBody = new TextEncoder().encode(encodeSnapshot(final));
 

--- a/src/sync/sync.ts
+++ b/src/sync/sync.ts
@@ -260,8 +260,11 @@ export async function syncOnce(
   // a local change on the next pass. Only completed actions feed in, so a failed action's path
   // keeps the entry the bucket really holds; the manifest is uploaded even when some actions
   // failed, so one bad file never leaves the rest of the pass's pushes invisible to every other
-  // device (#87).
-  const manifest = manifestAfterSync(local, remoteView, executed.completed, now);
+  // device (#87). Pushed files are recorded at the hash executed.pushedFiles carries, hashed from
+  // the bytes executeSyncPlan actually uploaded rather than this local snapshot, so an edit landing
+  // between the snapshot and the push's own read is never left naming stale content another
+  // device's verifyFetch would then reject until this device happens to sync again.
+  const manifest = manifestAfterSync(remoteView, executed.completed, executed.pushedFiles, now);
   const final = adoptLiveStats(manifest, await takeSnapshot(reader, local));
   const manifestBody = new TextEncoder().encode(encodeSnapshot(final));
 


### PR DESCRIPTION
## Problem

- A push records the manifest entry from the pre push local snapshot instead of the bytes it actually uploads
- An edit landing between the snapshot and the push's own read leaves the manifest naming content older than what the bucket really holds
- Every other device's `verifyFetch` then rejects the real bytes as a hash mismatch until the origin device happens to sync again, indefinitely if it stays offline

## Why

- Closes a race that could permanently block every other device from ever fetching a file's latest content if the editing device stays offline
- Keeps the manifest's existing guarantee that it never names content the bucket doesn't actually hold

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes uploaded-byte metadata authoritative for manifest updates.
- Hashes successful pushes from the exact bytes passed to storage.
- Retains conflict-copy metadata when the subsequent restore operation fails.
- Builds the remote manifest from completed deletions and recorded successful uploads.
- Adds execution, planning, and orchestration tests for snapshot drift and partial conflict success.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until successful conflict-copy uploads remain discoverable when a later action detects concurrency.

The targeted restore-failure case is fixed, but syncOnce still abandons the entire manifest update on a later concurrent action, leaving any earlier successful conflict-copy object absent from the manifest until the originating device retries.

**Files Needing Attention:** src/sync/sync.ts, src/sync/execute.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/sync/execute.ts | Records exact uploaded-byte metadata and preserves successful conflict-copy uploads across later failures. |
| src/sync/plan.ts | Rebuilds manifest projection around completed deletions and concrete pushed-file metadata. |
| src/sync/sync.ts | Feeds pushed metadata into manifest construction, but the concurrency early return can still strand earlier successful conflict-copy uploads. |
| src/sync/execute.test.ts | Covers exact-byte push metadata and preservation of conflict-copy metadata after restore failure. |
| src/sync/plan.test.ts | Covers manifest projection from pushed metadata and completed deletions. |
| src/sync/sync.test.ts | Verifies that a failed conflict restore still publishes the successfully uploaded copy. |

<sub>Reviews (2): Last reviewed commit: ["Address comment"](https://github.com/8thpark/geode/commit/05a60b7e79a5c4a08dc61ae6e710baaffd63789c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49213954)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Sync flow](https://app.greptile.com/8thpark/-/custom-context/knowledge-base/8thpark/geode/-/docs/sync-flow.md)

<!-- /greptile_comment -->