### PR TITLE
Sync → Flush open editors before reading the vault

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ import {
   createObsidianLocalWriter,
   createObsidianReader,
   createObsidianStore,
+  flushOpenEditors,
 } from "./vault/obsidian";
 import { diffSnapshots, takeSnapshot } from "./vault/vault";
 
@@ -239,6 +240,10 @@ export default class GeodePlugin extends Plugin {
     );
     const reader = createObsidianReader(this.app.vault);
     const localWriter = createObsidianLocalWriter(this.app.vault.adapter);
+
+    // Flush every open editor to disk right before the snapshot below reads the vault, so a file
+    // mid edit is never invisible to this pass's drift checks (see flushOpenEditors).
+    await flushOpenEditors(this.app.workspace);
 
     const previous = await stateStore.read();
     const outcome = await syncOnce(previous, reader, localWriter, storage, Date.now());

--- a/src/vault/obsidian.test.ts
+++ b/src/vault/obsidian.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import type { DataAdapter } from "obsidian";
+import type { DataAdapter, Workspace } from "obsidian";
 import { DEFAULT_SETTINGS } from "../settings/settings.ts";
-import { createObsidianLocalWriter, createObsidianStore } from "./obsidian.ts";
+import { createObsidianLocalWriter, createObsidianStore, flushOpenEditors } from "./obsidian.ts";
 import { fingerprintSettings, type Snapshot } from "./vault.ts";
 
 // fakeAdapter returns a DataAdapter whose exists/read/write operate over one in-memory file map,
@@ -344,4 +344,46 @@ test("createObsidianStore: a state file from a newer format version reads back a
   );
 
   assert.deepEqual(await store.read(), empty);
+});
+
+// fakeWorkspace returns a Workspace whose getLeavesOfType("markdown") yields one leaf per entry in
+// views, enough to drive flushOpenEditors without the rest of the Workspace surface.
+function fakeWorkspace(views: unknown[]): Workspace {
+  const workspace = {
+    getLeavesOfType: (type: string) => {
+      if (type !== "markdown") {
+        return [];
+      }
+      return views.map((view) => ({ view }));
+    },
+  };
+  return workspace as unknown as Workspace;
+}
+
+test("flushOpenEditors: saves every open markdown leaf", async () => {
+  const saved: string[] = [];
+  const views = [{ save: async () => saved.push("a") }, { save: async () => saved.push("b") }];
+
+  await flushOpenEditors(fakeWorkspace(views));
+
+  assert.deepEqual(saved.sort(), ["a", "b"]);
+});
+
+test("flushOpenEditors: a leaf whose view has no save method is skipped, not treated as an error", async () => {
+  const saved: string[] = [];
+  const views = [{ save: async () => saved.push("a") }, { otherMethod: () => {} }];
+
+  await flushOpenEditors(fakeWorkspace(views));
+
+  assert.deepEqual(saved, ["a"]);
+});
+
+test("flushOpenEditors: no open markdown leaves is a no-op", async () => {
+  await flushOpenEditors(fakeWorkspace([]));
+});
+
+test("flushOpenEditors: a save failure rejects rather than being swallowed", async () => {
+  const views = [{ save: async () => Promise.reject(new Error("disk full")) }];
+
+  await assert.rejects(flushOpenEditors(fakeWorkspace(views)), /disk full/);
 });

--- a/src/vault/obsidian.ts
+++ b/src/vault/obsidian.ts
@@ -1,4 +1,4 @@
-import type { DataAdapter, Vault } from "obsidian";
+import type { DataAdapter, Vault, Workspace } from "obsidian";
 import type { GeodeSettings } from "../settings/settings.ts";
 import type { LocalWriter } from "../sync/execute.ts";
 import {
@@ -123,6 +123,28 @@ export function createObsidianStore(
       await adapter.write(statePath, encodeSnapshot(withFingerprint));
     },
   };
+}
+
+// flushOpenEditors forces every open markdown editor to write its current buffer to disk, closing
+// the window where Obsidian's own debounced autosave (TextFileView.requestSave, ~2s) leaves
+// keystrokes sitting in the editor only: checkLocalDrift reads through the Vault API, which only
+// ever sees bytes already on disk, so without this a pull can land on a path whose editor still
+// holds older content, and the next autosave then silently overwrites the pulled bytes with
+// content sync never saw and never checked. Called right before a snapshot is taken, so the
+// residual race is only whatever the user types in the moment between this flush and that read,
+// not however long has passed since Obsidian's own debounce last fired. A leaf whose view carries
+// no save (anything other than a text file view) is skipped rather than treated as an error.
+export async function flushOpenEditors(workspace: Workspace): Promise<void> {
+  const leaves = workspace.getLeavesOfType("markdown");
+  const flushes: Promise<void>[] = [];
+  for (const leaf of leaves) {
+    const view = leaf.view as unknown as { save?: () => Promise<void> };
+    if (typeof view.save !== "function") {
+      continue;
+    }
+    flushes.push(view.save());
+  }
+  await Promise.all(flushes);
 }
 
 // ensureParentDir creates path's parent folder, and any folders above it, before a write that


### PR DESCRIPTION
## Problem

- `checkLocalDrift` reads through the Vault API, which only reflects bytes Obsidian has already written to disk
- Obsidian's own editor autosave debounces roughly two seconds behind the last keystroke, so a file mid edit can hold unsaved bytes the drift check never sees
- A pull landing in that window overwrites the file, and the pending autosave then reintroduces the stale buffer on top of it, silently discarding the pulled content
- The same blind spot lets a conflict rename preserve stale, pre edit bytes as the local side rather than what the editor actually holds

## Why

- Closes a silent data loss path ahead of automatic sync landing, where the exposure window turns from an occasional manual click into a routine background pass
- Relies on the existing drift check machinery rather than adding a parallel safety mechanism, keeping the fix small and the guarantee it depends on unchanged

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR flushes pending content from open Markdown editors before sync reads the vault.
- Adds `flushOpenEditors`, which awaits every save-capable Markdown view and propagates save failures.
- Calls the flush immediately before reading sync state and running `syncOnce`.
- Adds unit coverage for multiple leaves, unsupported views, empty workspaces, and failed saves.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete correctness or security failures identified.

The new flush is awaited before sync begins reading vault content, skips incompatible views, and aborts the sync through its existing error handling if persistence fails.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/main.ts | Integrates the editor flush into the guarded sync lifecycle immediately before vault reads. |
| src/vault/obsidian.ts | Adds a focused helper that awaits save-capable Markdown views and correctly propagates failures. |
| src/vault/obsidian.test.ts | Covers successful, unsupported, empty, and rejected editor-save cases. |

<sub>Reviews (1): Last reviewed commit: ["Fix editor race"](https://github.com/8thpark/geode/commit/9d09914741cd66909c8fad0de919dad01d9d1b8e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49223985)</sub>

**Context used:**

- Knowledge Base — [Plugin entrypoint (src/main.ts)](https://app.greptile.com/8thpark/-/custom-context/knowledge-base/8thpark/geode/-/docs/plugin-entrypoint.md)
- Knowledge Base — [Vault module](https://app.greptile.com/8thpark/-/custom-context/knowledge-base/8thpark/geode/-/docs/vault-module.md)

<!-- /greptile_comment -->