### PR TITLE
Sync → Create every ancestor folder explicitly on pull

### DIFF
--- a/src/vault/obsidian.test.ts
+++ b/src/vault/obsidian.test.ts
@@ -110,6 +110,26 @@ test("createObsidianLocalWriter: a pull is staged to a hidden temp file and rena
   ]);
 });
 
+test("createObsidianLocalWriter: a pull into a path whose ancestors don't exist creates every folder level, not just the immediate parent", async () => {
+  const { adapter, files, ops } = fakeWriterAdapter({
+    renameOverwrites: true,
+    stagedRenameFails: false,
+    writeBinaryFails: false,
+  });
+  const writer = createObsidianLocalWriter(adapter);
+
+  await writer.writeFile("a/b/c/d.md", bytes("pulled content"));
+
+  assert.equal(files.get("a/b/c/d.md"), "pulled content");
+  assert.deepEqual(ops, [
+    "mkdir a",
+    "mkdir a/b",
+    "mkdir a/b/c",
+    "writeBinary a/b/c/.d.md.geode-tmp",
+    "rename a/b/c/.d.md.geode-tmp -> a/b/c/d.md",
+  ]);
+});
+
 test("createObsidianLocalWriter: overwriting an existing file replaces it through the temp rename", async () => {
   const { adapter, files, ops } = fakeWriterAdapter(
     { renameOverwrites: true, stagedRenameFails: false, writeBinaryFails: false },

--- a/src/vault/obsidian.ts
+++ b/src/vault/obsidian.ts
@@ -148,17 +148,23 @@ export async function flushOpenEditors(workspace: Workspace): Promise<void> {
 }
 
 // ensureParentDir creates path's parent folder, and any folders above it, before a write that
-// might land somewhere the vault has never had a file before. mkdir is assumed to create
-// intermediate folders the same way Obsidian's own folder creation does.
+// might land somewhere the vault has never had a file before. Each folder level is created in
+// turn rather than left to a single adapter.mkdir call on the deepest one, since Obsidian's public
+// API leaves whether mkdir recurses through missing intermediate folders undocumented, and mobile
+// adapters (Capacitor) are not known to match desktop's behavior here.
 async function ensureParentDir(adapter: DataAdapter, path: string): Promise<void> {
   const lastSlash = path.lastIndexOf("/");
   if (lastSlash === -1) {
     return;
   }
   const dir = path.slice(0, lastSlash);
-  const exists = await adapter.exists(dir);
-  if (!exists) {
-    await adapter.mkdir(dir);
+  let current = "";
+  for (const segment of dir.split("/")) {
+    current = current === "" ? segment : `${current}/${segment}`;
+    const exists = await adapter.exists(current);
+    if (!exists) {
+      await adapter.mkdir(current);
+    }
   }
 }
 


### PR DESCRIPTION
## Problem

Pulling a file into a path whose ancestor folders don't exist yet relied on a single `adapter.mkdir` call on the immediate parent folder, assuming it recurses through missing intermediate folders the same way Obsidian's own folder creation does; that assumption is undocumented in Obsidian's public adapter API, and the mobile (Capacitor) adapter's behaviour here has never been verified

## Why

- Removes reliance on unverified adapter behaviour that a nested first time pull could hit on mobile
- Keeps directory creation testable without a fake that quietly papers over the assumption with its own recursive `mkdir`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes nested pull writes create each missing ancestor directory explicitly before staging the file.

- Updates `ensureParentDir` to check and create directory prefixes from shallowest to deepest.
- Adds a writer test verifying the ordered creation of all ancestor folders for a deeply nested path.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or security issues identified.

Current writer callers supply canonical vault-relative paths, writes execute sequentially within a sync pass, and the changed directory creation sequence preserves the existing staged-write behavior while removing reliance on recursive mkdir semantics.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/vault/obsidian.ts | Replaces reliance on recursive adapter mkdir behavior with explicit, ordered ancestor creation; no actionable defect was found for the canonical vault-relative paths used by current callers. |
| src/vault/obsidian.test.ts | Adds focused coverage confirming that every missing ancestor is created before the temporary file is written and renamed. |

<sub>Reviews (1): Last reviewed commit: ["Fix mkdir"](https://github.com/8thpark/geode/commit/6e5156577bf6441ca73e895e7fc8056940f4bd08) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49226011)</sub>

**Context used:**

- Knowledge Base — [Vault module](https://app.greptile.com/8thpark/-/custom-context/knowledge-base/8thpark/geode/-/docs/vault-module.md)

<!-- /greptile_comment -->