### PR TITLE
Storage → Fail loudly on listing XML this parser cannot recognize

### DIFF
--- a/src/storage/storage.test.ts
+++ b/src/storage/storage.test.ts
@@ -309,11 +309,14 @@ test("parseListObjectsXml decodes XML entities in object keys", () => {
 </ListBucketResult>`;
 
   assert.deepEqual(parseListObjectsXml(xml), {
-    objects: [
-      { key: "notes/Foo & Bar (draft).md", size: 12, lastModified: "2026-07-13T00:00:00.000Z" },
-      { key: "notes/2 < 3 😀.md", size: 34, lastModified: "2026-07-13T00:01:00.000Z" },
-    ],
-    nextContinuationToken: undefined,
+    ok: true,
+    page: {
+      objects: [
+        { key: "notes/Foo & Bar (draft).md", size: 12, lastModified: "2026-07-13T00:00:00.000Z" },
+        { key: "notes/2 < 3 😀.md", size: 34, lastModified: "2026-07-13T00:01:00.000Z" },
+      ],
+      nextContinuationToken: undefined,
+    },
   });
 });
 
@@ -329,9 +332,10 @@ test("parseListObjectsXml surfaces the continuation token when the listing is tr
   <NextContinuationToken>1ueGcxLPRx1Tr/XYExHnhbYLgveDs2J/wm36Hy4vbOwM=</NextContinuationToken>
 </ListBucketResult>`;
 
-  const page = parseListObjectsXml(xml);
-  assert.equal(page.nextContinuationToken, "1ueGcxLPRx1Tr/XYExHnhbYLgveDs2J/wm36Hy4vbOwM=");
-  assert.equal(page.objects.length, 1);
+  const result = parseListObjectsXml(xml);
+  assert.ok(result.ok);
+  assert.equal(result.page.nextContinuationToken, "1ueGcxLPRx1Tr/XYExHnhbYLgveDs2J/wm36Hy4vbOwM=");
+  assert.equal(result.page.objects.length, 1);
 });
 
 test("parseListObjectsXml ignores the token on the final page", () => {
@@ -345,5 +349,50 @@ test("parseListObjectsXml ignores the token on the final page", () => {
   <IsTruncated>false</IsTruncated>
 </ListBucketResult>`;
 
-  assert.equal(parseListObjectsXml(xml).nextContinuationToken, undefined);
+  const result = parseListObjectsXml(xml);
+  assert.ok(result.ok);
+  assert.equal(result.page.nextContinuationToken, undefined);
+});
+
+test("parseListObjectsXml treats a bare IsTruncated marker as an empty bucket", () => {
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult>
+  <IsTruncated>false</IsTruncated>
+</ListBucketResult>`;
+
+  assert.deepEqual(parseListObjectsXml(xml), {
+    ok: true,
+    page: { objects: [], nextContinuationToken: undefined },
+  });
+});
+
+test("parseListObjectsXml treats a bare KeyCount marker as an empty bucket", () => {
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult>
+  <KeyCount>0</KeyCount>
+</ListBucketResult>`;
+
+  assert.deepEqual(parseListObjectsXml(xml), {
+    ok: true,
+    page: { objects: [], nextContinuationToken: undefined },
+  });
+});
+
+test("parseListObjectsXml fails loudly on a body with no recognizable listing markers", () => {
+  // A provider whose response uses a namespace prefix on <Contents> (or attributes this parser's
+  // bare-tag regex doesn't match) would otherwise parse to zero objects, indistinguishable from a
+  // genuinely empty bucket. That would let a first sync proceed and silently orphan every file the
+  // listing failed to surface (#109), so this shape must be refused rather than guessed at.
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <ns:Contents>
+    <ns:Key>notes/a.md</ns:Key>
+  </ns:Contents>
+</ListBucketResult>`;
+
+  assert.deepEqual(parseListObjectsXml(xml), {
+    ok: false,
+    message:
+      "listing response has no <Contents>, <KeyCount>, or <IsTruncated>; unrecognized XML shape",
+  });
 });

--- a/src/storage/storage.test.ts
+++ b/src/storage/storage.test.ts
@@ -392,7 +392,38 @@ test("parseListObjectsXml fails loudly on a body with no recognizable listing ma
 
   assert.deepEqual(parseListObjectsXml(xml), {
     ok: false,
-    message:
-      "listing response has no <Contents>, <KeyCount>, or <IsTruncated>; unrecognized XML shape",
+    message: "listing response XML shape is unrecognized; refusing to guess it is empty",
+  });
+});
+
+test("parseListObjectsXml fails on an attribute-bearing Contents despite IsTruncated", () => {
+  // A namespace prefix isn't the only way a provider can dodge the strict <Contents> pattern: an
+  // attribute on the opening tag does too, and unlike a wholly unrecognized body, the rest of the
+  // response can still look completely ordinary, IsTruncated included. Checking only for
+  // IsTruncated's presence would wave this through as an empty bucket and orphan the entry it
+  // dropped, so the parser must instead notice that a Contents-shaped tag existed but never made
+  // it into the parsed objects.
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult>
+  <Contents encoding-type="url">
+    <Key>notes/a.md</Key>
+    <LastModified>2026-07-13T00:00:00.000Z</LastModified>
+    <Size>1</Size>
+  </Contents>
+  <IsTruncated>false</IsTruncated>
+</ListBucketResult>`;
+
+  assert.deepEqual(parseListObjectsXml(xml), {
+    ok: false,
+    message: "listing response XML shape is unrecognized; refusing to guess it is empty",
+  });
+});
+
+test("parseListObjectsXml fails loudly on a blank body", () => {
+  // A 200 response with an empty body is never a genuine ListObjectsV2 response, even for an
+  // empty bucket: the real thing is always a full XML document carrying at least IsTruncated.
+  assert.deepEqual(parseListObjectsXml(""), {
+    ok: false,
+    message: "listing response XML shape is unrecognized; refusing to guess it is empty",
   });
 });

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -460,9 +460,17 @@ async function s3ListObjects(
       };
     }
 
-    const page = parseListObjectsXml(new TextDecoder().decode(response.body));
-    objects.push(...page.objects);
-    continuationToken = page.nextContinuationToken;
+    const parsed = parseListObjectsXml(new TextDecoder().decode(response.body));
+    if (!parsed.ok) {
+      return {
+        ok: false,
+        status: "server",
+        message: parsed.message,
+        objects: [],
+      };
+    }
+    objects.push(...parsed.page.objects);
+    continuationToken = parsed.page.nextContinuationToken;
   } while (continuationToken !== undefined);
 
   return { ok: true, status: "ok", message: "", objects };

--- a/src/storage/xml.ts
+++ b/src/storage/xml.ts
@@ -1,18 +1,22 @@
 import type { ObjectMeta } from "./storage.ts";
 
-// ListPage is one page of a ListObjectsV2 response: the objects it carries and, when the listing
-// is truncated, the token that fetches the next page. nextContinuationToken is undefined once the
-// listing is complete.
+// ListPage is one successfully parsed page of a ListObjectsV2 response: the objects it carries
+// and, when the listing is truncated, the token that fetches the next page.
+// nextContinuationToken is undefined once the listing is complete.
 export type ListPage = {
   objects: ObjectMeta[];
   nextContinuationToken: string | undefined;
 };
 
+// ParsedListPage is the outcome of parsing a ListObjectsV2 XML response. ok is false when the
+// body doesn't match the shape this parser understands.
+export type ParsedListPage = { ok: true; page: ListPage } | { ok: false; message: string };
+
 // parseListObjectsXml extracts object keys, sizes, and last-modified timestamps from an S3
 // ListObjectsV2 XML response, along with the continuation token when the listing is truncated.
 // Regex rather than a DOM parser: the schema is narrow and stable, and DOMParser isn't available
 // outside a browser-like runtime, which would make this untestable under node:test.
-export function parseListObjectsXml(xml: string): ListPage {
+export function parseListObjectsXml(xml: string): ParsedListPage {
   const objects: ObjectMeta[] = [];
   const contentsPattern = /<Contents>([\s\S]*?)<\/Contents>/g;
   let match = contentsPattern.exec(xml);
@@ -27,6 +31,25 @@ export function parseListObjectsXml(xml: string): ListPage {
     match = contentsPattern.exec(xml);
   }
 
+  // A response with zero <Contents> matches is indistinguishable from a genuinely empty bucket,
+  // unless it's neither: an empty ListObjectsV2 response always still carries <KeyCount> or
+  // <IsTruncated>, so a body missing both too is a shape this parser doesn't understand (a
+  // namespace prefix or an attribute on <Contents> that the bare-tag regex above never matches).
+  // Returning an empty page for that would look exactly like an empty bucket, which would let a
+  // first sync proceed and silently orphan every file the listing failed to surface (#109).
+  if (
+    objects.length === 0 &&
+    xml.trim() !== "" &&
+    !hasTag(xml, "KeyCount") &&
+    !hasTag(xml, "IsTruncated")
+  ) {
+    return {
+      ok: false,
+      message:
+        "listing response has no <Contents>, <KeyCount>, or <IsTruncated>; unrecognized XML shape",
+    };
+  }
+
   // A token is only meaningful when IsTruncated is true. Guarding on both avoids looping forever
   // if a provider echoes a stale token on the final page.
   const truncated = fieldFrom(xml, "IsTruncated") === "true";
@@ -36,8 +59,8 @@ export function parseListObjectsXml(xml: string): ListPage {
     nextContinuationToken = token;
   }
   return {
-    objects,
-    nextContinuationToken,
+    ok: true,
+    page: { objects, nextContinuationToken },
   };
 }
 
@@ -88,4 +111,9 @@ function fieldFrom(block: string, tag: string): string {
     return "";
   }
   return found[1];
+}
+
+// hasTag reports whether a bare opening <tag> is present anywhere in the XML.
+function hasTag(xml: string, tag: string): boolean {
+  return new RegExp(`<${tag}>`).test(xml);
 }

--- a/src/storage/xml.ts
+++ b/src/storage/xml.ts
@@ -31,22 +31,20 @@ export function parseListObjectsXml(xml: string): ParsedListPage {
     match = contentsPattern.exec(xml);
   }
 
-  // A response with zero <Contents> matches is indistinguishable from a genuinely empty bucket,
-  // unless it's neither: an empty ListObjectsV2 response always still carries <KeyCount> or
-  // <IsTruncated>, so a body missing both too is a shape this parser doesn't understand (a
-  // namespace prefix or an attribute on <Contents> that the bare-tag regex above never matches).
-  // Returning an empty page for that would look exactly like an empty bucket, which would let a
-  // first sync proceed and silently orphan every file the listing failed to surface (#109).
-  if (
-    objects.length === 0 &&
-    xml.trim() !== "" &&
-    !hasTag(xml, "KeyCount") &&
-    !hasTag(xml, "IsTruncated")
-  ) {
+  // looseContentsCount counts every opening tag that looks like a Contents element (a namespace
+  // prefix or trailing attributes included), not just the exact bare form the strict pattern
+  // above requires. A mismatch against what actually got parsed means some entries were dropped
+  // silently: a provider whose <Contents> carries an attribute, or is namespace prefixed, still
+  // reports IsTruncated or KeyCount normally, so checking only for those markers' presence (as an
+  // earlier version of this guard did) would still wave a listing like that through as an empty
+  // bucket. A first sync over that result would then push local files and write a manifest that
+  // never mentions the entries the parser silently dropped, orphaning them forever (#109).
+  const looseContentsCount = looseTagCount(xml, "Contents");
+  const recognizable = hasTag(xml, "KeyCount") || hasTag(xml, "IsTruncated");
+  if (looseContentsCount !== objects.length || (objects.length === 0 && !recognizable)) {
     return {
       ok: false,
-      message:
-        "listing response has no <Contents>, <KeyCount>, or <IsTruncated>; unrecognized XML shape",
+      message: "listing response XML shape is unrecognized; refusing to guess it is empty",
     };
   }
 
@@ -116,4 +114,16 @@ function fieldFrom(block: string, tag: string): string {
 // hasTag reports whether a bare opening <tag> is present anywhere in the XML.
 function hasTag(xml: string, tag: string): boolean {
   return new RegExp(`<${tag}>`).test(xml);
+}
+
+// looseTagCount counts opening tags matching the given local name anywhere in the XML, regardless
+// of a namespace prefix or trailing attributes, deliberately looser than the exact <tag> form
+// fieldFrom and the Contents block pattern require.
+function looseTagCount(xml: string, tag: string): number {
+  const pattern = new RegExp(`<(?!/)[\\w:-]*${tag}\\b`, "g");
+  const found = xml.match(pattern);
+  if (found === null) {
+    return 0;
+  }
+  return found.length;
 }


### PR DESCRIPTION
## Problem

`parseListObjectsXml` only matches bare `<Contents>` tags with no attributes and no namespace prefix. A provider whose listing response does not match that exact shape parses to zero objects, which is indistinguishable from a genuinely empty bucket. That silently defeats the first sync orphan check, letting a sync proceed and strand files that already exist in the bucket.

## Why

- Keeps the existing first sync orphan refusal effective against providers whose XML does not match this parser's assumptions
- Failing loudly is safer than guessing, since treating an unrecognized listing as empty can strand remote files with nothing pointing at them

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR now rejects unrecognized ListObjectsV2 XML instead of interpreting it as an empty bucket.
- Adds structural checks for unsupported `<Contents>` forms and blank responses.
- Propagates parsing failures through the storage listing result.
- Adds coverage for valid empty listings and previously missed malformed response shapes.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The previously reported attribute-bearing Contents and blank-response paths now return parsing failures, and no blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/storage/xml.ts | Adds a discriminated parse result and rejects listing responses whose detected entries do not match those parsed. |
| src/storage/storage.ts | Propagates unrecognized listing XML as a server failure rather than returning an empty object list. |
| src/storage/storage.test.ts | Updates parser expectations and covers empty, blank, namespace-prefixed, and attribute-bearing listing responses. |

<sub>Reviews (2): Last reviewed commit: ["Address comment"](https://github.com/8thpark/geode/commit/e671d6eef40d9c1fa8bd50cade7bc86c34f8be6a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49229188)</sub>

**Context used:**

- Knowledge Base — [Storage module](https://app.greptile.com/8thpark/-/custom-context/knowledge-base/8thpark/geode/-/docs/storage-module.md)

<!-- /greptile_comment -->