### PR TITLE
Storage → Move to content addressed blob storage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,10 @@ With `npm run dev` running:
      "mc alias set local http://minio:9000 geodedev geodedev && mc ls local/geode-dev"
    ```
 
+   Object keys are content addressed (`.geode/blobs/<sha256>`), not vault paths, so this listing
+   won't show your note names; `.geode/manifest.json` is what maps a path to the blob holding its
+   content.
+
 Obsidian's plugin data file (`data.json`), geode's own vault state file (`state.json`), and its
 log file (`geode.log`), all of which land at the repo root because the dev vault symlinks the
 whole repo in as the plugin folder, are gitignored and should never be committed. The MinIO

--- a/docs/similar-projects.md
+++ b/docs/similar-projects.md
@@ -6,6 +6,8 @@
 - [Remote Sync](#remote-sync)
 - [MCP](#mcp)
 - [API](#api)
+- [Real Time Collaboration](#real-time-collaboration)
+- [Encryption](#encryption)
 - [Prior Art](#prior-art)
 
 Allowing for seamless and secure interaction with your Obsidian vault remotely from multiple device
@@ -30,6 +32,7 @@ below.
 - [Cloud Sync](https://github.com/ai-bytedance/obsidian-cloud-sync)
 - [Fast Note Sync](https://github.com/haierkeys/obsidian-fast-note-sync)
 - [Sync Share](https://github.com/Alt-er/obsidian-sync-share)
+- [Nutstore Sync](https://github.com/nutstore/obsidian-nutstore-sync)
 
 ## MCP
 
@@ -38,10 +41,23 @@ below.
 - [MCP Obsidian](https://github.com/MarkusPfundstein/mcp-obsidian)
 - [MCP Vault](https://github.com/bitbonsai/mcpvault)
 - [Vault as MCP](https://github.com/ebullient/obsidian-vault-mcp)
+- [MCP Server](https://github.com/cyanheads/obsidian-mcp-server)
 
 ## API
 
 - [Local REST API](https://github.com/coddingtonbear/obsidian-local-rest-api)
+
+## Real Time Collaboration
+
+- [Relay](https://github.com/no-instructions/relay)
+- [Peerdraft](https://github.com/peerdraft/obsidian-plugin)
+
+## Encryption
+
+- [Vault Encrypt](https://github.com/pluppen/obsidian-vault-encrypt-plugin)
+- [Crypt It](https://github.com/remotely-save/crypt-it)
+- [Meld Encrypt](https://github.com/meld-cp/obsidian-encrypt)
+- [gpgCrypt](https://github.com/tejado/obsidian-gpgCrypt)
 
 ## Prior Art
 

--- a/docs/similar-projects.md
+++ b/docs/similar-projects.md
@@ -6,6 +6,7 @@
 - [Remote Sync](#remote-sync)
 - [MCP](#mcp)
 - [API](#api)
+- [Prior Art](#prior-art)
 
 Allowing for seamless and secure interaction with your Obsidian vault remotely from multiple device
 and tools. There are similar projects in the space, that we can learn from, which are outlined
@@ -25,6 +26,10 @@ below.
 - [GitHub Gitless Sync](https://github.com/silvanocerza/github-gitless-sync)
 - [YAOS](https://github.com/kavinsood/yaos)
 - [BYOC](https://github.com/winters27/obsidian-byoc)
+- [AnySocket Sync](https://github.com/lynxaegon/obsidian-anysocket-sync)
+- [Cloud Sync](https://github.com/ai-bytedance/obsidian-cloud-sync)
+- [Fast Note Sync](https://github.com/haierkeys/obsidian-fast-note-sync)
+- [Sync Share](https://github.com/Alt-er/obsidian-sync-share)
 
 ## MCP
 
@@ -37,3 +42,15 @@ below.
 ## API
 
 - [Local REST API](https://github.com/coddingtonbear/obsidian-local-rest-api)
+
+## Prior Art
+
+- [Restic](https://github.com/restic/restic)
+- [Rclone (Bisync)](https://rclone.org/bisync)
+- [Cryptomator](https://docs.cryptomator.org/security/vault)
+- [Unison](https://github.com/bcpierce00/unison)
+- [Syncthing](https://docs.syncthing.net/users/syncing.html)
+- [Joplin](https://joplinapp.org/help)
+- [Seafile](https://seafile.com/en/home)
+- [Age](https://github.com/FiloSottile/age)
+- [Git Annex](https://git-annex.branchable.com)

--- a/src/storage/storage.itest.ts
+++ b/src/storage/storage.itest.ts
@@ -113,51 +113,35 @@ test("deleteObject removes an object", async () => {
   assert.equal(getResult.status, "not_found");
 });
 
-test("copyObject duplicates the bytes under a new key, leaving the source intact", async () => {
+test("headObject reports ok for an existing key without returning a body", async () => {
   const client = createS3Client(liveSettings, SECRET_ACCESS_KEY, fetchTransport);
-  const body = new TextEncoder().encode("copy me");
-  await client.putObject("copy-test/source.md", body);
+  const key = "head-test/exists.md";
+  await client.putObject(key, new TextEncoder().encode("present"));
 
-  const copyResult = await client.copyObject("copy-test/source.md", "copy-test/dest.md");
-  assert.equal(copyResult.ok, true);
-  assert.equal(copyResult.status, "ok");
-
-  const dest = await client.getObject("copy-test/dest.md");
-  assert.equal(dest.ok, true);
-  assert.deepEqual(dest.body, body);
-  const source = await client.getObject("copy-test/source.md");
-  assert.equal(source.ok, true);
-
-  await client.deleteObject("copy-test/source.md");
-  await client.deleteObject("copy-test/dest.md");
-});
-
-test("copyObject round-trips a source key with SigV4-sensitive characters", async () => {
-  const client = createS3Client(liveSettings, SECRET_ACCESS_KEY, fetchTransport);
-  const key = "copy-test/Don't stop! (really).md";
-  const body = new TextEncoder().encode("tricky source");
-  await client.putObject(key, body);
-
-  const copyResult = await client.copyObject(key, "copy-test/tricky-dest.md");
-  assert.equal(copyResult.ok, true);
-
-  const dest = await client.getObject("copy-test/tricky-dest.md");
-  assert.equal(dest.ok, true);
-  assert.deepEqual(dest.body, body);
+  const headResult = await client.headObject(key);
+  assert.equal(headResult.ok, true);
+  assert.equal(headResult.status, "ok");
 
   await client.deleteObject(key);
-  await client.deleteObject("copy-test/tricky-dest.md");
 });
 
-test("copyObject of a missing source fails with not_found, never a phantom empty object", async () => {
+test("headObject on a missing key fails with not_found", async () => {
   const client = createS3Client(liveSettings, SECRET_ACCESS_KEY, fetchTransport);
 
-  const copyResult = await client.copyObject("copy-test/does-not-exist.md", "copy-test/nope.md");
-  assert.equal(copyResult.ok, false);
-  assert.equal(copyResult.status, "not_found");
+  const headResult = await client.headObject("head-test/does-not-exist.md");
+  assert.equal(headResult.ok, false);
+  assert.equal(headResult.status, "not_found");
+});
 
-  const dest = await client.getObject("copy-test/nope.md");
-  assert.equal(dest.ok, false);
+test("headObject round-trips a key with SigV4-sensitive characters", async () => {
+  const client = createS3Client(liveSettings, SECRET_ACCESS_KEY, fetchTransport);
+  const key = "head-test/Don't stop! (really).md";
+  await client.putObject(key, new TextEncoder().encode("tricky key"));
+
+  const headResult = await client.headObject(key);
+  assert.equal(headResult.ok, true);
+
+  await client.deleteObject(key);
 });
 
 test("listObjects returns only keys under the given prefix", async () => {

--- a/src/storage/storage.itest.ts
+++ b/src/storage/storage.itest.ts
@@ -121,6 +121,7 @@ test("headObject reports ok for an existing key without returning a body", async
   const headResult = await client.headObject(key);
   assert.equal(headResult.ok, true);
   assert.equal(headResult.status, "ok");
+  assert.notEqual(headResult.etag, null);
 
   await client.deleteObject(key);
 });

--- a/src/storage/storage.test.ts
+++ b/src/storage/storage.test.ts
@@ -43,7 +43,7 @@ function probeStub(over: Partial<StorageClient>): StorageClient {
       body: new Uint8Array(),
       etag: '"probe"',
     }),
-    copyObject: async () => ({ ok: true, status: "ok", message: "" }),
+    headObject: async () => ({ ok: true, status: "ok", message: "" }),
     deleteObject: async () => ({ ok: true, status: "ok", message: "" }),
     listObjects: async () => ({ ok: true, status: "ok", message: "", objects: [] }),
   };

--- a/src/storage/storage.test.ts
+++ b/src/storage/storage.test.ts
@@ -43,7 +43,7 @@ function probeStub(over: Partial<StorageClient>): StorageClient {
       body: new Uint8Array(),
       etag: '"probe"',
     }),
-    headObject: async () => ({ ok: true, status: "ok", message: "" }),
+    headObject: async () => ({ ok: true, status: "ok", message: "", etag: '"probe"' }),
     deleteObject: async () => ({ ok: true, status: "ok", message: "" }),
     listObjects: async () => ({ ok: true, status: "ok", message: "", objects: [] }),
   };

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -18,14 +18,6 @@ export type ConnectionResult = {
   message: string;
 };
 
-// CopyResult reports whether an object was copied to a new key. Message is the empty string when
-// ok is true.
-export type CopyResult = {
-  ok: boolean;
-  status: ResultStatus;
-  message: string;
-};
-
 // DeleteResult reports whether an object was removed. Message is the empty string when ok is
 // true.
 export type DeleteResult = {
@@ -43,6 +35,14 @@ export type GetResult = {
   message: string;
   body: Uint8Array | null;
   etag: string | null;
+};
+
+// HeadResult reports whether an object exists at a key, without transferring its body. Message is
+// the empty string when ok is true.
+export type HeadResult = {
+  ok: boolean;
+  status: ResultStatus;
+  message: string;
 };
 
 // HttpResponse is the normalized reply a Transport returns: the HTTP status and the fully read
@@ -102,7 +102,7 @@ export type ResultStatus =
 export type StorageClient = {
   putObject: (key: string, body: Uint8Array, condition?: PutCondition) => Promise<PutResult>;
   getObject: (key: string, expectedBytes?: number) => Promise<GetResult>;
-  copyObject: (sourceKey: string, destKey: string) => Promise<CopyResult>;
+  headObject: (key: string) => Promise<HeadResult>;
   deleteObject: (key: string) => Promise<DeleteResult>;
   listObjects: (prefix?: string) => Promise<ListResult>;
 };
@@ -134,8 +134,7 @@ export function createS3Client(
     putObject: (key, body, condition) =>
       s3PutObject(client, transport, baseUrl, key, body, condition),
     getObject: (key, expectedBytes) => s3GetObject(client, transport, baseUrl, key, expectedBytes),
-    copyObject: (sourceKey, destKey) =>
-      s3CopyObject(client, transport, baseUrl, settings.bucket, sourceKey, destKey),
+    headObject: (key) => s3HeadObject(client, transport, baseUrl, key),
     deleteObject: (key) => s3DeleteObject(client, transport, baseUrl, key),
     listObjects: (prefix) => s3ListObjects(client, transport, baseUrl, prefix),
   };
@@ -302,46 +301,6 @@ function missingFieldFor(settings: GeodeSettings, secretAccessKey: string): stri
   return "";
 }
 
-// s3CopyObject server-side copies sourceKey to destKey within the same bucket, so the bytes never
-// travel through the client. The x-amz-copy-source header names the source as "/bucket/key" with
-// the key percent-encoded exactly as a request path is, so a source containing spaces or SigV4
-// sensitive characters is signed byte for byte the way the server canonicalizes it. S3 has a
-// documented quirk where CopyObject can answer 200 and then carry an <Error> in the body when the
-// copy fails mid-stream; treating that as success would let the caller delete a source it never
-// actually backed up, so the body is inspected and a failure surfaced rather than swallowed.
-async function s3CopyObject(
-  client: AwsClient,
-  transport: Transport,
-  baseUrl: string,
-  bucket: string,
-  sourceKey: string,
-  destKey: string,
-): Promise<CopyResult> {
-  const source = `/${bucket}/${encodeKey(sourceKey)}`;
-  let response: HttpResponse;
-  try {
-    response = await send(client, transport, `${baseUrl}/${encodeKey(destKey)}`, {
-      method: "PUT",
-      headers: { "x-amz-copy-source": source },
-    });
-  } catch (err) {
-    return { ok: false, status: "network", message: messageFor(err) };
-  }
-
-  if (!response.ok) {
-    return {
-      ok: false,
-      status: statusForHttp(response.status),
-      message: `Storage rejected the copy (${response.status})`,
-    };
-  }
-  const body = new TextDecoder().decode(response.body);
-  if (body.includes("<Error")) {
-    return { ok: false, status: "server", message: "Storage rejected the copy (200 error body)" };
-  }
-  return { ok: true, status: "ok", message: "" };
-}
-
 // s3DeleteObject removes key from the bucket.
 async function s3DeleteObject(
   client: AwsClient,
@@ -416,6 +375,33 @@ async function s3GetObject(
     body: response.body,
     etag: response.header("etag"),
   };
+}
+
+// s3HeadObject reports whether key exists, without transferring the object's body. Used to check
+// for an already stored blob before uploading it: a content addressed key that already exists
+// holds, by construction, the exact bytes a caller would otherwise upload, so the upload can be
+// skipped entirely once its existence is confirmed.
+async function s3HeadObject(
+  client: AwsClient,
+  transport: Transport,
+  baseUrl: string,
+  key: string,
+): Promise<HeadResult> {
+  let response: HttpResponse;
+  try {
+    response = await send(client, transport, `${baseUrl}/${encodeKey(key)}`, { method: "HEAD" });
+  } catch (err) {
+    return { ok: false, status: "network", message: messageFor(err) };
+  }
+
+  if (!response.ok) {
+    return {
+      ok: false,
+      status: statusForHttp(response.status),
+      message: `Storage rejected the head (${response.status})`,
+    };
+  }
+  return { ok: true, status: "ok", message: "" };
 }
 
 // s3ListObjects lists objects in the bucket, optionally restricted to a key prefix. S3 caps a

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -38,11 +38,14 @@ export type GetResult = {
 };
 
 // HeadResult reports whether an object exists at a key, without transferring its body. Message is
-// the empty string when ok is true.
+// the empty string when ok is true. Etag is the object's ETag exactly as the server sent it,
+// mirroring GetResult, so a caller can detect the object changing underneath it without paying
+// for a body transfer; null when ok is false or the server sent none.
 export type HeadResult = {
   ok: boolean;
   status: ResultStatus;
   message: string;
+  etag: string | null;
 };
 
 // HttpResponse is the normalized reply a Transport returns: the HTTP status and the fully read
@@ -377,10 +380,11 @@ async function s3GetObject(
   };
 }
 
-// s3HeadObject reports whether key exists, without transferring the object's body. Used to check
-// for an already stored blob before uploading it: a content addressed key that already exists
-// holds, by construction, the exact bytes a caller would otherwise upload, so the upload can be
-// skipped entirely once its existence is confirmed.
+// s3HeadObject reports whether key exists, without transferring the object's body. Used both to
+// check for an already stored blob before uploading it (a content addressed key that already
+// exists holds, by construction, the exact bytes a caller would otherwise upload, so the upload
+// can be skipped entirely) and, via its etag, to detect a mutable key like the manifest changing
+// underneath a plan without paying for a body transfer.
 async function s3HeadObject(
   client: AwsClient,
   transport: Transport,
@@ -391,7 +395,7 @@ async function s3HeadObject(
   try {
     response = await send(client, transport, `${baseUrl}/${encodeKey(key)}`, { method: "HEAD" });
   } catch (err) {
-    return { ok: false, status: "network", message: messageFor(err) };
+    return { ok: false, status: "network", message: messageFor(err), etag: null };
   }
 
   if (!response.ok) {
@@ -399,9 +403,10 @@ async function s3HeadObject(
       ok: false,
       status: statusForHttp(response.status),
       message: `Storage rejected the head (${response.status})`,
+      etag: null,
     };
   }
-  return { ok: true, status: "ok", message: "" };
+  return { ok: true, status: "ok", message: "", etag: response.header("etag") };
 }
 
 // s3ListObjects lists objects in the bucket, optionally restricted to a key prefix. S3 caps a

--- a/src/sync/execute.test.ts
+++ b/src/sync/execute.test.ts
@@ -964,12 +964,12 @@ test("executeSyncPlan: a pull stages its payload, then checks cheapest-last, and
   const reader: Reader = {
     ...baseReader,
     readFile: async (path) => {
-      ops.push("checkLocal");
+      ops.push("hashLocal");
       return baseReader.readFile(path);
     },
-    size: async (path) => {
-      ops.push("confirmLocal");
-      return baseReader.size(path);
+    stat: async (path) => {
+      ops.push("statLocal");
+      return baseReader.stat(path);
     },
   };
   const { writer, files } = fakeLocalWriter();
@@ -1017,7 +1017,17 @@ test("executeSyncPlan: a pull stages its payload, then checks cheapest-last, and
   );
 
   assert.deepEqual(failures, []);
-  assert.deepEqual(ops, ["stage", "checkLocal", "checkManifest", "confirmLocal", "commit"]);
+  // The stat either side of hashLocal is checkLocalDrift bracketing its own read; the one after
+  // checkManifest is the confirmation, and nothing but the commit follows it.
+  assert.deepEqual(ops, [
+    "stage",
+    "statLocal",
+    "hashLocal",
+    "statLocal",
+    "checkManifest",
+    "statLocal",
+    "commit",
+  ]);
   assert.equal(files.get("a.md"), "hello");
 });
 
@@ -1066,6 +1076,96 @@ test("executeSyncPlan: a pull whose local file is edited while the manifest chec
   assert.deepEqual(completed, []);
   assert.equal(files.get("a.md"), "as snapshotted");
   assert.equal(readerFiles["a.md"], "edited during the manifest check");
+});
+
+test("executeSyncPlan: a pull refused when the edit landing during the manifest check keeps the byte length", async () => {
+  // A typo fixed in place rewrites a note without changing its length, so an existence and size
+  // comparison would wave it through and commit the pulled bytes over it: success reported, the
+  // path advanced in state.json at the pulled hash, the edit gone with nothing able to tell it
+  // ever existed. The mtime is what makes the final confirmation a guard rather than a formality.
+  const readerFiles: Record<string, string> = { "a.md": "hello world" };
+  const readerMtimes: Record<string, number> = { "a.md": 1 };
+  const reader = fakeReader(readerFiles, readerMtimes);
+  const local = snapshot({
+    path: "a.md",
+    size: "hello world".length,
+    mtime: 1,
+    hash: await hashOf("hello world"),
+  });
+  const { writer, files } = fakeLocalWriter();
+  files.set("a.md", "hello world");
+  const hash = await hashOf("remote a");
+  const { storage } = fakeStorage({ [blobKeyFor(hash)]: "remote a", [MANIFEST_KEY]: "current" });
+  const head = await storage.headObject(MANIFEST_KEY);
+  const innerHead = storage.headObject;
+  storage.headObject = async (key) => {
+    if (key === MANIFEST_KEY) {
+      readerFiles["a.md"] = "hello werld";
+      readerMtimes["a.md"] = 2;
+    }
+    return innerHead(key);
+  };
+  const remote = snapshot(file("a.md", hash));
+
+  const { failures, completed } = await executeSyncPlan(
+    [{ kind: "pull", path: "a.md" }],
+    local,
+    reader,
+    writer,
+    storage,
+    1,
+    remote,
+    head.etag,
+  );
+
+  assert.equal("hello werld".length, "hello world".length);
+  assert.deepEqual(failures, [
+    { path: "a.md", message: "changed locally mid sync; sync again to reconcile" },
+  ]);
+  assert.deepEqual(completed, []);
+  assert.equal(files.get("a.md"), "hello world");
+});
+
+test("executeSyncPlan: a pullDelete refused when the edit landing during the manifest check keeps the byte length", async () => {
+  // The same rewrite guarding a deletion, where losing it trashes the file the user was mid edit
+  // on rather than overwriting one save.
+  const readerFiles: Record<string, string> = { "a.md": "hello world" };
+  const readerMtimes: Record<string, number> = { "a.md": 1 };
+  const reader = fakeReader(readerFiles, readerMtimes);
+  const local = snapshot({
+    path: "a.md",
+    size: "hello world".length,
+    mtime: 1,
+    hash: await hashOf("hello world"),
+  });
+  const { writer, files } = fakeLocalWriter();
+  files.set("a.md", "hello world");
+  const { storage } = fakeStorage({ [MANIFEST_KEY]: "current" });
+  const head = await storage.headObject(MANIFEST_KEY);
+  const innerHead = storage.headObject;
+  storage.headObject = async (key) => {
+    if (key === MANIFEST_KEY) {
+      readerFiles["a.md"] = "hello werld";
+      readerMtimes["a.md"] = 2;
+    }
+    return innerHead(key);
+  };
+
+  const { failures } = await executeSyncPlan(
+    [{ kind: "pullDelete", path: "a.md" }],
+    local,
+    reader,
+    writer,
+    storage,
+    1,
+    empty,
+    head.etag,
+  );
+
+  assert.deepEqual(failures, [
+    { path: "a.md", message: "changed locally mid sync; sync again to reconcile" },
+  ]);
+  assert.equal(files.get("a.md"), "hello world");
 });
 
 test("executeSyncPlan: a pullDelete whose local file is edited while the manifest check is in flight is refused", async () => {

--- a/src/sync/execute.test.ts
+++ b/src/sync/execute.test.ts
@@ -462,6 +462,111 @@ test("executeSyncPlan: a conflict restore onto a path recreated after the snapsh
   assert.equal(files.get("a.md"), "recreated after snapshot");
 });
 
+test("executeSyncPlan: a conflict restore onto a path recreated after its own rename is refused, and the recreated file survives", async () => {
+  // The window the "create" commit exists for. Between the rename that vacates the path and the
+  // commit that lands the remote version on it sit a blob push, a fetch and a staged write: ample
+  // room for the user, or another plugin, to create a note at the same path. That file is not the
+  // local edit the conflict copy preserved, no snapshot describes it, and nothing anywhere else
+  // holds its content, so the restore must refuse rather than replace it and report success.
+  const reader = fakeReader({ "a.md": "local edit" });
+  const { writer, files } = fakeLocalWriter();
+  files.set("a.md", "local edit");
+  const innerRename = writer.renameFile;
+  writer.renameFile = async (path, newPath) => {
+    await innerRename(path, newPath);
+    files.set(path, "recreated mid sync");
+  };
+  const remoteHash = await hashOf("remote edit");
+  const { storage, objects } = fakeStorage({ [blobKeyFor(remoteHash)]: "remote edit" });
+  const remote = snapshot(file("a.md", remoteHash));
+  const now = Date.parse("2026-07-14T10:00:00.000Z");
+
+  const { completed, failures, pushedFiles } = await executeSyncPlan(
+    [{ kind: "conflict", path: "a.md", deletedSide: "none" }],
+    empty,
+    reader,
+    writer,
+    storage,
+    now,
+    remote,
+  );
+
+  assert.deepEqual(failures, [
+    { path: "a.md", message: "changed locally mid sync; sync again to reconcile" },
+  ]);
+  assert.deepEqual(completed, []);
+  assert.equal(files.get("a.md"), "recreated mid sync");
+  // Neither of the other two versions is lost either: the local edit is still under its copy name
+  // and in the bucket, and the remote version was never on this device to begin with. The next
+  // sync sees the recreated file as a local change and replans the path as an ordinary conflict.
+  const copyHash = await hashOf("local edit");
+  assert.equal(files.get(conflictCopyPath("a.md", now)), "local edit");
+  assert.equal(objects.get(blobKeyFor(copyHash)), "local edit");
+  assert.deepEqual(pushedFiles, [
+    {
+      path: conflictCopyPath("a.md", now),
+      size: "local edit".length,
+      mtime: now,
+      hash: copyHash,
+    },
+  ]);
+});
+
+test("executeSyncPlan: a conflict restore is refused by its commit even when the recreated file is too new for the reader to see", async () => {
+  // checkLocalDrift reads through Obsidian's file index, which lags a file by however long the
+  // index takes to notice it; the writer's own stat does not. A file already on disk but not yet
+  // indexed must still stop the restore, which is exactly what the "create" commit is for and
+  // what a Reader based check could never manage on its own.
+  const reader = fakeReader({});
+  const { writer, files } = fakeLocalWriter();
+  files.set("a.md", "created but not yet indexed");
+  const hash = await hashOf("remote edit");
+  const { storage } = fakeStorage({ [blobKeyFor(hash)]: "remote edit" });
+  const remote = snapshot(file("a.md", hash));
+  const now = Date.parse("2026-07-14T10:00:00.000Z");
+
+  const { failures } = await executeSyncPlan(
+    [{ kind: "conflict", path: "a.md", deletedSide: "local" }],
+    empty,
+    reader,
+    writer,
+    storage,
+    now,
+    remote,
+  );
+
+  assert.deepEqual(failures, [
+    { path: "a.md", message: "changed locally mid sync; sync again to reconcile" },
+  ]);
+  assert.equal(files.get("a.md"), "created but not yet indexed");
+});
+
+test("executeSyncPlan: an ordinary pull still replaces the file its plan decided to move on from", async () => {
+  // The counterpart to the restore's "create": a pull's whole job is to install over the path's
+  // previous content, which checkLocalDrift has just confirmed is what the snapshot saw. Refusing
+  // an occupied destination here would break every update of an existing note.
+  const reader = fakeReader({ "a.md": "as snapshotted" });
+  const local = snapshot(file("a.md", await hashOf("as snapshotted")));
+  const { writer, files } = fakeLocalWriter();
+  files.set("a.md", "as snapshotted");
+  const hash = await hashOf("remote edit");
+  const { storage } = fakeStorage({ [blobKeyFor(hash)]: "remote edit" });
+  const remote = snapshot(file("a.md", hash));
+
+  const { failures } = await executeSyncPlan(
+    [{ kind: "pull", path: "a.md" }],
+    local,
+    reader,
+    writer,
+    storage,
+    1,
+    remote,
+  );
+
+  assert.deepEqual(failures, []);
+  assert.equal(files.get("a.md"), "remote edit");
+});
+
 test("executeSyncPlan: a conflict with nothing remote to pull preserves the local edit as a copy and reports no failure", async () => {
   const reader = fakeReader({ "a.md": "local edit" });
   const { writer, files } = fakeLocalWriter();
@@ -809,9 +914,9 @@ test("executeSyncPlan: a pull whose local file is edited while its payload stage
   const { writer, files } = fakeLocalWriter();
   let discarded = 0;
   const innerStage = writer.stageFile;
-  writer.stageFile = async (path, data) => {
+  writer.stageFile = async (path, data, mode) => {
     readerFiles["a.md"] = "edited while staging";
-    const staged = await innerStage(path, data);
+    const staged = await innerStage(path, data, mode);
 
     return {
       commit: staged.commit,
@@ -861,9 +966,9 @@ test("executeSyncPlan: a pull stages its payload before both drift checks and co
   };
   const { writer, files } = fakeLocalWriter();
   const innerStage = writer.stageFile;
-  writer.stageFile = async (path, data) => {
+  writer.stageFile = async (path, data, mode) => {
     ops.push("stage");
-    const staged = await innerStage(path, data);
+    const staged = await innerStage(path, data, mode);
 
     return {
       commit: async () => {
@@ -910,8 +1015,8 @@ test("executeSyncPlan: a pull refused by manifest drift discards its staged payl
   const { writer, files } = fakeLocalWriter();
   let discarded = 0;
   const innerStage = writer.stageFile;
-  writer.stageFile = async (path, data) => {
-    const staged = await innerStage(path, data);
+  writer.stageFile = async (path, data, mode) => {
+    const staged = await innerStage(path, data, mode);
 
     return {
       commit: staged.commit,
@@ -950,8 +1055,8 @@ test("executeSyncPlan: a discard that itself fails never masks the failure that 
   const reader = fakeReader({});
   const { writer, files } = fakeLocalWriter();
   const innerStage = writer.stageFile;
-  writer.stageFile = async (path, data) => {
-    const staged = await innerStage(path, data);
+  writer.stageFile = async (path, data, mode) => {
+    const staged = await innerStage(path, data, mode);
 
     return {
       commit: staged.commit,

--- a/src/sync/execute.test.ts
+++ b/src/sync/execute.test.ts
@@ -744,9 +744,9 @@ test("executeSyncPlan: a pull whose local write throws is reported and doesn't s
 });
 
 test("executeSyncPlan: a conflict whose rename throws is reported and the local edit is never overwritten", async () => {
-  // If the rename that vacates the local path throws, the local edit is still sitting there. We
-  // must report the failure and skip the pull, otherwise the remote version would clobber a
-  // diverged edit we failed to preserve.
+  // If the rename that vacates the local path throws, the local edit is still sitting there. The
+  // failure must be reported and the staged remote version thrown away rather than committed,
+  // otherwise the remote version would clobber a diverged edit we failed to preserve.
   const reader = fakeReader({ "a.md": "local edit" });
   const { writer, files } = fakeLocalWriter();
   files.set("a.md", "local edit");
@@ -755,6 +755,7 @@ test("executeSyncPlan: a conflict whose rename throws is reported and the local 
   };
   const hash = await hashOf("remote edit");
   const { storage, objects } = fakeStorage({ [blobKeyFor(hash)]: "remote edit" });
+  const remote = snapshot(file("a.md", hash));
   const now = Date.parse("2026-07-14T10:00:00.000Z");
 
   const { failures } = await executeSyncPlan(
@@ -764,6 +765,7 @@ test("executeSyncPlan: a conflict whose rename throws is reported and the local 
     writer,
     storage,
     now,
+    remote,
   );
 
   const copyHash = await hashOf("local edit");
@@ -949,19 +951,25 @@ test("executeSyncPlan: a pull whose local file is edited while its payload stage
   assert.equal(discarded, 1);
 });
 
-test("executeSyncPlan: a pull stages its payload before both drift checks and commits only after them", async () => {
+test("executeSyncPlan: a pull stages its payload, then checks cheapest-last, and commits only after every check", async () => {
   // The ordering the whole fix turns on, asserted directly because every other test here can only
   // observe its consequences. Staging last would put the payload write between the final check and
-  // the destination changing; running the manifest HEAD last would put the local read, the slow
-  // check, in front of it instead. Only this order leaves each check with nothing but the commit's
-  // rename ahead of it, and puts the unrecoverable check (local) closest to that rename.
+  // the destination changing. Running the manifest HEAD first, as this used to, put the local read
+  // and hash behind it, so a manifest replaced during that read still authorized the write. Running
+  // it last instead would leave the local guarantee ending a network round trip before the commit.
+  // Only cheapest-last leaves every check with nothing ahead of it but an index lookup and the
+  // commit's rename.
   const ops: string[] = [];
-  const baseReader = fakeReader({});
+  const baseReader = fakeReader({ "a.md": "as snapshotted" });
   const reader: Reader = {
     ...baseReader,
-    fileExists: async (path) => {
+    readFile: async (path) => {
       ops.push("checkLocal");
-      return baseReader.fileExists(path);
+      return baseReader.readFile(path);
+    },
+    size: async (path) => {
+      ops.push("confirmLocal");
+      return baseReader.size(path);
     },
   };
   const { writer, files } = fakeLocalWriter();
@@ -990,10 +998,16 @@ test("executeSyncPlan: a pull stages its payload before both drift checks and co
   const manifestHead = await storage.headObject(MANIFEST_KEY);
   ops.length = 0;
   const remote = snapshot(file("a.md", hash));
+  const local = snapshot({
+    path: "a.md",
+    size: "as snapshotted".length,
+    mtime: 1,
+    hash: await hashOf("as snapshotted"),
+  });
 
   const { failures } = await executeSyncPlan(
     [{ kind: "pull", path: "a.md" }],
-    empty,
+    local,
     reader,
     writer,
     storage,
@@ -1003,8 +1017,166 @@ test("executeSyncPlan: a pull stages its payload before both drift checks and co
   );
 
   assert.deepEqual(failures, []);
-  assert.deepEqual(ops, ["stage", "checkManifest", "checkLocal", "commit"]);
+  assert.deepEqual(ops, ["stage", "checkLocal", "checkManifest", "confirmLocal", "commit"]);
   assert.equal(files.get("a.md"), "hello");
+});
+
+test("executeSyncPlan: a pull whose local file is edited while the manifest check is in flight is refused", async () => {
+  // The half of the local guarantee the content hash cannot cover on its own. The hash proves what
+  // the file held when it ran, but a manifest HEAD follows it, and an edit landing during that
+  // round trip would otherwise be committed over: the action reports success, the path advances in
+  // state.json at the pulled hash, and nothing afterwards can tell the edit existed. The
+  // index-only confirmation after the HEAD is what catches it.
+  const readerFiles: Record<string, string> = { "a.md": "as snapshotted" };
+  const reader = fakeReader(readerFiles);
+  const local = snapshot({
+    path: "a.md",
+    size: "as snapshotted".length,
+    mtime: 1,
+    hash: await hashOf("as snapshotted"),
+  });
+  const { writer, files } = fakeLocalWriter();
+  files.set("a.md", "as snapshotted");
+  const hash = await hashOf("remote a");
+  const { storage } = fakeStorage({ [blobKeyFor(hash)]: "remote a", [MANIFEST_KEY]: "current" });
+  const head = await storage.headObject(MANIFEST_KEY);
+  const innerHead = storage.headObject;
+  storage.headObject = async (key) => {
+    if (key === MANIFEST_KEY) {
+      readerFiles["a.md"] = "edited during the manifest check";
+    }
+    return innerHead(key);
+  };
+  const remote = snapshot(file("a.md", hash));
+
+  const { failures, completed } = await executeSyncPlan(
+    [{ kind: "pull", path: "a.md" }],
+    local,
+    reader,
+    writer,
+    storage,
+    1,
+    remote,
+    head.etag,
+  );
+
+  assert.deepEqual(failures, [
+    { path: "a.md", message: "changed locally mid sync; sync again to reconcile" },
+  ]);
+  assert.deepEqual(completed, []);
+  assert.equal(files.get("a.md"), "as snapshotted");
+  assert.equal(readerFiles["a.md"], "edited during the manifest check");
+});
+
+test("executeSyncPlan: a pullDelete whose local file is edited while the manifest check is in flight is refused", async () => {
+  // The same window guarding a deletion rather than a write, where losing it costs the user the
+  // file itself rather than one edit.
+  const readerFiles: Record<string, string> = { "a.md": "as snapshotted" };
+  const reader = fakeReader(readerFiles);
+  const local = snapshot({
+    path: "a.md",
+    size: "as snapshotted".length,
+    mtime: 1,
+    hash: await hashOf("as snapshotted"),
+  });
+  const { writer, files } = fakeLocalWriter();
+  files.set("a.md", "as snapshotted");
+  const { storage } = fakeStorage({ [MANIFEST_KEY]: "current" });
+  const head = await storage.headObject(MANIFEST_KEY);
+  const innerHead = storage.headObject;
+  storage.headObject = async (key) => {
+    if (key === MANIFEST_KEY) {
+      readerFiles["a.md"] = "edited during the manifest check";
+    }
+    return innerHead(key);
+  };
+
+  const { failures } = await executeSyncPlan(
+    [{ kind: "pullDelete", path: "a.md" }],
+    local,
+    reader,
+    writer,
+    storage,
+    1,
+    empty,
+    head.etag,
+  );
+
+  assert.deepEqual(failures, [
+    { path: "a.md", message: "changed locally mid sync; sync again to reconcile" },
+  ]);
+  assert.equal(files.get("a.md"), "as snapshotted");
+});
+
+test("executeSyncPlan: a conflict fetches, stages and checks the manifest before it vacates the path", async () => {
+  // The ordering that makes the restore's guarantee worth having, asserted directly. Every slow
+  // and fallible step runs while the local edit is still sitting at its own path, so the interval
+  // in which that path stands empty, and a note created there could be replaced by the restore, is
+  // the rename and the commit back to back. Vacating first, as this used to, spanned a download, a
+  // staged write and a network round trip.
+  const ops: string[] = [];
+  const reader = fakeReader({ "a.md": "local edit" });
+  const { writer, files } = fakeLocalWriter();
+  files.set("a.md", "local edit");
+  const innerStage = writer.stageFile;
+  writer.stageFile = async (path, data, mode) => {
+    ops.push("stage");
+    const staged = await innerStage(path, data, mode);
+
+    return {
+      commit: async () => {
+        ops.push("commit");
+        await staged.commit();
+      },
+      discard: staged.discard,
+    };
+  };
+  const innerRename = writer.renameFile;
+  writer.renameFile = async (path, newPath) => {
+    ops.push("rename");
+    await innerRename(path, newPath);
+  };
+  const remoteHash = await hashOf("remote edit");
+  const { storage } = fakeStorage({
+    [blobKeyFor(remoteHash)]: "remote edit",
+    [MANIFEST_KEY]: "current",
+  });
+  const head = await storage.headObject(MANIFEST_KEY);
+  const innerGet = storage.getObject;
+  storage.getObject = async (key, size) => {
+    ops.push("fetch");
+    return innerGet(key, size);
+  };
+  const innerHead = storage.headObject;
+  storage.headObject = async (key) => {
+    if (key === MANIFEST_KEY) {
+      ops.push("checkManifest");
+    }
+    return innerHead(key);
+  };
+  const innerPut = storage.putObject;
+  storage.putObject = async (key, body, condition) => {
+    ops.push("pushCopy");
+    return innerPut(key, body, condition);
+  };
+  const remote = snapshot(file("a.md", remoteHash));
+  const now = Date.parse("2026-07-14T10:00:00.000Z");
+
+  const { failures } = await executeSyncPlan(
+    [{ kind: "conflict", path: "a.md", deletedSide: "none" }],
+    empty,
+    reader,
+    writer,
+    storage,
+    now,
+    remote,
+    head.etag,
+  );
+
+  assert.deepEqual(failures, []);
+  assert.deepEqual(ops, ["fetch", "stage", "checkManifest", "rename", "commit", "pushCopy"]);
+  assert.equal(files.get("a.md"), "remote edit");
+  assert.equal(files.get(conflictCopyPath("a.md", now)), "local edit");
 });
 
 test("executeSyncPlan: a pull refused by manifest drift discards its staged payload", async () => {
@@ -1086,7 +1258,11 @@ test("executeSyncPlan: a discard that itself fails never masks the failure that 
   assert.equal(files.has("a.md"), false);
 });
 
-test("executeSyncPlan: a conflict restore refuses when the manifest has moved on, and the local edit survives as a copy", async () => {
+test("executeSyncPlan: a conflict restore refuses when the manifest has moved on, leaving the vault exactly as it was", async () => {
+  // The manifest is confirmed before the local edit is moved aside, so a stale plan costs nothing
+  // locally: the note is still at its own path, under its own name, and the whole conflict is
+  // replanned against the newer manifest next pass. Checking after the rename, as this used to,
+  // left the split half applied instead: a copy on disk and an empty path where the note was.
   const reader = fakeReader({ "a.md": "local edit" });
   const { writer, files } = fakeLocalWriter();
   files.set("a.md", "local edit");
@@ -1098,7 +1274,7 @@ test("executeSyncPlan: a conflict restore refuses when the manifest has moved on
   const remote = snapshot(file("a.md", hash));
   const now = Date.parse("2026-07-14T10:00:00.000Z");
 
-  const { failures } = await executeSyncPlan(
+  const { failures, pushedFiles } = await executeSyncPlan(
     [{ kind: "conflict", path: "a.md", deletedSide: "none" }],
     empty,
     reader,
@@ -1112,11 +1288,10 @@ test("executeSyncPlan: a conflict restore refuses when the manifest has moved on
   assert.deepEqual(failures, [
     { path: "a.md", message: "changed remotely mid sync; sync again to reconcile" },
   ]);
-  // The local edit was already renamed and pushed as a copy before the drift was caught, so it is
-  // never lost; only the stale remote restore is refused.
-  assert.equal(files.get("a.md"), undefined);
-  assert.equal(files.get(conflictCopyPath("a.md", now)), "local edit");
-  assert.equal(objects.get(blobKeyFor(await hashOf("local edit"))), "local edit");
+  assert.equal(files.get("a.md"), "local edit");
+  assert.equal(files.has(conflictCopyPath("a.md", now)), false);
+  assert.equal(objects.has(blobKeyFor(await hashOf("local edit"))), false);
+  assert.deepEqual(pushedFiles, []);
 });
 
 test("executeSyncPlan: conflict restore with hash mismatch is refused and nothing is written", async () => {
@@ -1146,7 +1321,11 @@ test("executeSyncPlan: conflict restore with hash mismatch is refused and nothin
   assert.equal(files.has("a.md"), false);
 });
 
-test("executeSyncPlan: conflict with hash mismatch on remote restore is reported and local edit survives", async () => {
+test("executeSyncPlan: conflict with hash mismatch on remote restore leaves the local edit where the user left it", async () => {
+  // Corrupt or truncated remote bytes are caught while the local edit is still untouched at its
+  // own path, because the fetch and its integrity check now run before anything local moves. The
+  // conflict is simply replanned next pass. Splitting first, as this used to, meant a blob that
+  // never verifies left the note renamed away and its path empty on every single pass.
   const reader = fakeReader({ "a.md": "local edit" });
   const { writer, files } = fakeLocalWriter();
   files.set("a.md", "local edit");
@@ -1165,26 +1344,15 @@ test("executeSyncPlan: conflict with hash mismatch on remote restore is reported
     remote,
   );
 
-  const copyHash = await hashOf("local edit");
   assert.deepEqual(failures, [
     {
       path: "a.md",
       message: "fetched bytes do not match manifest hash; sync again to reconcile",
     },
   ]);
-  // The local edit was renamed to the conflict copy before the pull was attempted.
-  assert.equal(files.get("a.md"), undefined);
-  assert.equal(files.get(conflictCopyPath("a.md", now)), "local edit");
-  assert.equal(objects.get(blobKeyFor(copyHash)), "local edit");
-  // The action is reported failed, never completed, but the copy really did land in the bucket:
-  // pushedFiles must still carry it, or the manifest built from it would never know it's there.
+  assert.equal(files.get("a.md"), "local edit");
+  assert.equal(files.has(conflictCopyPath("a.md", now)), false);
+  assert.equal(objects.has(blobKeyFor(await hashOf("local edit"))), false);
   assert.deepEqual(completed, []);
-  assert.deepEqual(pushedFiles, [
-    {
-      path: conflictCopyPath("a.md", now),
-      size: "local edit".length,
-      mtime: now,
-      hash: copyHash,
-    },
-  ]);
+  assert.deepEqual(pushedFiles, []);
 });

--- a/src/sync/execute.test.ts
+++ b/src/sync/execute.test.ts
@@ -3,7 +3,7 @@ import { test } from "node:test";
 import { hashBytes } from "../vault/vault.ts";
 import { executeSyncPlan } from "./execute.ts";
 import { empty, fakeLocalWriter, fakeReader, fakeStorage, file, snapshot } from "./fake.ts";
-import { blobKeyFor, conflictCopyPath, type SyncAction } from "./plan.ts";
+import { blobKeyFor, conflictCopyPath, MANIFEST_KEY, type SyncAction } from "./plan.ts";
 
 // hashOf returns the real content hash of text, for building local snapshots whose entries
 // executeSyncPlan's drift check can verify against a fake reader's live bytes, and for keying a
@@ -680,6 +680,91 @@ test("executeSyncPlan: pull with truncated body is refused and nothing is writte
     },
   ]);
   assert.equal(files.has("a.md"), false);
+});
+
+test("executeSyncPlan: pull refuses when the manifest has moved on, rather than writing stale content", async () => {
+  // A blob fetched by its own hash always reads back exactly that content, so unlike a plaintext
+  // path keyed read it can never itself notice a newer manifest having since pointed the path at
+  // a different hash. Passing an etag that no longer matches the manifest's current one simulates
+  // another device having completed a whole sync in the window between this pass reading the
+  // manifest and this pull committing its write.
+  const reader = fakeReader({});
+  const { writer, files } = fakeLocalWriter();
+  const hash = await hashOf("hello");
+  const { storage } = fakeStorage({ [blobKeyFor(hash)]: "hello", [MANIFEST_KEY]: "irrelevant" });
+  const remote = snapshot(file("a.md", hash));
+
+  const { failures } = await executeSyncPlan(
+    [{ kind: "pull", path: "a.md" }],
+    empty,
+    reader,
+    writer,
+    storage,
+    1,
+    remote,
+    '"stale-etag"',
+  );
+
+  assert.deepEqual(failures, [
+    { path: "a.md", message: "changed remotely mid sync; sync again to reconcile" },
+  ]);
+  assert.equal(files.has("a.md"), false);
+});
+
+test("executeSyncPlan: pull proceeds when the manifest etag still matches what the plan was made from", async () => {
+  const reader = fakeReader({});
+  const { writer, files } = fakeLocalWriter();
+  const hash = await hashOf("hello");
+  const { storage } = fakeStorage({ [blobKeyFor(hash)]: "hello", [MANIFEST_KEY]: "current" });
+  const remote = snapshot(file("a.md", hash));
+  const manifestHead = await storage.headObject(MANIFEST_KEY);
+
+  const { failures } = await executeSyncPlan(
+    [{ kind: "pull", path: "a.md" }],
+    empty,
+    reader,
+    writer,
+    storage,
+    1,
+    remote,
+    manifestHead.etag,
+  );
+
+  assert.deepEqual(failures, []);
+  assert.equal(files.get("a.md"), "hello");
+});
+
+test("executeSyncPlan: a conflict restore refuses when the manifest has moved on, and the local edit survives as a copy", async () => {
+  const reader = fakeReader({ "a.md": "local edit" });
+  const { writer, files } = fakeLocalWriter();
+  files.set("a.md", "local edit");
+  const hash = await hashOf("remote edit");
+  const { storage, objects } = fakeStorage({
+    [blobKeyFor(hash)]: "remote edit",
+    [MANIFEST_KEY]: "irrelevant",
+  });
+  const remote = snapshot(file("a.md", hash));
+  const now = Date.parse("2026-07-14T10:00:00.000Z");
+
+  const { failures } = await executeSyncPlan(
+    [{ kind: "conflict", path: "a.md", deletedSide: "none" }],
+    empty,
+    reader,
+    writer,
+    storage,
+    now,
+    remote,
+    '"stale-etag"',
+  );
+
+  assert.deepEqual(failures, [
+    { path: "a.md", message: "changed remotely mid sync; sync again to reconcile" },
+  ]);
+  // The local edit was already renamed and pushed as a copy before the drift was caught, so it is
+  // never lost; only the stale remote restore is refused.
+  assert.equal(files.get("a.md"), undefined);
+  assert.equal(files.get(conflictCopyPath("a.md", now)), "local edit");
+  assert.equal(objects.get(blobKeyFor(await hashOf("local edit"))), "local edit");
 });
 
 test("executeSyncPlan: conflict restore with hash mismatch is refused and nothing is written", async () => {

--- a/src/sync/execute.test.ts
+++ b/src/sync/execute.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { hashBytes } from "../vault/vault.ts";
+import { hashBytes, type Reader } from "../vault/vault.ts";
 import { executeSyncPlan } from "./execute.ts";
 import { empty, fakeLocalWriter, fakeReader, fakeStorage, file, snapshot } from "./fake.ts";
 import { blobKeyFor, conflictCopyPath, MANIFEST_KEY, type SyncAction } from "./plan.ts";
@@ -605,15 +605,20 @@ test("executeSyncPlan: a conflict whose copy push fails is a failed action, even
 });
 
 test("executeSyncPlan: a pull whose local write throws is reported and doesn't stop the rest of the plan", async () => {
-  // writeFile can throw on a disk full or permission error. Like every storage failure, that must
+  // A commit can throw on a disk full or permission error. Like every storage failure, that must
   // be recorded as a per file failure rather than escaping the loop and abandoning b.md.
   const reader = fakeReader({});
   const { writer, files } = fakeLocalWriter();
-  writer.writeFile = async (path) => {
-    if (path === "a.md") {
-      throw new Error("EACCES: permission denied");
-    }
-    files.set(path, "pulled");
+  writer.stageFile = async (path) => {
+    return {
+      commit: async () => {
+        if (path === "a.md") {
+          throw new Error("EACCES: permission denied");
+        }
+        files.set(path, "pulled");
+      },
+      discard: async () => {},
+    };
   };
   const aHash = await hashOf("remote a");
   const bHash = await hashOf("remote b");
@@ -789,6 +794,191 @@ test("executeSyncPlan: pull proceeds when the manifest etag still matches what t
 
   assert.deepEqual(failures, []);
   assert.equal(files.get("a.md"), "hello");
+});
+
+test("executeSyncPlan: a pull whose local file is edited while its payload stages is refused, and the edit survives", async () => {
+  // The window this closes. Staging the payload used to happen after checkLocalDrift, inside the
+  // single writeFile call, so an edit landing during that write, which on a large attachment is
+  // nearly the whole pull, was checked for before it existed and then silently overwritten. Worse
+  // than a lost race elsewhere: the action reports success, so its path advances in state.json at
+  // the pulled hash and no later pass can tell the edit ever happened. Staging first is what puts
+  // the edit in front of the check rather than behind it.
+  const readerFiles: Record<string, string> = { "a.md": "as snapshotted" };
+  const reader = fakeReader(readerFiles);
+  const local = snapshot(file("a.md", await hashOf("as snapshotted")));
+  const { writer, files } = fakeLocalWriter();
+  let discarded = 0;
+  const innerStage = writer.stageFile;
+  writer.stageFile = async (path, data) => {
+    readerFiles["a.md"] = "edited while staging";
+    const staged = await innerStage(path, data);
+
+    return {
+      commit: staged.commit,
+      discard: async () => {
+        discarded++;
+        await staged.discard();
+      },
+    };
+  };
+  const hash = await hashOf("remote a");
+  const { storage } = fakeStorage({ [blobKeyFor(hash)]: "remote a" });
+  const remote = snapshot(file("a.md", hash));
+
+  const { failures, completed } = await executeSyncPlan(
+    [{ kind: "pull", path: "a.md" }],
+    local,
+    reader,
+    writer,
+    storage,
+    1,
+    remote,
+  );
+
+  assert.deepEqual(failures, [
+    { path: "a.md", message: "changed locally mid sync; sync again to reconcile" },
+  ]);
+  assert.deepEqual(completed, []);
+  assert.equal(files.has("a.md"), false);
+  assert.equal(readerFiles["a.md"], "edited while staging");
+  assert.equal(discarded, 1);
+});
+
+test("executeSyncPlan: a pull stages its payload before both drift checks and commits only after them", async () => {
+  // The ordering the whole fix turns on, asserted directly because every other test here can only
+  // observe its consequences. Staging last would put the payload write between the final check and
+  // the destination changing; running the manifest HEAD last would put the local read, the slow
+  // check, in front of it instead. Only this order leaves each check with nothing but the commit's
+  // rename ahead of it, and puts the unrecoverable check (local) closest to that rename.
+  const ops: string[] = [];
+  const baseReader = fakeReader({});
+  const reader: Reader = {
+    ...baseReader,
+    fileExists: async (path) => {
+      ops.push("checkLocal");
+      return baseReader.fileExists(path);
+    },
+  };
+  const { writer, files } = fakeLocalWriter();
+  const innerStage = writer.stageFile;
+  writer.stageFile = async (path, data) => {
+    ops.push("stage");
+    const staged = await innerStage(path, data);
+
+    return {
+      commit: async () => {
+        ops.push("commit");
+        await staged.commit();
+      },
+      discard: staged.discard,
+    };
+  };
+  const hash = await hashOf("hello");
+  const { storage } = fakeStorage({ [blobKeyFor(hash)]: "hello", [MANIFEST_KEY]: "current" });
+  const innerHead = storage.headObject;
+  storage.headObject = async (key) => {
+    if (key === MANIFEST_KEY) {
+      ops.push("checkManifest");
+    }
+    return innerHead(key);
+  };
+  const manifestHead = await storage.headObject(MANIFEST_KEY);
+  ops.length = 0;
+  const remote = snapshot(file("a.md", hash));
+
+  const { failures } = await executeSyncPlan(
+    [{ kind: "pull", path: "a.md" }],
+    empty,
+    reader,
+    writer,
+    storage,
+    1,
+    remote,
+    manifestHead.etag,
+  );
+
+  assert.deepEqual(failures, []);
+  assert.deepEqual(ops, ["stage", "checkManifest", "checkLocal", "commit"]);
+  assert.equal(files.get("a.md"), "hello");
+});
+
+test("executeSyncPlan: a pull refused by manifest drift discards its staged payload", async () => {
+  // A refused write must not leave its staging file behind holding a copy of remote content. The
+  // path is deterministic so a leftover would eventually be reclaimed, but "eventually" means the
+  // next pull of the same path, which may never come.
+  const reader = fakeReader({});
+  const { writer, files } = fakeLocalWriter();
+  let discarded = 0;
+  const innerStage = writer.stageFile;
+  writer.stageFile = async (path, data) => {
+    const staged = await innerStage(path, data);
+
+    return {
+      commit: staged.commit,
+      discard: async () => {
+        discarded++;
+        await staged.discard();
+      },
+    };
+  };
+  const hash = await hashOf("hello");
+  const { storage } = fakeStorage({ [blobKeyFor(hash)]: "hello", [MANIFEST_KEY]: "irrelevant" });
+  const remote = snapshot(file("a.md", hash));
+
+  const { failures } = await executeSyncPlan(
+    [{ kind: "pull", path: "a.md" }],
+    empty,
+    reader,
+    writer,
+    storage,
+    1,
+    remote,
+    '"stale-etag"',
+  );
+
+  assert.deepEqual(failures, [
+    { path: "a.md", message: "changed remotely mid sync; sync again to reconcile" },
+  ]);
+  assert.equal(files.has("a.md"), false);
+  assert.equal(discarded, 1);
+});
+
+test("executeSyncPlan: a discard that itself fails never masks the failure that refused the write", async () => {
+  // discardStaged swallows its own errors on purpose: the caller is already returning the reason
+  // the write was refused, and that reason is the one worth reporting. A throwing discard must not
+  // replace it, nor escape the loop and abandon the rest of the plan.
+  const reader = fakeReader({});
+  const { writer, files } = fakeLocalWriter();
+  const innerStage = writer.stageFile;
+  writer.stageFile = async (path, data) => {
+    const staged = await innerStage(path, data);
+
+    return {
+      commit: staged.commit,
+      discard: async () => {
+        throw new Error("EACCES: cannot remove staged file");
+      },
+    };
+  };
+  const hash = await hashOf("hello");
+  const { storage } = fakeStorage({ [blobKeyFor(hash)]: "hello", [MANIFEST_KEY]: "irrelevant" });
+  const remote = snapshot(file("a.md", hash));
+
+  const { failures } = await executeSyncPlan(
+    [{ kind: "pull", path: "a.md" }],
+    empty,
+    reader,
+    writer,
+    storage,
+    1,
+    remote,
+    '"stale-etag"',
+  );
+
+  assert.deepEqual(failures, [
+    { path: "a.md", message: "changed remotely mid sync; sync again to reconcile" },
+  ]);
+  assert.equal(files.has("a.md"), false);
 });
 
 test("executeSyncPlan: a conflict restore refuses when the manifest has moved on, and the local edit survives as a copy", async () => {

--- a/src/sync/execute.test.ts
+++ b/src/sync/execute.test.ts
@@ -318,6 +318,33 @@ test("executeSyncPlan: pullDelete of a file that exists but cannot be read is re
   assert.equal(files.get("a.md"), "hello");
 });
 
+test("executeSyncPlan: pullDelete refuses when the manifest has moved on, rather than deleting a repopulated path", async () => {
+  // pullDelete has no bucket object of its own to check, unlike pull's fetch, so it would
+  // otherwise remove a local file purely on the say of a stale plan even though another device has
+  // since pushed new content back to this exact path.
+  const reader = fakeReader({ "a.md": "hello" });
+  const { writer, files } = fakeLocalWriter();
+  files.set("a.md", "hello");
+  const local = snapshot(file("a.md", await hashOf("hello")));
+  const { storage } = fakeStorage({ [MANIFEST_KEY]: "irrelevant" });
+
+  const { failures } = await executeSyncPlan(
+    [{ kind: "pullDelete", path: "a.md" }],
+    local,
+    reader,
+    writer,
+    storage,
+    1,
+    empty,
+    '"stale-etag"',
+  );
+
+  assert.deepEqual(failures, [
+    { path: "a.md", message: "changed remotely mid sync; sync again to reconcile" },
+  ]);
+  assert.equal(files.get("a.md"), "hello");
+});
+
 test("executeSyncPlan: a conflict renames the local copy, pushes its blob to storage, and pulls the remote version clean", async () => {
   const reader = fakeReader({ "a.md": "local edit" });
   const { writer, files } = fakeLocalWriter();
@@ -383,7 +410,10 @@ test("executeSyncPlan: a conflict with nothing local to preserve just pulls the 
 test("executeSyncPlan: a conflict restore onto a path recreated after the snapshot is refused", async () => {
   // The snapshot saw this path as locally deleted, so the plan decided the remote edit could be
   // restored with nothing to preserve. The user then recreated the file before the plan reached
-  // this action; overwriting it now would discard content the plan never saw (#86).
+  // this action; overwriting it now would discard content the plan never saw (#86). No remote
+  // snapshot is supplied either, so the fetch this branch attempts first refuses on its own
+  // account (a plan with no manifest entry to restore from is already inconsistent); either way
+  // the recreated file is never touched.
   const reader = fakeReader({ "a.md": "recreated after snapshot" });
   const { writer, files } = fakeLocalWriter();
   files.set("a.md", "recreated after snapshot");
@@ -397,6 +427,33 @@ test("executeSyncPlan: a conflict restore onto a path recreated after the snapsh
     writer,
     storage,
     now,
+  );
+
+  assert.deepEqual(failures, [
+    { path: "a.md", message: "manifest missing expected hash for this path" },
+  ]);
+  assert.equal(files.get("a.md"), "recreated after snapshot");
+});
+
+test("executeSyncPlan: a conflict restore onto a path recreated after the snapshot is refused even with a real remote entry", async () => {
+  // The same scenario as above but with a real remote entry present, so the fetch succeeds and the
+  // recreated local file is what checkLocalDrift, run last, must catch.
+  const reader = fakeReader({ "a.md": "recreated after snapshot" });
+  const { writer, files } = fakeLocalWriter();
+  files.set("a.md", "recreated after snapshot");
+  const hash = await hashOf("remote edit");
+  const { storage } = fakeStorage({ [blobKeyFor(hash)]: "remote edit" });
+  const remote = snapshot(file("a.md", hash));
+  const now = Date.parse("2026-07-14T10:00:00.000Z");
+
+  const { failures } = await executeSyncPlan(
+    [{ kind: "conflict", path: "a.md", deletedSide: "local" }],
+    empty,
+    reader,
+    writer,
+    storage,
+    now,
+    remote,
   );
 
   assert.deepEqual(failures, [

--- a/src/sync/execute.test.ts
+++ b/src/sync/execute.test.ts
@@ -3,15 +3,16 @@ import { test } from "node:test";
 import { hashBytes } from "../vault/vault.ts";
 import { executeSyncPlan } from "./execute.ts";
 import { empty, fakeLocalWriter, fakeReader, fakeStorage, file, snapshot } from "./fake.ts";
-import { conflictCopyPath, type SyncAction, trashKeyFor } from "./plan.ts";
+import { blobKeyFor, conflictCopyPath, type SyncAction } from "./plan.ts";
 
 // hashOf returns the real content hash of text, for building local snapshots whose entries
-// executeSyncPlan's drift check can verify against a fake reader's live bytes.
+// executeSyncPlan's drift check can verify against a fake reader's live bytes, and for keying a
+// fakeStorage seed at the blob key content actually lives under.
 async function hashOf(text: string): Promise<string> {
   return hashBytes(new TextEncoder().encode(text));
 }
 
-test("executeSyncPlan: push reads the local file and puts it remotely", async () => {
+test("executeSyncPlan: push reads the local file and puts its blob remotely", async () => {
   const reader = fakeReader({ "a.md": "hello" });
   const { writer, files } = fakeLocalWriter();
   const { storage, objects } = fakeStorage();
@@ -25,10 +26,11 @@ test("executeSyncPlan: push reads the local file and puts it remotely", async ()
     1,
   );
 
+  const hash = await hashOf("hello");
   assert.deepEqual(failures, []);
-  assert.equal(objects.get("a.md"), "hello");
+  assert.equal(objects.get(blobKeyFor(hash)), "hello");
   assert.equal(files.size, 0);
-  assert.deepEqual(pushedFiles, [{ path: "a.md", size: 5, mtime: 1, hash: await hashOf("hello") }]);
+  assert.deepEqual(pushedFiles, [{ path: "a.md", size: 5, mtime: 1, hash }]);
 });
 
 test("executeSyncPlan: a push records the bytes it actually uploaded, not the pre push snapshot's hash", async () => {
@@ -50,38 +52,67 @@ test("executeSyncPlan: a push records the bytes it actually uploaded, not the pr
     1,
   );
 
+  const hash = await hashOf("edited after snapshot");
   assert.deepEqual(failures, []);
-  assert.equal(objects.get("a.md"), "edited after snapshot");
+  assert.equal(objects.get(blobKeyFor(hash)), "edited after snapshot");
   assert.deepEqual(pushedFiles, [
-    {
-      path: "a.md",
-      size: "edited after snapshot".length,
-      mtime: 1,
-      hash: await hashOf("edited after snapshot"),
-    },
+    { path: "a.md", size: "edited after snapshot".length, mtime: 1, hash },
   ]);
 });
 
-test("executeSyncPlan: pushDelete trashes the remote object before removing its live key", async () => {
+test("executeSyncPlan: pushing content already stored under another path costs a HEAD, never a re-upload", async () => {
+  // The whole point of a content addressed key: a rename, or a second file with identical bytes,
+  // recognises the blob already exists and skips the PUT entirely.
+  const reader = fakeReader({ "b.md": "hello" });
+  const { writer } = fakeLocalWriter();
+  const hash = await hashOf("hello");
+  const { storage, objects } = fakeStorage({ [blobKeyFor(hash)]: "hello" });
+  let puts = 0;
+  storage.putObject = async () => {
+    puts++;
+    return { ok: true, status: "ok", message: "" };
+  };
+
+  const { failures, pushedFiles } = await executeSyncPlan(
+    [{ kind: "push", path: "b.md" }],
+    empty,
+    reader,
+    writer,
+    storage,
+    1,
+  );
+
+  assert.deepEqual(failures, []);
+  assert.equal(puts, 0);
+  assert.equal(objects.size, 1);
+  assert.deepEqual(pushedFiles, [{ path: "b.md", size: 5, mtime: 1, hash }]);
+});
+
+test("executeSyncPlan: pushDelete completes without touching the bucket, and the blob survives", async () => {
   const reader = fakeReader({});
   const { writer } = fakeLocalWriter();
-  const { storage, objects } = fakeStorage({ "a.md": "hello" });
+  const hash = await hashOf("hello");
+  const { storage, objects } = fakeStorage({ [blobKeyFor(hash)]: "hello" });
+  const remote = snapshot(file("a.md", hash));
 
-  const { failures } = await executeSyncPlan(
+  const { completed, failures } = await executeSyncPlan(
     [{ kind: "pushDelete", path: "a.md" }],
     empty,
     reader,
     writer,
     storage,
     0,
+    remote,
   );
 
   assert.deepEqual(failures, []);
-  assert.equal(objects.has("a.md"), false);
-  assert.equal(objects.get(trashKeyFor("a.md", 0)), "hello");
+  assert.deepEqual(completed, [{ kind: "pushDelete", path: "a.md" }]);
+  // Deletion is a manifest change, never a bucket write: the blob is never destroyed, so it stays
+  // reachable at its hash for as long as any retained manifest, past or present, still names it.
+  assert.equal(objects.get(blobKeyFor(hash)), "hello");
 });
 
-test("executeSyncPlan: pushDelete of an already absent remote object succeeds without trashing", async () => {
+test("executeSyncPlan: pushDelete succeeds even when the bucket never held a blob for the path", async () => {
   const reader = fakeReader({});
   const { writer } = fakeLocalWriter();
   const { storage, objects } = fakeStorage({});
@@ -100,79 +131,12 @@ test("executeSyncPlan: pushDelete of an already absent remote object succeeds wi
   assert.equal(objects.size, 0);
 });
 
-test("executeSyncPlan: pushDelete leaves the live object intact when the trash copy fails", async () => {
-  const reader = fakeReader({});
-  const { writer } = fakeLocalWriter();
-  const { storage, objects } = fakeStorage({ "a.md": "hello" });
-  storage.copyObject = async () => ({ ok: false, status: "server", message: "copy boom" });
-
-  const { failed, failures } = await executeSyncPlan(
-    [{ kind: "pushDelete", path: "a.md" }],
-    empty,
-    reader,
-    writer,
-    storage,
-    0,
-  );
-
-  assert.deepEqual(failures, [{ path: "a.md", message: "copy boom" }]);
-  assert.equal(failed.length, 1);
-  assert.equal(objects.get("a.md"), "hello");
-});
-
-test("executeSyncPlan: pushDelete removes the object that still matches the snapshot", async () => {
-  const reader = fakeReader({});
-  const { writer } = fakeLocalWriter();
-  const { storage, objects } = fakeStorage({ "a.md": "hello" });
-  const remote = snapshot(file("a.md", await hashOf("hello")));
-
-  const { completed, failures } = await executeSyncPlan(
-    [{ kind: "pushDelete", path: "a.md" }],
-    empty,
-    reader,
-    writer,
-    storage,
-    0,
-    remote,
-  );
-
-  assert.deepEqual(failures, []);
-  assert.equal(completed.length, 1);
-  assert.equal(objects.has("a.md"), false);
-  assert.equal(objects.get(trashKeyFor("a.md", 0)), "hello");
-});
-
-test("executeSyncPlan: pushDelete aborts as concurrent when remote object drifted", async () => {
-  const reader = fakeReader({});
-  const { writer } = fakeLocalWriter();
-  // Another device pushed new content to a.md after the manifest this pass planned from was read.
-  const { storage, objects } = fakeStorage({ "a.md": "hello world" });
-  const remote = snapshot(file("a.md", await hashOf("hello")));
-
-  const { concurrent, failed, failures } = await executeSyncPlan(
-    [{ kind: "pushDelete", path: "a.md" }],
-    empty,
-    reader,
-    writer,
-    storage,
-    0,
-    remote,
-  );
-
-  assert.equal(concurrent, true);
-  assert.equal(failed.length, 1);
-  assert.equal(failures.length, 1);
-  assert.equal(failures[0]?.path, "a.md");
-  // The newer bytes survive untouched: nothing deleted, nothing trashed.
-  assert.equal(objects.get("a.md"), "hello world");
-  assert.equal(objects.has(trashKeyFor("a.md", 0)), false);
-});
-
-test("executeSyncPlan: pull fetches the remote object and writes it locally", async () => {
+test("executeSyncPlan: pull fetches the remote blob and writes it locally", async () => {
   const reader = fakeReader({});
   const { writer, files } = fakeLocalWriter();
-  const { storage } = fakeStorage({ "a.md": "hello" });
-  const remote = snapshot(file("a.md", await hashOf("hello")));
+  const hash = await hashOf("hello");
+  const { storage } = fakeStorage({ [blobKeyFor(hash)]: "hello" });
+  const remote = snapshot(file("a.md", hash));
 
   const { failures } = await executeSyncPlan(
     [{ kind: "pull", path: "a.md" }],
@@ -193,8 +157,9 @@ test("executeSyncPlan: pull overwrites a local file that still matches the snaps
   const { writer, files } = fakeLocalWriter();
   files.set("a.md", "unchanged");
   const local = snapshot(file("a.md", await hashOf("unchanged")));
-  const { storage } = fakeStorage({ "a.md": "remote edit" });
-  const remote = snapshot(file("a.md", await hashOf("remote edit")));
+  const remoteHash = await hashOf("remote edit");
+  const { storage } = fakeStorage({ [blobKeyFor(remoteHash)]: "remote edit" });
+  const remote = snapshot(file("a.md", remoteHash));
 
   const { failures } = await executeSyncPlan(
     [{ kind: "pull", path: "a.md" }],
@@ -219,11 +184,13 @@ test("executeSyncPlan: pull onto a file edited after the snapshot is refused and
   const { writer, files } = fakeLocalWriter();
   files.set("a.md", "edited after snapshot");
   const local = snapshot(file("a.md", await hashOf("as snapshotted")));
-  const { storage } = fakeStorage({ "a.md": "remote edit", "b.md": "remote b" });
-  const remote = snapshot(
-    file("a.md", await hashOf("remote edit")),
-    file("b.md", await hashOf("remote b")),
-  );
+  const aHash = await hashOf("remote edit");
+  const bHash = await hashOf("remote b");
+  const { storage } = fakeStorage({
+    [blobKeyFor(aHash)]: "remote edit",
+    [blobKeyFor(bHash)]: "remote b",
+  });
+  const remote = snapshot(file("a.md", aHash), file("b.md", bHash));
 
   const actions: SyncAction[] = [
     { kind: "pull", path: "a.md" },
@@ -246,7 +213,32 @@ test("executeSyncPlan: pull onto a file created after the snapshot is refused", 
   const reader = fakeReader({ "a.md": "created after snapshot" });
   const { writer, files } = fakeLocalWriter();
   files.set("a.md", "created after snapshot");
-  const { storage } = fakeStorage({ "a.md": "remote edit" });
+  const hash = await hashOf("remote edit");
+  const { storage } = fakeStorage({ [blobKeyFor(hash)]: "remote edit" });
+  const remote = snapshot(file("a.md", hash));
+
+  const { failures } = await executeSyncPlan(
+    [{ kind: "pull", path: "a.md" }],
+    empty,
+    reader,
+    writer,
+    storage,
+    1,
+    remote,
+  );
+
+  assert.deepEqual(failures, [
+    { path: "a.md", message: "changed locally mid sync; sync again to reconcile" },
+  ]);
+  assert.equal(files.get("a.md"), "created after snapshot");
+});
+
+test("executeSyncPlan: a pull whose manifest entry carries no hash is refused before any storage read", async () => {
+  // Every pull through syncOnce carries a manifest entry; a caller that supplies no remote view at
+  // all (the empty default) has no key to even attempt a read against.
+  const reader = fakeReader({});
+  const { writer, files } = fakeLocalWriter();
+  const { storage } = fakeStorage();
 
   const { failures } = await executeSyncPlan(
     [{ kind: "pull", path: "a.md" }],
@@ -258,9 +250,9 @@ test("executeSyncPlan: pull onto a file created after the snapshot is refused", 
   );
 
   assert.deepEqual(failures, [
-    { path: "a.md", message: "changed locally mid sync; sync again to reconcile" },
+    { path: "a.md", message: "manifest missing expected hash for this path" },
   ]);
-  assert.equal(files.get("a.md"), "created after snapshot");
+  assert.equal(files.has("a.md"), false);
 });
 
 test("executeSyncPlan: pullDelete removes a local file that still matches the snapshot", async () => {
@@ -326,12 +318,13 @@ test("executeSyncPlan: pullDelete of a file that exists but cannot be read is re
   assert.equal(files.get("a.md"), "hello");
 });
 
-test("executeSyncPlan: a conflict renames the local copy, pushes it to storage, and pulls the remote version clean", async () => {
+test("executeSyncPlan: a conflict renames the local copy, pushes its blob to storage, and pulls the remote version clean", async () => {
   const reader = fakeReader({ "a.md": "local edit" });
   const { writer, files } = fakeLocalWriter();
   files.set("a.md", "local edit");
-  const { storage, objects } = fakeStorage({ "a.md": "remote edit" });
-  const remote = snapshot(file("a.md", await hashOf("remote edit")));
+  const remoteHash = await hashOf("remote edit");
+  const { storage, objects } = fakeStorage({ [blobKeyFor(remoteHash)]: "remote edit" });
+  const remote = snapshot(file("a.md", remoteHash));
   const now = Date.parse("2026-07-14T10:00:00.000Z");
 
   const { failures, pushedFiles } = await executeSyncPlan(
@@ -344,13 +337,14 @@ test("executeSyncPlan: a conflict renames the local copy, pushes it to storage, 
     remote,
   );
 
+  const copyHash = await hashOf("local edit");
   assert.deepEqual(failures, []);
   assert.equal(files.get("a.md"), "remote edit");
   assert.equal(files.get(conflictCopyPath("a.md", now)), "local edit");
-  // The conflict copy must also reach storage: otherwise the manifest uploaded after this sync
-  // claims a remote object that doesn't exist, and every other device fails forever trying to
-  // pull it.
-  assert.equal(objects.get(conflictCopyPath("a.md", now)), "local edit");
+  // The conflict copy's blob must also reach storage: otherwise the manifest uploaded after this
+  // sync claims a path pointing at a blob that doesn't exist, and every other device fails
+  // forever trying to pull it.
+  assert.equal(objects.get(blobKeyFor(copyHash)), "local edit");
   // Recorded at the hash of the copy's own bytes, the same race a push closes: the conflict copy
   // is read fresh at execution time, never assumed from a pre-sync snapshot.
   assert.deepEqual(pushedFiles, [
@@ -358,7 +352,7 @@ test("executeSyncPlan: a conflict renames the local copy, pushes it to storage, 
       path: conflictCopyPath("a.md", now),
       size: "local edit".length,
       mtime: now,
-      hash: await hashOf("local edit"),
+      hash: copyHash,
     },
   ]);
 });
@@ -366,8 +360,9 @@ test("executeSyncPlan: a conflict renames the local copy, pushes it to storage, 
 test("executeSyncPlan: a conflict with nothing local to preserve just pulls the remote version, never reading a deleted local file", async () => {
   const reader = fakeReader({});
   const { writer, files } = fakeLocalWriter();
-  const { storage } = fakeStorage({ "a.md": "remote edit" });
-  const remote = snapshot(file("a.md", await hashOf("remote edit")));
+  const hash = await hashOf("remote edit");
+  const { storage } = fakeStorage({ [blobKeyFor(hash)]: "remote edit" });
+  const remote = snapshot(file("a.md", hash));
   const now = Date.parse("2026-07-14T10:00:00.000Z");
 
   const { failures } = await executeSyncPlan(
@@ -392,7 +387,7 @@ test("executeSyncPlan: a conflict restore onto a path recreated after the snapsh
   const reader = fakeReader({ "a.md": "recreated after snapshot" });
   const { writer, files } = fakeLocalWriter();
   files.set("a.md", "recreated after snapshot");
-  const { storage } = fakeStorage({ "a.md": "remote edit" });
+  const { storage } = fakeStorage();
   const now = Date.parse("2026-07-14T10:00:00.000Z");
 
   const { failures } = await executeSyncPlan(
@@ -426,10 +421,11 @@ test("executeSyncPlan: a conflict with nothing remote to pull preserves the loca
     now,
   );
 
+  const copyHash = await hashOf("local edit");
   assert.deepEqual(failures, []);
   assert.equal(files.has("a.md"), false);
   assert.equal(files.get(conflictCopyPath("a.md", now)), "local edit");
-  assert.equal(objects.get(conflictCopyPath("a.md", now)), "local edit");
+  assert.equal(objects.get(blobKeyFor(copyHash)), "local edit");
 });
 
 test("executeSyncPlan: a push whose local file vanished is reported and doesn't stop the rest of the plan", async () => {
@@ -446,9 +442,9 @@ test("executeSyncPlan: a push whose local file vanished is reported and doesn't 
   ];
   const { failures } = await executeSyncPlan(actions, empty, reader, writer, storage, 1);
 
+  const worldHash = await hashOf("world");
   assert.deepEqual(failures, [{ path: "a.md", message: "no such file: a.md" }]);
-  assert.equal(objects.get("b.md"), "world");
-  assert.equal(objects.has("a.md"), false);
+  assert.equal(objects.get(blobKeyFor(worldHash)), "world");
 });
 
 test("executeSyncPlan: a conflict whose local file vanished is reported, nothing is renamed or pushed, and the plan continues", async () => {
@@ -466,23 +462,24 @@ test("executeSyncPlan: a conflict whose local file vanished is reported, nothing
   ];
   const { failures } = await executeSyncPlan(actions, empty, reader, writer, storage, now);
 
+  const worldHash = await hashOf("world");
   assert.deepEqual(failures, [{ path: "a.md", message: "no such file: a.md" }]);
   // No conflict copy was created locally or remotely from a file that wasn't there to preserve.
   assert.equal(files.has(conflictCopyPath("a.md", now)), false);
-  assert.equal(objects.has(conflictCopyPath("a.md", now)), false);
   // The following action still ran.
-  assert.equal(objects.get("b.md"), "world");
+  assert.equal(objects.get(blobKeyFor(worldHash)), "world");
 });
 
 test("executeSyncPlan: a failed push is reported and doesn't stop the rest of the plan", async () => {
   const reader = fakeReader({ "a.md": "hello", "b.md": "world" });
   const { writer, files } = fakeLocalWriter();
   const { storage, objects } = fakeStorage();
-  storage.putObject = async (key) => {
-    if (key === "a.md") {
+  const helloHash = await hashOf("hello");
+  storage.putObject = async (key, body) => {
+    if (key === blobKeyFor(helloHash)) {
       return { ok: false, status: "server", message: "Storage rejected the write (500)" };
     }
-    objects.set(key, "world");
+    objects.set(key, new TextDecoder().decode(body));
     return { ok: true, status: "ok", message: "" };
   };
 
@@ -499,8 +496,9 @@ test("executeSyncPlan: a failed push is reported and doesn't stop the rest of th
     1,
   );
 
+  const worldHash = await hashOf("world");
   assert.deepEqual(failures, [{ path: "a.md", message: "Storage rejected the write (500)" }]);
-  assert.equal(objects.get("b.md"), "world");
+  assert.equal(objects.get(blobKeyFor(worldHash)), "world");
   assert.equal(files.size, 0);
   // The pass reports exactly which actions completed and which didn't, so syncOnce can record
   // b.md's progress in the manifest while leaving a.md pending for the next pass (#87).
@@ -511,19 +509,18 @@ test("executeSyncPlan: a failed push is reported and doesn't stop the rest of th
 test("executeSyncPlan: a conflict whose copy push fails is a failed action, even though the failure names the copy path", async () => {
   // The copy push failure is recorded against copyPath, not the action's own path; failed must
   // still carry the action itself, so syncOnce reverts the right path and the manifest never
-  // claims a copy the bucket refused.
+  // claims a copy pointing at a blob the bucket refused.
   const reader = fakeReader({ "a.md": "local edit" });
   const { writer, files } = fakeLocalWriter();
   files.set("a.md", "local edit");
-  const { storage, objects } = fakeStorage({ "a.md": "remote edit" });
-  const remote = snapshot(file("a.md", await hashOf("remote edit")));
-  const inner = storage.putObject;
-  storage.putObject = async (key, body, condition) => {
-    if (key !== "a.md") {
-      return { ok: false, status: "server", message: "Storage rejected the write (500)" };
-    }
-    return inner(key, body, condition);
-  };
+  const remoteHash = await hashOf("remote edit");
+  const { storage, objects } = fakeStorage({ [blobKeyFor(remoteHash)]: "remote edit" });
+  const remote = snapshot(file("a.md", remoteHash));
+  storage.putObject = async () => ({
+    ok: false,
+    status: "server",
+    message: "Storage rejected the write (500)",
+  });
   const now = Date.parse("2026-07-14T10:00:00.000Z");
 
   const action: SyncAction = { kind: "conflict", path: "a.md", deletedSide: "none" };
@@ -537,6 +534,7 @@ test("executeSyncPlan: a conflict whose copy push fails is a failed action, even
     remote,
   );
 
+  const copyHash = await hashOf("local edit");
   assert.deepEqual(failures, [
     { path: conflictCopyPath("a.md", now), message: "Storage rejected the write (500)" },
   ]);
@@ -546,7 +544,7 @@ test("executeSyncPlan: a conflict whose copy push fails is a failed action, even
   // ready to push next pass.
   assert.equal(files.get("a.md"), "remote edit");
   assert.equal(files.get(conflictCopyPath("a.md", now)), "local edit");
-  assert.equal(objects.has(conflictCopyPath("a.md", now)), false);
+  assert.equal(objects.has(blobKeyFor(copyHash)), false);
 });
 
 test("executeSyncPlan: a pull whose local write throws is reported and doesn't stop the rest of the plan", async () => {
@@ -560,11 +558,13 @@ test("executeSyncPlan: a pull whose local write throws is reported and doesn't s
     }
     files.set(path, "pulled");
   };
-  const { storage } = fakeStorage({ "a.md": "remote a", "b.md": "remote b" });
-  const remote = snapshot(
-    file("a.md", await hashOf("remote a")),
-    file("b.md", await hashOf("remote b")),
-  );
+  const aHash = await hashOf("remote a");
+  const bHash = await hashOf("remote b");
+  const { storage } = fakeStorage({
+    [blobKeyFor(aHash)]: "remote a",
+    [blobKeyFor(bHash)]: "remote b",
+  });
+  const remote = snapshot(file("a.md", aHash), file("b.md", bHash));
 
   const actions: SyncAction[] = [
     { kind: "pull", path: "a.md" },
@@ -586,7 +586,8 @@ test("executeSyncPlan: a conflict whose rename throws is reported and the local 
   writer.renameFile = async () => {
     throw new Error("EACCES: permission denied");
   };
-  const { storage, objects } = fakeStorage({ "a.md": "remote edit" });
+  const hash = await hashOf("remote edit");
+  const { storage, objects } = fakeStorage({ [blobKeyFor(hash)]: "remote edit" });
   const now = Date.parse("2026-07-14T10:00:00.000Z");
 
   const { failures } = await executeSyncPlan(
@@ -598,17 +599,19 @@ test("executeSyncPlan: a conflict whose rename throws is reported and the local 
     now,
   );
 
+  const copyHash = await hashOf("local edit");
   assert.deepEqual(failures, [{ path: "a.md", message: "EACCES: permission denied" }]);
   // The local edit is untouched and the remote version never overwrote it.
   assert.equal(files.get("a.md"), "local edit");
-  assert.equal(objects.has(conflictCopyPath("a.md", now)), false);
+  assert.equal(objects.has(blobKeyFor(copyHash)), false);
 });
 
 test("executeSyncPlan: pull with matching hash writes the file to disk", async () => {
   const reader = fakeReader({});
   const { writer, files } = fakeLocalWriter();
-  const { storage } = fakeStorage({ "a.md": "hello" });
-  const remote = snapshot(file("a.md", await hashOf("hello")));
+  const hash = await hashOf("hello");
+  const { storage } = fakeStorage({ [blobKeyFor(hash)]: "hello" });
+  const remote = snapshot(file("a.md", hash));
 
   const { failures } = await executeSyncPlan(
     [{ kind: "pull", path: "a.md" }],
@@ -625,10 +628,14 @@ test("executeSyncPlan: pull with matching hash writes the file to disk", async (
 });
 
 test("executeSyncPlan: pull with hash mismatch is refused and nothing is written to disk", async () => {
+  // The blob key claims to hold "correct content"'s hash but the bytes under it don't match:
+  // storage corruption, essentially impossible in the real world once the key is the hash, but
+  // still checked rather than trusted blind.
   const reader = fakeReader({});
   const { writer, files } = fakeLocalWriter();
-  const { storage } = fakeStorage({ "a.md": "wrong content" });
-  const remote = snapshot(file("a.md", await hashOf("correct content")));
+  const correctHash = await hashOf("correct content");
+  const { storage } = fakeStorage({ [blobKeyFor(correctHash)]: "wrong content" });
+  const remote = snapshot(file("a.md", correctHash));
 
   const { failures } = await executeSyncPlan(
     [{ kind: "pull", path: "a.md" }],
@@ -652,8 +659,9 @@ test("executeSyncPlan: pull with hash mismatch is refused and nothing is written
 test("executeSyncPlan: pull with truncated body is refused and nothing is written to disk", async () => {
   const reader = fakeReader({});
   const { writer, files } = fakeLocalWriter();
-  const { storage } = fakeStorage({ "a.md": "hel" });
-  const remote = snapshot(file("a.md", await hashOf("hello")));
+  const hash = await hashOf("hello");
+  const { storage } = fakeStorage({ [blobKeyFor(hash)]: "hel" });
+  const remote = snapshot(file("a.md", hash));
 
   const { failures } = await executeSyncPlan(
     [{ kind: "pull", path: "a.md" }],
@@ -677,8 +685,9 @@ test("executeSyncPlan: pull with truncated body is refused and nothing is writte
 test("executeSyncPlan: conflict restore with hash mismatch is refused and nothing is written", async () => {
   const reader = fakeReader({});
   const { writer, files } = fakeLocalWriter();
-  const { storage } = fakeStorage({ "a.md": "wrong content" });
-  const remote = snapshot(file("a.md", await hashOf("correct content")));
+  const correctHash = await hashOf("correct content");
+  const { storage } = fakeStorage({ [blobKeyFor(correctHash)]: "wrong content" });
+  const remote = snapshot(file("a.md", correctHash));
   const now = Date.parse("2026-07-14T10:00:00.000Z");
 
   const { failures } = await executeSyncPlan(
@@ -704,8 +713,9 @@ test("executeSyncPlan: conflict with hash mismatch on remote restore is reported
   const reader = fakeReader({ "a.md": "local edit" });
   const { writer, files } = fakeLocalWriter();
   files.set("a.md", "local edit");
-  const { storage, objects } = fakeStorage({ "a.md": "wrong content" });
-  const remote = snapshot(file("a.md", await hashOf("correct content")));
+  const correctHash = await hashOf("correct content");
+  const { storage, objects } = fakeStorage({ [blobKeyFor(correctHash)]: "wrong content" });
+  const remote = snapshot(file("a.md", correctHash));
   const now = Date.parse("2026-07-14T10:00:00.000Z");
 
   const { failures, completed, pushedFiles } = await executeSyncPlan(
@@ -718,6 +728,7 @@ test("executeSyncPlan: conflict with hash mismatch on remote restore is reported
     remote,
   );
 
+  const copyHash = await hashOf("local edit");
   assert.deepEqual(failures, [
     {
       path: "a.md",
@@ -727,7 +738,7 @@ test("executeSyncPlan: conflict with hash mismatch on remote restore is reported
   // The local edit was renamed to the conflict copy before the pull was attempted.
   assert.equal(files.get("a.md"), undefined);
   assert.equal(files.get(conflictCopyPath("a.md", now)), "local edit");
-  assert.equal(objects.get(conflictCopyPath("a.md", now)), "local edit");
+  assert.equal(objects.get(blobKeyFor(copyHash)), "local edit");
   // The action is reported failed, never completed, but the copy really did land in the bucket:
   // pushedFiles must still carry it, or the manifest built from it would never know it's there.
   assert.deepEqual(completed, []);
@@ -736,7 +747,7 @@ test("executeSyncPlan: conflict with hash mismatch on remote restore is reported
       path: conflictCopyPath("a.md", now),
       size: "local edit".length,
       mtime: now,
-      hash: await hashOf("local edit"),
+      hash: copyHash,
     },
   ]);
 });

--- a/src/sync/execute.ts
+++ b/src/sync/execute.ts
@@ -1,12 +1,13 @@
 import type { StorageClient } from "../storage/storage.ts";
 import { byPath, type FileState, hashBytes, type Reader, type Snapshot } from "../vault/vault.ts";
-import { blobKeyFor, conflictCopyPath, type SyncAction } from "./plan.ts";
+import { blobKeyFor, conflictCopyPath, MANIFEST_KEY, type SyncAction } from "./plan.ts";
 
 // DRIFT_MESSAGE is the failure reported when a local file changed after the snapshot an action
 // was planned from; the next sync re-snapshots and replans the path as a conflict.
 const DRIFT_MESSAGE = "changed locally mid sync; sync again to reconcile";
 
 const HASH_MISMATCH_MESSAGE = "fetched bytes do not match manifest hash; sync again to reconcile";
+const MANIFEST_DRIFT_MESSAGE = "changed remotely mid sync; sync again to reconcile";
 const MANIFEST_MISSING_HASH_MESSAGE = "manifest missing expected hash for this path";
 
 // ExecuteResult reports what executeSyncPlan carried out: completed holds every action fully
@@ -14,12 +15,15 @@ const MANIFEST_MISSING_HASH_MESSAGE = "manifest missing expected hash for this p
 // the FileState of every path a blob now exists under, hashed from those exact bytes. pushedFiles
 // is not limited to completed actions: a conflict's copy push can succeed even when the rest of
 // that same action later fails, and the copy still needs to reach the manifest. There is no
-// concurrency flag: every write here is either additive (a blob keyed by its own hash, which a
-// losing race still leaves holding the right bytes) or, for a delete, touches no bucket object at
-// all (see the pushDelete branch of executeAction), so no per file operation can ever discover that
-// the plan's remote view went stale mid pass. The one CAS the plan still depends on is the
-// manifest's own conditional PUT (sync.ts), which remains the sole and sufficient guard against two
-// devices syncing at overlapping times.
+// concurrency flag: a write here is either additive (a blob keyed by its own hash, which a losing
+// race still leaves holding the right bytes) or, for a delete, touches no bucket object at all (see
+// the pushDelete branch of executeAction), so neither can ever discover that the plan's remote view
+// went stale mid pass. A pull family read is different: it fetches a specific blob by the hash the
+// plan already decided on, which by construction always "succeeds" with exactly that content, so it
+// can never notice on its own that a newer manifest has since pointed the path elsewhere; that is
+// what manifestDrifted checks for immediately before each such write. The one CAS the plan
+// ultimately depends on either way is the manifest's own conditional PUT (sync.ts), the backstop
+// that still catches anything a mid pass check's own race window lets through.
 export type ExecuteResult = {
   completed: SyncAction[];
   failed: SyncAction[];
@@ -52,7 +56,10 @@ type ActionResult = {
 // was made from, so each destructive local write can first check the file hasn't changed since
 // (#86). now is passed in rather than read internally so a conflict's copy name is deterministic
 // under test. remote is the manifest the plan was made from, giving each action the hash its
-// path is expected to hold; its empty default suits callers with no remote view.
+// path is expected to hold; its empty default suits callers with no remote view. manifestEtag is
+// the etag of that same manifest read, checked again immediately before a pull family write so a
+// manifest that moved on mid pass is caught before stale content lands on disk (see
+// manifestDrifted); null skips the check for callers with no manifest read to compare against.
 export async function executeSyncPlan(
   actions: SyncAction[],
   local: Snapshot,
@@ -61,6 +68,7 @@ export async function executeSyncPlan(
   storage: StorageClient,
   now: number,
   remote: Snapshot = { files: [] },
+  manifestEtag: string | null = null,
 ): Promise<ExecuteResult> {
   const completed: SyncAction[] = [];
   const failed: SyncAction[] = [];
@@ -78,6 +86,7 @@ export async function executeSyncPlan(
       localWriter,
       storage,
       now,
+      manifestEtag,
     );
     // A conflict's copy push can succeed even when the rest of the action later fails (the pull,
     // its integrity check, or the local write), so pushed is gathered regardless of outcome: it
@@ -185,6 +194,7 @@ async function executeAction(
   localWriter: LocalWriter,
   storage: StorageClient,
   now: number,
+  manifestEtag: string | null,
 ): Promise<ActionResult> {
   if (action.kind === "push") {
     let bytes: Uint8Array;
@@ -225,6 +235,9 @@ async function executeAction(
     if (!fetched.ok) {
       return { failures: [fetched.failure], pushed: [] };
     }
+    if (await manifestDrifted(storage, manifestEtag)) {
+      return { failures: [{ path: action.path, message: MANIFEST_DRIFT_MESSAGE }], pushed: [] };
+    }
     const failure = await applyLocalWrite(action.path, () =>
       localWriter.writeFile(action.path, fetched.body),
     );
@@ -259,6 +272,9 @@ async function executeAction(
     const fetched = await pullBlob(storage, action.path, remoteByPath.get(action.path));
     if (!fetched.ok) {
       return { failures: [fetched.failure], pushed: [] };
+    }
+    if (await manifestDrifted(storage, manifestEtag)) {
+      return { failures: [{ path: action.path, message: MANIFEST_DRIFT_MESSAGE }], pushed: [] };
     }
     const failure = await applyLocalWrite(action.path, () =>
       localWriter.writeFile(action.path, fetched.body),
@@ -311,6 +327,10 @@ async function executeAction(
     failures.push(fetched.failure);
     return { failures, pushed: pushedFiles };
   }
+  if (await manifestDrifted(storage, manifestEtag)) {
+    failures.push({ path: action.path, message: MANIFEST_DRIFT_MESSAGE });
+    return { failures, pushed: pushedFiles };
+  }
   const writeFailure = await applyLocalWrite(action.path, () =>
     localWriter.writeFile(action.path, fetched.body),
   );
@@ -337,6 +357,24 @@ function localFailureMessage(err: unknown): string {
     return err.message;
   }
   return "local file operation failed";
+}
+
+// manifestDrifted reports whether the remote manifest has changed since the pass began, checked
+// immediately before a pull family write commits fetched content to disk. A blob fetched by its
+// own hash always reads back exactly that content, so unlike a plaintext path keyed read this can
+// never itself notice a newer manifest having since pointed the path at a different hash; the
+// manifest's own etag is the only signal left that the plan's remote view is stale. A HEAD, not a
+// full re-fetch, keeps this cheap enough to run before every such write, the same "check right
+// before the destructive write" shape checkLocalDrift already uses for the local side. A caller
+// with no manifest read to compare against (etag null) skips the check rather than treating a
+// missing baseline as drift.
+async function manifestDrifted(storage: StorageClient, etag: string | null): Promise<boolean> {
+  if (etag === null) {
+    return false;
+  }
+  const head = await storage.headObject(MANIFEST_KEY);
+
+  return !head.ok || head.etag !== etag;
 }
 
 // pullBlob reads the blob a path's expected FileState names and verifies it against that expected

--- a/src/sync/execute.ts
+++ b/src/sync/execute.ts
@@ -1,25 +1,27 @@
-import type { PutCondition, StorageClient } from "../storage/storage.ts";
+import type { StorageClient } from "../storage/storage.ts";
 import { byPath, type FileState, hashBytes, type Reader, type Snapshot } from "../vault/vault.ts";
-import { conflictCopyPath, type SyncAction, trashKeyFor } from "./plan.ts";
+import { blobKeyFor, conflictCopyPath, type SyncAction } from "./plan.ts";
 
 // DRIFT_MESSAGE is the failure reported when a local file changed after the snapshot an action
 // was planned from; the next sync re-snapshots and replans the path as a conflict.
 const DRIFT_MESSAGE = "changed locally mid sync; sync again to reconcile";
 
-const REMOTE_DRIFT_MESSAGE = "changed remotely mid sync; sync again to reconcile";
 const HASH_MISMATCH_MESSAGE = "fetched bytes do not match manifest hash; sync again to reconcile";
 const MANIFEST_MISSING_HASH_MESSAGE = "manifest missing expected hash for this path";
-const REMOTE_ETAG_MESSAGE = "remote object has no etag";
 
 // ExecuteResult reports what executeSyncPlan carried out: completed holds every action fully
-// applied, failed the actions that weren't, failures the per file detail of why, concurrent
-// whether a file precondition proved the remote snapshot stale, and pushedFiles the FileState of
-// every path actually written to the bucket, hashed from those exact bytes. pushedFiles is not
-// limited to completed actions: a conflict's copy push can succeed even when the rest of that
-// same action later fails, and the copy still needs to reach the manifest.
+// applied, failed the actions that weren't, failures the per file detail of why, and pushedFiles
+// the FileState of every path a blob now exists under, hashed from those exact bytes. pushedFiles
+// is not limited to completed actions: a conflict's copy push can succeed even when the rest of
+// that same action later fails, and the copy still needs to reach the manifest. There is no
+// concurrency flag: every write here is either additive (a blob keyed by its own hash, which a
+// losing race still leaves holding the right bytes) or, for a delete, touches no bucket object at
+// all (see the pushDelete branch of executeAction), so no per file operation can ever discover that
+// the plan's remote view went stale mid pass. The one CAS the plan still depends on is the
+// manifest's own conditional PUT (sync.ts), which remains the sole and sufficient guard against two
+// devices syncing at overlapping times.
 export type ExecuteResult = {
   completed: SyncAction[];
-  concurrent: boolean;
   failed: SyncAction[];
   failures: SyncFailure[];
   pushedFiles: FileState[];
@@ -40,23 +42,17 @@ export type SyncFailure = {
 };
 
 type ActionResult = {
-  concurrent: boolean;
   failures: SyncFailure[];
   pushed: FileState[];
 };
-
-type PutConditionResult =
-  | { ok: true; kind: "done" }
-  | { ok: true; kind: "put"; condition: PutCondition }
-  | { ok: false; concurrent: boolean; failure: SyncFailure };
 
 // executeSyncPlan carries out every action against reader/localWriter (the local vault) and
 // storage (the remote bucket), and reports what completed and what couldn't be, so one failed
 // file never discards the progress of the rest of the pass (#87). local is the snapshot the plan
 // was made from, so each destructive local write can first check the file hasn't changed since
 // (#86). now is passed in rather than read internally so a conflict's copy name is deterministic
-// under test. remote is the manifest the plan was made from, used to make file PUTs conditional;
-// its empty default makes callers that lack a remote view create-only rather than overwrite.
+// under test. remote is the manifest the plan was made from, giving each action the hash its
+// path is expected to hold; its empty default suits callers with no remote view.
 export async function executeSyncPlan(
   actions: SyncAction[],
   local: Snapshot,
@@ -67,7 +63,6 @@ export async function executeSyncPlan(
   remote: Snapshot = { files: [] },
 ): Promise<ExecuteResult> {
   const completed: SyncAction[] = [];
-  let concurrent = false;
   const failed: SyncAction[] = [];
   const failures: SyncFailure[] = [];
   const pushedFiles: FileState[] = [];
@@ -95,18 +90,12 @@ export async function executeSyncPlan(
       continue;
     }
     failed.push(action);
-    if (actionResult.concurrent) {
-      concurrent = true;
-    }
     for (const failure of actionResult.failures) {
       failures.push(failure);
     }
-    if (actionResult.concurrent) {
-      break;
-    }
   }
 
-  return { completed, concurrent, failed, failures, pushedFiles };
+  return { completed, failed, failures, pushedFiles };
 }
 
 // applyLocalWrite runs one localWriter mutation, converting a thrown I/O error into a SyncFailure
@@ -157,10 +146,37 @@ async function checkLocalDrift(
   return null;
 }
 
-// executeAction carries out a single action and reports its failures and whether remote
-// concurrency invalidated the plan. An action can report more than one failure: a conflict whose
-// copy push fails still pulls the remote version, so the diverged local edit lands on disk even
-// when the bucket refuses the copy.
+// ensureBlobStored makes sure a blob holding bytes exists in the bucket at hash's key, uploading
+// only when it doesn't. The key is derived from the content itself, so an object already there is
+// guaranteed byte identical to what the caller would otherwise upload: a rename or a duplicate
+// attachment costs one HEAD and nothing more, never a re-upload. A losing ifAbsent PUT still means
+// another device wrote this exact content concurrently, so it counts as success rather than the
+// concurrency failure an ordinary conditional write would report; the key can only ever hold the
+// bytes its own hash names.
+async function ensureBlobStored(
+  storage: StorageClient,
+  hash: string,
+  bytes: Uint8Array,
+): Promise<{ ok: true } | { ok: false; message: string }> {
+  const key = blobKeyFor(hash);
+  const head = await storage.headObject(key);
+  if (head.ok) {
+    return { ok: true };
+  }
+  if (head.status !== "not_found") {
+    return { ok: false, message: head.message };
+  }
+  const put = await storage.putObject(key, bytes, { kind: "ifAbsent" });
+  if (put.ok || put.status === "conflict") {
+    return { ok: true };
+  }
+
+  return { ok: false, message: put.message };
+}
+
+// executeAction carries out a single action and reports its failures. An action can report more
+// than one failure: a conflict whose copy push fails still pulls the remote version, so the
+// diverged local edit lands on disk even when the bucket refuses the copy.
 async function executeAction(
   action: SyncAction,
   localByPath: Map<string, FileState>,
@@ -175,77 +191,45 @@ async function executeAction(
     try {
       bytes = await reader.readFile(action.path);
     } catch (err) {
-      return failedAction(action.path, localFailureMessage(err), false);
+      return failedAction(action.path, localFailureMessage(err));
     }
-    const checked = await putCondition(action.path, bytes, remoteByPath.get(action.path), storage);
-    if (!checked.ok) {
-      return { concurrent: checked.concurrent, failures: [checked.failure], pushed: [] };
-    }
+    // Hashed fresh from the bytes just read, not reused from a pre-push snapshot, so a file edited
+    // in the window between the snapshot and this read is never recorded in the manifest as
+    // content the bucket doesn't actually hold.
     const pushed = await pushedFile(action.path, bytes, now);
-    if (checked.kind === "done") {
-      return successfulAction([pushed]);
-    }
-    const result = await storage.putObject(action.path, bytes, checked.condition);
-    if (!result.ok) {
-      if (result.status !== "conflict") {
-        return failedAction(action.path, result.message, false);
-      }
-      const matches = await remoteMatches(action.path, bytes, storage);
-      if (matches) {
-        return successfulAction([pushed]);
-      }
-      return failedAction(action.path, result.message, true);
+    const stored = await ensureBlobStored(storage, pushed.hash, bytes);
+    if (!stored.ok) {
+      return failedAction(action.path, stored.message);
     }
 
     return successfulAction([pushed]);
   }
 
   if (action.kind === "pushDelete") {
-    // Confirm the remote object still holds the bytes this pass planned to delete before touching
-    // it. A drifted or already absent object is handled without destroying newer content (#133).
-    const drift = await checkRemoteDrift(action.path, remoteByPath.get(action.path), storage);
-    if (drift !== null) {
-      return drift;
-    }
-    // Park the object under the reserved trash prefix before removing it from its live key, so a
-    // mistaken delete stays recoverable (#53). A copy that 404s means the object is already gone
-    // remotely (another device deleted it), which is the end state a pushDelete wants: nothing to
-    // trash, nothing to delete. Any other copy failure aborts before the delete, so the live
-    // object is never destroyed without a backup sitting beside it.
-    const copied = await storage.copyObject(action.path, trashKeyFor(action.path, now));
-    if (!copied.ok) {
-      if (copied.status === "not_found") {
-        return successfulAction();
-      }
-      return failedAction(action.path, copied.message, false);
-    }
-    const result = await storage.deleteObject(action.path);
-    if (!result.ok) {
-      return failedAction(action.path, result.message, false);
-    }
-
+    // A deletion is purely a manifest change: the path is dropped from what manifestAfterSync
+    // builds (see plan.ts), and the blob it pointed at is left exactly where it is, never
+    // destroyed, so it stays reachable for as long as any retained manifest still names its hash.
+    // Nothing here touches the bucket, so nothing here can fail, and the drift another device
+    // might race in underneath (#133) is no longer a hazard: there is no live object at a shared
+    // key for that race to clobber. What used to be a trash copy for a recovery window (#53) is
+    // now the default: deletion was never destructive to begin with.
     return successfulAction();
   }
 
   if (action.kind === "pull") {
     const drift = await checkLocalDrift(reader, action.path, localByPath.get(action.path));
     if (drift !== null) {
-      return { concurrent: false, failures: [drift], pushed: [] };
+      return { failures: [drift], pushed: [] };
     }
-    const result = await storage.getObject(action.path, remoteByPath.get(action.path)?.size);
-    if (!result.ok || result.body === null) {
-      return failedAction(action.path, result.message, false);
-    }
-    const body = result.body;
-    const integrity = await verifyFetch(action.path, body, remoteByPath.get(action.path));
-    if (integrity !== null) {
-      return { concurrent: false, failures: [integrity], pushed: [] };
+    const fetched = await pullBlob(storage, action.path, remoteByPath.get(action.path));
+    if (!fetched.ok) {
+      return { failures: [fetched.failure], pushed: [] };
     }
     const failure = await applyLocalWrite(action.path, () =>
-      localWriter.writeFile(action.path, body),
+      localWriter.writeFile(action.path, fetched.body),
     );
     if (failure !== null) {
-      return { concurrent: false, failures: [failure], pushed: [] };
+      return { failures: [failure], pushed: [] };
     }
 
     return successfulAction();
@@ -254,11 +238,11 @@ async function executeAction(
   if (action.kind === "pullDelete") {
     const drift = await checkLocalDrift(reader, action.path, localByPath.get(action.path));
     if (drift !== null) {
-      return { concurrent: false, failures: [drift], pushed: [] };
+      return { failures: [drift], pushed: [] };
     }
     const failure = await applyLocalWrite(action.path, () => localWriter.deleteFile(action.path));
     if (failure !== null) {
-      return { concurrent: false, failures: [failure], pushed: [] };
+      return { failures: [failure], pushed: [] };
     }
 
     return successfulAction();
@@ -270,22 +254,17 @@ async function executeAction(
   if (action.deletedSide === "local") {
     const drift = await checkLocalDrift(reader, action.path, localByPath.get(action.path));
     if (drift !== null) {
-      return { concurrent: false, failures: [drift], pushed: [] };
+      return { failures: [drift], pushed: [] };
     }
-    const result = await storage.getObject(action.path, remoteByPath.get(action.path)?.size);
-    if (!result.ok || result.body === null) {
-      return failedAction(action.path, result.message, false);
-    }
-    const body = result.body;
-    const integrity = await verifyFetch(action.path, body, remoteByPath.get(action.path));
-    if (integrity !== null) {
-      return { concurrent: false, failures: [integrity], pushed: [] };
+    const fetched = await pullBlob(storage, action.path, remoteByPath.get(action.path));
+    if (!fetched.ok) {
+      return { failures: [fetched.failure], pushed: [] };
     }
     const failure = await applyLocalWrite(action.path, () =>
-      localWriter.writeFile(action.path, body),
+      localWriter.writeFile(action.path, fetched.body),
     );
     if (failure !== null) {
-      return { concurrent: false, failures: [failure], pushed: [] };
+      return { failures: [failure], pushed: [] };
     }
 
     return successfulAction();
@@ -300,7 +279,7 @@ async function executeAction(
   try {
     localBytes = await reader.readFile(action.path);
   } catch (err) {
-    return failedAction(action.path, localFailureMessage(err), false);
+    return failedAction(action.path, localFailureMessage(err));
   }
   // A failed rename means the local edit is still sitting at action.path untouched. Bail before
   // the pull below would overwrite it, so a diverged edit is never silently discarded by an I/O
@@ -309,162 +288,42 @@ async function executeAction(
     localWriter.renameFile(action.path, copyPath),
   );
   if (renameFailure !== null) {
-    return { concurrent: false, failures: [renameFailure], pushed: [] };
+    return { failures: [renameFailure], pushed: [] };
   }
   const failures: SyncFailure[] = [];
   const pushedFiles: FileState[] = [];
-  let concurrent = false;
-  const copyResult = await storage.putObject(copyPath, localBytes, { kind: "ifAbsent" });
-  if (!copyResult.ok) {
-    failures.push({ path: copyPath, message: copyResult.message });
-    concurrent = copyResult.status === "conflict";
+  const copyFile = await pushedFile(copyPath, localBytes, now);
+  const stored = await ensureBlobStored(storage, copyFile.hash, localBytes);
+  if (!stored.ok) {
+    failures.push({ path: copyPath, message: stored.message });
   } else {
-    pushedFiles.push(await pushedFile(copyPath, localBytes, now));
+    pushedFiles.push(copyFile);
   }
 
   // deletedSide "remote": there is nothing at this path remotely to pull, the rename above
   // already vacated it locally, and that is the correct final state, not a failure to report.
   if (action.deletedSide === "remote") {
-    return { concurrent, failures, pushed: pushedFiles };
+    return { failures, pushed: pushedFiles };
   }
 
-  const result = await storage.getObject(action.path, remoteByPath.get(action.path)?.size);
-  if (!result.ok || result.body === null) {
-    failures.push({ path: action.path, message: result.message });
-    return { concurrent, failures, pushed: pushedFiles };
-  }
-  const body = result.body;
-  const integrity = await verifyFetch(action.path, body, remoteByPath.get(action.path));
-  if (integrity !== null) {
-    failures.push(integrity);
-    return { concurrent, failures, pushed: pushedFiles };
+  const fetched = await pullBlob(storage, action.path, remoteByPath.get(action.path));
+  if (!fetched.ok) {
+    failures.push(fetched.failure);
+    return { failures, pushed: pushedFiles };
   }
   const writeFailure = await applyLocalWrite(action.path, () =>
-    localWriter.writeFile(action.path, body),
+    localWriter.writeFile(action.path, fetched.body),
   );
   if (writeFailure !== null) {
     failures.push(writeFailure);
   }
 
-  return { concurrent, failures, pushed: pushedFiles };
+  return { failures, pushed: pushedFiles };
 }
 
-// failedAction returns one failed action result with its concurrency classification.
-function failedAction(path: string, message: string, concurrent: boolean): ActionResult {
-  return { concurrent, failures: [{ path, message }], pushed: [] };
-}
-
-// pushedFile returns the FileState for bytes just written to path in the bucket, hashed fresh
-// from those exact bytes rather than reused from a pre-push snapshot, so a file edited in the
-// window between the snapshot and this read is never recorded in the manifest as content the
-// bucket doesn't actually hold.
-async function pushedFile(path: string, bytes: Uint8Array, mtime: number): Promise<FileState> {
-  return { path, size: bytes.length, mtime, hash: await hashBytes(bytes) };
-}
-
-// putCondition returns the precondition that keeps a file PUT tied to the remote snapshot this
-// pass planned from. Existing objects are also hashed before their ETag is trusted, because an
-// ETag fetched after another pass's PUT describes that newer object rather than the snapshot.
-async function putCondition(
-  path: string,
-  bytes: Uint8Array,
-  expected: FileState | undefined,
-  storage: StorageClient,
-): Promise<PutConditionResult> {
-  if (expected === undefined) {
-    return { ok: true, kind: "put", condition: { kind: "ifAbsent" } };
-  }
-  const fetched = await storage.getObject(path, expected.size);
-  if (!fetched.ok || fetched.body === null) {
-    if (fetched.status === "not_found") {
-      return { ok: true, kind: "put", condition: { kind: "ifAbsent" } };
-    }
-    return {
-      ok: false,
-      concurrent: false,
-      failure: { path, message: fetched.message },
-    };
-  }
-  const remoteHash = await hashBytes(fetched.body);
-  if (remoteHash !== expected.hash) {
-    if (remoteHash === (await hashBytes(bytes))) {
-      return { ok: true, kind: "done" };
-    }
-    return {
-      ok: false,
-      concurrent: true,
-      failure: { path, message: REMOTE_DRIFT_MESSAGE },
-    };
-  }
-  if (fetched.etag === null) {
-    return {
-      ok: false,
-      concurrent: false,
-      failure: { path, message: REMOTE_ETAG_MESSAGE },
-    };
-  }
-
-  return { ok: true, kind: "put", condition: { kind: "ifMatch", etag: fetched.etag } };
-}
-
-// checkRemoteDrift confirms the object a pushDelete is about to destroy still holds the bytes the
-// plan snapshotted. It returns the result to hand straight back when the delete must not proceed,
-// or null when it is safe. Another device can push new content to this path in the window between
-// the manifest being read and the delete running (#133); an unconditional delete would discard
-// those bytes, and because the manifest CAS then loses without the winner re-uploading, they would
-// not reappear until that file was next edited locally. A remote hash that no longer matches the
-// snapshot is exactly that race, failed as concurrent so the pass abandons its stale manifest and
-// the next sync replans; an object already gone is the end state the delete wants, so it succeeds.
-// Verifying right before the delete shrinks the residual window to the gap between this read and
-// the delete itself, the same shape checkLocalDrift uses for local writes; closing it entirely
-// needs a conditional delete, which awaits provider probing (#108). expected is undefined only for
-// a caller that supplied no remote view (the empty default), which cannot happen through syncOnce
-// where a pushDelete always carries a manifest entry; such a caller keeps the prior unconditional
-// behaviour, its delete still recoverable from the trash copy (#53).
-async function checkRemoteDrift(
-  path: string,
-  expected: FileState | undefined,
-  storage: StorageClient,
-): Promise<ActionResult | null> {
-  if (expected === undefined) {
-    return null;
-  }
-  const fetched = await storage.getObject(path, expected.size);
-  if (!fetched.ok || fetched.body === null) {
-    if (fetched.status === "not_found") {
-      return successfulAction();
-    }
-    return failedAction(path, fetched.message, false);
-  }
-  if ((await hashBytes(fetched.body)) !== expected.hash) {
-    return failedAction(path, REMOTE_DRIFT_MESSAGE, true);
-  }
-
-  return null;
-}
-
-// remoteMatches reports whether path already holds bytes, making a failed create idempotent. A
-// previous pass can leave an unmanifested object after losing the manifest CAS; accepting those
-// same bytes lets the retry fold it into the manifest without an unsafe overwrite.
-async function remoteMatches(
-  path: string,
-  bytes: Uint8Array,
-  storage: StorageClient,
-): Promise<boolean> {
-  // The local bytes are the best estimate of the remote object's size for the deadline: a match
-  // means they are identical, and a mismatch still budgets close enough to bound the download.
-  const fetched = await storage.getObject(path, bytes.byteLength);
-  if (!fetched.ok || fetched.body === null) {
-    return false;
-  }
-
-  return (await hashBytes(fetched.body)) === (await hashBytes(bytes));
-}
-
-// successfulAction returns the zero failure result for a completed action, pushed carrying the
-// FileState of any bytes it wrote to the bucket, empty for an action that pushed nothing.
-function successfulAction(pushed: FileState[] = []): ActionResult {
-  return { concurrent: false, failures: [], pushed };
+// failedAction returns one failed action result carrying a single failure.
+function failedAction(path: string, message: string): ActionResult {
+  return { failures: [{ path, message }], pushed: [] };
 }
 
 // localFailureMessage turns whatever a local vault operation threw into a SyncFailure message.
@@ -480,21 +339,56 @@ function localFailureMessage(err: unknown): string {
   return "local file operation failed";
 }
 
-// verifyFetch hashes fetched bytes and compares against the expected hash from the remote
-// snapshot. A mismatch means the storage response was truncated, corrupted, or tampered with;
-// writing it to disk would silently propagate damage to every other device on the next sync. A
-// missing expected hash is a programming error — the manifest should always carry an entry for a
-// path the plan decided to pull — surfaced rather than silently bypassed.
+// pullBlob reads the blob a path's expected FileState names and verifies it against that expected
+// hash before handing it back, so a caller's local write never receives storage's response
+// unchecked. expected comes from the remote manifest the plan was made from; missing it means the
+// plan itself is inconsistent (every pull carries a manifest entry through syncOnce) and there is
+// no key to even attempt a read against.
+async function pullBlob(
+  storage: StorageClient,
+  path: string,
+  expected: FileState | undefined,
+): Promise<{ ok: true; body: Uint8Array } | { ok: false; failure: SyncFailure }> {
+  if (expected === undefined) {
+    return { ok: false, failure: { path, message: MANIFEST_MISSING_HASH_MESSAGE } };
+  }
+  const fetched = await storage.getObject(blobKeyFor(expected.hash), expected.size);
+  if (!fetched.ok || fetched.body === null) {
+    return { ok: false, failure: { path, message: fetched.message } };
+  }
+  const integrity = await verifyFetch(path, fetched.body, expected);
+  if (integrity !== null) {
+    return { ok: false, failure: integrity };
+  }
+
+  return { ok: true, body: fetched.body };
+}
+
+// pushedFile returns the FileState for bytes just written to a blob in the bucket, hashed fresh
+// from those exact bytes.
+async function pushedFile(path: string, bytes: Uint8Array, mtime: number): Promise<FileState> {
+  return { path, size: bytes.length, mtime, hash: await hashBytes(bytes) };
+}
+
+// successfulAction returns the zero failure result for a completed action, pushed carrying the
+// FileState of any bytes it wrote to the bucket, empty for an action that pushed nothing.
+function successfulAction(pushed: FileState[] = []): ActionResult {
+  return { failures: [], pushed };
+}
+
+// verifyFetch hashes fetched bytes and compares against the expected hash, closing the gap
+// between "storage answered ok" and "storage answered with the right bytes". A mismatch means the
+// response was truncated, corrupted, or (with a hash derived key) essentially impossible short of
+// storage corruption; writing it to disk would silently propagate damage to every other device on
+// the next sync.
 async function verifyFetch(
   path: string,
   body: Uint8Array,
-  expected: FileState | undefined,
+  expected: FileState,
 ): Promise<SyncFailure | null> {
-  if (expected === undefined) {
-    return { path, message: MANIFEST_MISSING_HASH_MESSAGE };
-  }
   if ((await hashBytes(body)) === expected.hash) {
     return null;
   }
+
   return { path, message: HASH_MISMATCH_MESSAGE };
 }

--- a/src/sync/execute.ts
+++ b/src/sync/execute.ts
@@ -1,5 +1,12 @@
 import type { StorageClient } from "../storage/storage.ts";
-import { byPath, type FileState, hashBytes, type Reader, type Snapshot } from "../vault/vault.ts";
+import {
+  byPath,
+  type FileStat,
+  type FileState,
+  hashBytes,
+  type Reader,
+  type Snapshot,
+} from "../vault/vault.ts";
 import { blobKeyFor, conflictCopyPath, MANIFEST_KEY, type SyncAction } from "./plan.ts";
 
 // DRIFT_MESSAGE is the failure reported when a local file changed after the snapshot an action
@@ -87,17 +94,10 @@ type ActionResult = {
   pushed: FileState[];
 };
 
-// LocalCheck is the outcome of checkLocalDrift: the failure to report, or what the path was
-// holding at the moment its content was verified, for confirmLocalUnchanged to compare against
+// LocalCheck is the outcome of checkLocalDrift: the failure to report, or the stat the path
+// carried at the moment its content was verified, for confirmLocalUnchanged to compare against
 // once the remaining checks have run.
-type LocalCheck = { ok: true; seen: LocalStat } | { ok: false; failure: SyncFailure };
-
-// LocalStat is what the vault index says about a path: whether anything is there, and how many
-// bytes it holds. An absent path is present false at size zero, never a null to unpack.
-type LocalStat = {
-  present: boolean;
-  size: number;
-};
+type LocalCheck = { ok: true; seen: FileStat } | { ok: false; failure: SyncFailure };
 
 // executeSyncPlan carries out every action against reader/localWriter (the local vault) and
 // storage (the remote bucket), and reports what completed and what couldn't be, so one failed
@@ -187,9 +187,9 @@ async function checkLocalDrift(
   path: string,
   expected: FileState | undefined,
 ): Promise<LocalCheck> {
-  const exists = await reader.fileExists(path);
-  if (!exists) {
-    return { ok: true, seen: { present: false, size: 0 } };
+  const before = await reader.stat(path);
+  if (!before.present) {
+    return { ok: true, seen: before };
   }
   let bytes: Uint8Array;
   try {
@@ -204,7 +204,9 @@ async function checkLocalDrift(
     return { ok: false, failure: { path, message: DRIFT_MESSAGE } };
   }
 
-  return { ok: true, seen: { present: true, size: bytes.length } };
+  // Read back after the content, not before it, so the stat handed on describes the file as of the
+  // instant these exact bytes were verified rather than as of whenever the read began.
+  return { ok: true, seen: await reader.stat(path) };
 }
 
 // commitPulledContent lands fetched remote bytes on a local path, in the only order that leaves
@@ -264,29 +266,28 @@ async function commitPulledContent(
 }
 
 // confirmLocalUnchanged is the last look at a path before it is written over or deleted, run after
-// the manifest check so nothing but the mutation itself follows it. It compares the path against
-// what checkLocalDrift saw moments earlier, using only what the vault index already holds
-// (existence and size) and never rereading content: the hash has already proved those bytes were
-// the snapshot's, and the whole point of this one is to be cheap enough to sit last, so the
-// manifest check is not left standing behind a whole file read. A path confirmed absent must still
-// be absent; one confirmed to hold the snapshot's content must still hold exactly that many bytes.
+// the manifest check so nothing but the mutation itself follows it. It compares the path's stat
+// against the one checkLocalDrift recorded when it verified the content, and never rereads: the
+// hash has already proved those bytes were the snapshot's, and the whole point of this one is to
+// be cheap enough to sit last, so the manifest check is not left standing behind a whole file read.
 //
-// What it cannot see is a rewrite landing in this window that keeps the byte length exactly, which
-// is why it is a second line behind the hash rather than a replacement for it. That residue spans
-// one network round trip, and the create commit closes the appearing-file half of it entirely.
+// Size alone would not do. A typo fixed in place rewrites a note without changing its length, so
+// an mtime comparison is what actually makes this a guard rather than a formality; size is kept
+// beside it because a rewrite inside the same clock tick moves one when it cannot move the other.
+// This is the same stat pair takeSnapshot gates its rehash on, used here in the conservative
+// direction: it can only ever refuse a write, so an mtime that moved without the content moving
+// costs one replanned pass, never a wrong answer.
 async function confirmLocalUnchanged(
   reader: Reader,
   path: string,
-  seen: LocalStat,
+  seen: FileStat,
 ): Promise<SyncFailure | null> {
-  const present = await reader.fileExists(path);
-  if (present !== seen.present) {
-    return { path, message: DRIFT_MESSAGE };
-  }
-  if (!present) {
-    return null;
-  }
-  if ((await reader.size(path)) !== seen.size) {
+  const current = await reader.stat(path);
+  if (
+    current.present !== seen.present ||
+    current.size !== seen.size ||
+    current.mtime !== seen.mtime
+  ) {
     return { path, message: DRIFT_MESSAGE };
   }
 

--- a/src/sync/execute.ts
+++ b/src/sync/execute.ts
@@ -25,9 +25,9 @@ const MANIFEST_MISSING_HASH_MESSAGE = "manifest missing expected hash for this p
 // specific blob by the hash the plan already decided on, which by construction always "succeeds"
 // with exactly that content, and pullDelete has no bucket object of its own to check at all, so
 // neither can notice on its own that a newer manifest has since pointed the path elsewhere or
-// repopulated it; that is what manifestDrifted checks for, immediately before each such local
-// delete and, for a write, immediately before the staged commit that actually changes the path
-// (see commitPulledContent). The one CAS the plan ultimately depends on either way is the
+// repopulated it; that is what manifestDrifted checks for, with nothing left between it and the
+// local change but an index lookup (see commitPulledContent for the ordering and why every check
+// is arranged cheapest-last). The one CAS the plan ultimately depends on either way is the
 // manifest's own conditional PUT (sync.ts), the backstop that still catches anything a mid pass
 // check's own race window lets through.
 export type ExecuteResult = {
@@ -85,6 +85,18 @@ export type WriteMode = "replace" | "create";
 type ActionResult = {
   failures: SyncFailure[];
   pushed: FileState[];
+};
+
+// LocalCheck is the outcome of checkLocalDrift: the failure to report, or what the path was
+// holding at the moment its content was verified, for confirmLocalUnchanged to compare against
+// once the remaining checks have run.
+type LocalCheck = { ok: true; seen: LocalStat } | { ok: false; failure: SyncFailure };
+
+// LocalStat is what the vault index says about a path: whether anything is there, and how many
+// bytes it holds. An absent path is present false at size zero, never a null to unpack.
+type LocalStat = {
+  present: boolean;
+  size: number;
 };
 
 // executeSyncPlan carries out every action against reader/localWriter (the local vault) and
@@ -164,56 +176,62 @@ async function applyLocalWrite(path: string, op: () => Promise<void>): Promise<S
 // conflict, which is where the conflict copy machinery lives. Only a confirmed absent path, or
 // content that still hashes to the snapshot's entry, is safe to write over: a file that exists
 // but cannot be read is refused with the read's own error, never treated as absent, since
-// deleting content that was never verified is the exact hole this check closes. Checking right
-// before the destructive write shrinks the unguardable race to the moment between this check and
-// the write itself, rather than the whole plan execution.
+// deleting content that was never verified is the exact hole this check closes.
+//
+// A passing check hands back what it saw rather than a bare null, because reading and hashing a
+// whole file is far too slow to be the last thing before the write; confirmLocalUnchanged compares
+// against this observation once the cheaper checks have run, so the content guarantee reaches all
+// the way to the mutation instead of ending wherever this check happened to sit.
 async function checkLocalDrift(
   reader: Reader,
   path: string,
   expected: FileState | undefined,
-): Promise<SyncFailure | null> {
+): Promise<LocalCheck> {
   const exists = await reader.fileExists(path);
   if (!exists) {
-    return null;
+    return { ok: true, seen: { present: false, size: 0 } };
   }
   let bytes: Uint8Array;
   try {
     bytes = await reader.readFile(path);
   } catch (err) {
-    return { path, message: localFailureMessage(err) };
+    return { ok: false, failure: { path, message: localFailureMessage(err) } };
   }
   if (expected === undefined) {
-    return { path, message: DRIFT_MESSAGE };
+    return { ok: false, failure: { path, message: DRIFT_MESSAGE } };
   }
   if ((await hashBytes(bytes)) !== expected.hash) {
-    return { path, message: DRIFT_MESSAGE };
+    return { ok: false, failure: { path, message: DRIFT_MESSAGE } };
   }
 
-  return null;
+  return { ok: true, seen: { present: true, size: bytes.length } };
 }
 
 // commitPulledContent lands fetched remote bytes on a local path, in the only order that leaves
-// both drift checks meaningful. The payload is staged first, so by the time either check runs the
+// every check meaningful. The payload is staged first, so by the time any check runs the
 // destination is still untouched and all that remains is commit's rename; staging afterwards, as
 // this used to, meant the whole payload write sat between the last check and the path changing,
-// which on a large attachment is ample room for the edit the check exists to protect.
+// which on a large attachment is ample room for the edit the checks exist to protect.
 //
-// The two checks are then ordered by what losing each race costs. A manifest that moved on is
-// caught again regardless by syncOnce's conditional manifest PUT, so slipping past this check
-// costs a spurious conflict copy on the next pass and nothing else. A local edit landing after
-// checkLocalDrift has no such backstop: the action reports success, its path advances in
-// state.json at the pulled hash, and nothing afterwards can tell the edit ever existed. The
-// unrecoverable one therefore goes last, closest to the commit.
+// The three checks then run cheapest-last, which is the only arrangement that leaves none of them
+// standing behind another's slow work. checkLocalDrift is the expensive one: it reads and hashes
+// the whole destination, so anything ordered after it inherits that read as its own race window,
+// which is exactly what left a manifest replaced mid read able to authorize this write. It
+// therefore goes first. manifestDrifted's network round trip follows. Last, with nothing but the
+// commit behind it, confirmLocalUnchanged re-checks the destination against the index alone, so
+// the local guarantee spans the manifest HEAD as well rather than ending before it. Every check is
+// a check-then-act, and the residue of each is now a single index lookup rather than a whole file
+// read or a network call.
 //
-// checkLocal is injected rather than derived here because a conflict's restore lands on a path its
-// own rename just vacated and so has no snapshot content to verify against (see vacatedByRename);
-// mode is what guards that path instead, refusing the commit outright if the destination turns out
-// not to be empty after all.
+// mode carries the rest of the local guarantee for a write onto a path that is supposed to be
+// empty: the commit itself refuses an occupied destination (see WriteMode), which is as close to
+// the rename as a check can be placed.
 async function commitPulledContent(
   path: string,
   body: Uint8Array,
   mode: WriteMode,
-  checkLocal: () => Promise<SyncFailure | null>,
+  expected: FileState | undefined,
+  reader: Reader,
   localWriter: LocalWriter,
   storage: StorageClient,
   manifestEtag: string | null,
@@ -222,19 +240,54 @@ async function commitPulledContent(
   if (!staged.ok) {
     return staged.failure;
   }
+  const checked = await checkLocalDrift(reader, path, expected);
+  if (!checked.ok) {
+    await discardStaged(staged.write);
+    return checked.failure;
+  }
   if (await manifestDrifted(storage, manifestEtag)) {
     await discardStaged(staged.write);
     return { path, message: MANIFEST_DRIFT_MESSAGE };
   }
-  const drift = await checkLocal();
-  if (drift !== null) {
+  const moved = await confirmLocalUnchanged(reader, path, checked.seen);
+  if (moved !== null) {
     await discardStaged(staged.write);
-    return drift;
+    return moved;
   }
   const failure = await applyLocalWrite(path, () => staged.write.commit());
   if (failure !== null) {
     await discardStaged(staged.write);
     return failure;
+  }
+
+  return null;
+}
+
+// confirmLocalUnchanged is the last look at a path before it is written over or deleted, run after
+// the manifest check so nothing but the mutation itself follows it. It compares the path against
+// what checkLocalDrift saw moments earlier, using only what the vault index already holds
+// (existence and size) and never rereading content: the hash has already proved those bytes were
+// the snapshot's, and the whole point of this one is to be cheap enough to sit last, so the
+// manifest check is not left standing behind a whole file read. A path confirmed absent must still
+// be absent; one confirmed to hold the snapshot's content must still hold exactly that many bytes.
+//
+// What it cannot see is a rewrite landing in this window that keeps the byte length exactly, which
+// is why it is a second line behind the hash rather than a replacement for it. That residue spans
+// one network round trip, and the create commit closes the appearing-file half of it entirely.
+async function confirmLocalUnchanged(
+  reader: Reader,
+  path: string,
+  seen: LocalStat,
+): Promise<SyncFailure | null> {
+  const present = await reader.fileExists(path);
+  if (present !== seen.present) {
+    return { path, message: DRIFT_MESSAGE };
+  }
+  if (!present) {
+    return null;
+  }
+  if ((await reader.size(path)) !== seen.size) {
+    return { path, message: DRIFT_MESSAGE };
   }
 
   return null;
@@ -282,8 +335,8 @@ async function ensureBlobStored(
 }
 
 // executeAction carries out a single action and reports its failures. An action can report more
-// than one failure: a conflict whose copy push fails still pulls the remote version, so the
-// diverged local edit lands on disk even when the bucket refuses the copy.
+// than one failure: once a conflict has moved the local edit aside, its restore and its copy push
+// succeed or fail independently, and both outcomes belong to the same action.
 async function executeAction(
   action: SyncAction,
   localByPath: Map<string, FileState>,
@@ -333,7 +386,8 @@ async function executeAction(
       action.path,
       fetched.body,
       "replace",
-      () => checkLocalDrift(reader, action.path, localByPath.get(action.path)),
+      localByPath.get(action.path),
+      reader,
       localWriter,
       storage,
       manifestEtag,
@@ -349,13 +403,25 @@ async function executeAction(
     // A deletion is only safe once the manifest is confirmed still current: unlike pull's fetch,
     // which reads a specific blob and so cannot itself observe staleness, a delete has nothing of
     // its own to check against and would otherwise remove a path a newer manifest has since
-    // repopulated, based purely on the stale plan.
+    // repopulated, based purely on the stale plan. Acting on a manifest that moved on is worse
+    // here than for a write, too: the local file goes to trash, this pass's own manifest upload
+    // then loses its conditional PUT, and the next pass reads the deletion as the user's own and
+    // pushes it, dropping from every device a path another device had just repopulated.
+    //
+    // The checks are therefore ordered exactly as commitPulledContent orders them, and for the
+    // same reason: the expensive content hash first, the manifest HEAD next, and an index-only
+    // confirmation last so neither guarantee ends a whole file read or a network round trip
+    // before the delete it is guarding.
+    const checked = await checkLocalDrift(reader, action.path, localByPath.get(action.path));
+    if (!checked.ok) {
+      return { failures: [checked.failure], pushed: [] };
+    }
     if (await manifestDrifted(storage, manifestEtag)) {
       return { failures: [{ path: action.path, message: MANIFEST_DRIFT_MESSAGE }], pushed: [] };
     }
-    const drift = await checkLocalDrift(reader, action.path, localByPath.get(action.path));
-    if (drift !== null) {
-      return { failures: [drift], pushed: [] };
+    const moved = await confirmLocalUnchanged(reader, action.path, checked.seen);
+    if (moved !== null) {
+      return { failures: [moved], pushed: [] };
     }
     const failure = await applyLocalWrite(action.path, () => localWriter.deleteFile(action.path));
     if (failure !== null) {
@@ -379,7 +445,8 @@ async function executeAction(
       action.path,
       fetched.body,
       "create",
-      () => checkLocalDrift(reader, action.path, localByPath.get(action.path)),
+      localByPath.get(action.path),
+      reader,
       localWriter,
       storage,
       manifestEtag,
@@ -402,50 +469,65 @@ async function executeAction(
   } catch (err) {
     return failedAction(action.path, localFailureMessage(err));
   }
-  // A failed rename means the local edit is still sitting at action.path untouched. Bail before
-  // the pull below would overwrite it, so a diverged edit is never silently discarded by an I/O
-  // error the way it would be if we pushed on to restore the remote version.
+
+  // deletedSide "remote": there is nothing at this path remotely to restore, so the rename is the
+  // whole local change and the path being left empty afterwards is the correct final state, not a
+  // failure to report. A failed rename means the local edit is still sitting at action.path
+  // untouched, so there is nothing to preserve a copy of and nothing to push.
+  if (action.deletedSide === "remote") {
+    const renameFailure = await applyLocalWrite(action.path, () =>
+      localWriter.renameFile(action.path, copyPath),
+    );
+    if (renameFailure !== null) {
+      return { failures: [renameFailure], pushed: [] };
+    }
+
+    return pushConflictCopy(storage, copyPath, localBytes, now, []);
+  }
+
+  // deletedSide "none": both sides changed, so the local edit moves aside and the remote version
+  // takes the path. Everything slow and fallible happens before that path is vacated: the remote
+  // version is fetched, verified and staged, and the manifest is confirmed current, all while the
+  // local edit still sits untouched under its own name. Only then do the two renames run back to
+  // back, which is what makes the "create" commit's guarantee worth having: the window in which
+  // the path stands empty, and a note the user or another plugin creates there could be replaced
+  // by the restore, is two adjacent local operations rather than a download, a staged write and a
+  // network round trip.
+  //
+  // Failing before the rename also leaves the vault exactly as it was, so an unreachable blob or a
+  // manifest that moved on replans the whole conflict next pass rather than leaving it half
+  // applied: a copy on disk and an empty path where the user's note used to be, reported as a
+  // failure but never recovered from until some later pass happens to pull the path again.
+  const fetched = await pullBlob(storage, action.path, remoteByPath.get(action.path));
+  if (!fetched.ok) {
+    return { failures: [fetched.failure], pushed: [] };
+  }
+  const staged = await stageForWrite(localWriter, action.path, fetched.body, "create");
+  if (!staged.ok) {
+    return { failures: [staged.failure], pushed: [] };
+  }
+  if (await manifestDrifted(storage, manifestEtag)) {
+    await discardStaged(staged.write);
+    return { failures: [{ path: action.path, message: MANIFEST_DRIFT_MESSAGE }], pushed: [] };
+  }
   const renameFailure = await applyLocalWrite(action.path, () =>
     localWriter.renameFile(action.path, copyPath),
   );
   if (renameFailure !== null) {
+    await discardStaged(staged.write);
     return { failures: [renameFailure], pushed: [] };
   }
+  // Past the rename the local edit is safely under copyPath, so its blob is pushed whatever the
+  // restore then does: a commit refused by a note created in the gap must not also cost the user
+  // the edit this conflict set out to preserve.
   const failures: SyncFailure[] = [];
-  const pushedFiles: FileState[] = [];
-  const copyFile = await pushedFile(copyPath, localBytes, now);
-  const stored = await ensureBlobStored(storage, copyFile.hash, localBytes);
-  if (!stored.ok) {
-    failures.push({ path: copyPath, message: stored.message });
-  } else {
-    pushedFiles.push(copyFile);
+  const commitFailure = await applyLocalWrite(action.path, () => staged.write.commit());
+  if (commitFailure !== null) {
+    await discardStaged(staged.write);
+    failures.push(commitFailure);
   }
 
-  // deletedSide "remote": there is nothing at this path remotely to pull, the rename above
-  // already vacated it locally, and that is the correct final state, not a failure to report.
-  if (action.deletedSide === "remote") {
-    return { failures, pushed: pushedFiles };
-  }
-
-  const fetched = await pullBlob(storage, action.path, remoteByPath.get(action.path));
-  if (!fetched.ok) {
-    failures.push(fetched.failure);
-    return { failures, pushed: pushedFiles };
-  }
-  const writeFailure = await commitPulledContent(
-    action.path,
-    fetched.body,
-    "create",
-    vacatedByRename,
-    localWriter,
-    storage,
-    manifestEtag,
-  );
-  if (writeFailure !== null) {
-    failures.push(writeFailure);
-  }
-
-  return { failures, pushed: pushedFiles };
+  return pushConflictCopy(storage, copyPath, localBytes, now, failures);
 }
 
 // failedAction returns one failed action result carrying a single failure.
@@ -509,6 +591,28 @@ async function pullBlob(
   return { ok: true, body: fetched.body };
 }
 
+// pushConflictCopy stores the bytes a conflict moved aside and reports the FileState the manifest
+// needs to name that copy, appended to whatever failures the caller already collected: a conflict
+// can fail its restore and its copy push independently, and both belong in the same result. A
+// refused push is reported against the copy's own path, since that is the object the bucket
+// refused, and no FileState is returned for it, so the manifest never claims a copy the bucket
+// does not hold.
+async function pushConflictCopy(
+  storage: StorageClient,
+  copyPath: string,
+  bytes: Uint8Array,
+  now: number,
+  failures: SyncFailure[],
+): Promise<ActionResult> {
+  const copyFile = await pushedFile(copyPath, bytes, now);
+  const stored = await ensureBlobStored(storage, copyFile.hash, bytes);
+  if (!stored.ok) {
+    return { failures: [...failures, { path: copyPath, message: stored.message }], pushed: [] };
+  }
+
+  return { failures, pushed: [copyFile] };
+}
+
 // pushedFile returns the FileState for bytes just written to a blob in the bucket, hashed fresh
 // from those exact bytes.
 async function pushedFile(path: string, bytes: Uint8Array, mtime: number): Promise<FileState> {
@@ -535,18 +639,6 @@ async function stageForWrite(
 // FileState of any bytes it wrote to the bucket, empty for an action that pushed nothing.
 function successfulAction(pushed: FileState[] = []): ActionResult {
   return { failures: [], pushed };
-}
-
-// vacatedByRename is the content check for a conflict's restore, which lands on a path the same
-// action renamed away moments earlier. There is no snapshot entry left to compare bytes against,
-// so this one has nothing to check and says so. What it must not do is conclude that the path is
-// therefore still empty: the rename is followed by a blob push, a fetch and a staged write, and
-// anything the user or another plugin creates at that path in the meantime holds content no
-// conflict copy preserved. That is the "create" commit's job, immediately before the rename that
-// would otherwise replace it. Named rather than inlined as a null so the absence of a content
-// check on this one path reads as a decision rather than an oversight.
-async function vacatedByRename(): Promise<SyncFailure | null> {
-  return null;
 }
 
 // verifyFetch hashes fetched bytes and compares against the expected hash, closing the gap

--- a/src/sync/execute.ts
+++ b/src/sync/execute.ts
@@ -15,15 +15,17 @@ const MANIFEST_MISSING_HASH_MESSAGE = "manifest missing expected hash for this p
 // the FileState of every path a blob now exists under, hashed from those exact bytes. pushedFiles
 // is not limited to completed actions: a conflict's copy push can succeed even when the rest of
 // that same action later fails, and the copy still needs to reach the manifest. There is no
-// concurrency flag: a write here is either additive (a blob keyed by its own hash, which a losing
-// race still leaves holding the right bytes) or, for a delete, touches no bucket object at all (see
-// the pushDelete branch of executeAction), so neither can ever discover that the plan's remote view
-// went stale mid pass. A pull family read is different: it fetches a specific blob by the hash the
-// plan already decided on, which by construction always "succeeds" with exactly that content, so it
-// can never notice on its own that a newer manifest has since pointed the path elsewhere; that is
-// what manifestDrifted checks for immediately before each such write. The one CAS the plan
-// ultimately depends on either way is the manifest's own conditional PUT (sync.ts), the backstop
-// that still catches anything a mid pass check's own race window lets through.
+// concurrency flag: a remote side write is either additive (a blob keyed by its own hash, which a
+// losing race still leaves holding the right bytes) or, for pushDelete, touches no bucket object at
+// all, so neither can ever discover on its own that the plan's remote view went stale mid pass. The
+// pull family (pull, pullDelete, and a conflict's restore) is different: a pull's own fetch reads a
+// specific blob by the hash the plan already decided on, which by construction always "succeeds"
+// with exactly that content, and pullDelete has no bucket object of its own to check at all, so
+// neither can notice on its own that a newer manifest has since pointed the path elsewhere or
+// repopulated it; that is what manifestDrifted checks for immediately before each such local write
+// or delete. The one CAS the plan ultimately depends on either way is the manifest's own conditional
+// PUT (sync.ts), the backstop that still catches anything a mid pass check's own race window lets
+// through.
 export type ExecuteResult = {
   completed: SyncAction[];
   failed: SyncAction[];
@@ -227,16 +229,18 @@ async function executeAction(
   }
 
   if (action.kind === "pull") {
-    const drift = await checkLocalDrift(reader, action.path, localByPath.get(action.path));
-    if (drift !== null) {
-      return { failures: [drift], pushed: [] };
-    }
     const fetched = await pullBlob(storage, action.path, remoteByPath.get(action.path));
     if (!fetched.ok) {
       return { failures: [fetched.failure], pushed: [] };
     }
     if (await manifestDrifted(storage, manifestEtag)) {
       return { failures: [{ path: action.path, message: MANIFEST_DRIFT_MESSAGE }], pushed: [] };
+    }
+    // Checked last, immediately before the write: every check above this one is itself async and
+    // would otherwise widen the very race this exists to shrink (#86).
+    const drift = await checkLocalDrift(reader, action.path, localByPath.get(action.path));
+    if (drift !== null) {
+      return { failures: [drift], pushed: [] };
     }
     const failure = await applyLocalWrite(action.path, () =>
       localWriter.writeFile(action.path, fetched.body),
@@ -249,6 +253,13 @@ async function executeAction(
   }
 
   if (action.kind === "pullDelete") {
+    // A deletion is only safe once the manifest is confirmed still current: unlike pull's fetch,
+    // which reads a specific blob and so cannot itself observe staleness, a delete has nothing of
+    // its own to check against and would otherwise remove a path a newer manifest has since
+    // repopulated, based purely on the stale plan.
+    if (await manifestDrifted(storage, manifestEtag)) {
+      return { failures: [{ path: action.path, message: MANIFEST_DRIFT_MESSAGE }], pushed: [] };
+    }
     const drift = await checkLocalDrift(reader, action.path, localByPath.get(action.path));
     if (drift !== null) {
       return { failures: [drift], pushed: [] };
@@ -265,16 +276,18 @@ async function executeAction(
   // preserve; the remote edit simply wins and is restored onto the local path. The snapshot has
   // no entry here, so any file found now was recreated after it and must not be overwritten.
   if (action.deletedSide === "local") {
-    const drift = await checkLocalDrift(reader, action.path, localByPath.get(action.path));
-    if (drift !== null) {
-      return { failures: [drift], pushed: [] };
-    }
     const fetched = await pullBlob(storage, action.path, remoteByPath.get(action.path));
     if (!fetched.ok) {
       return { failures: [fetched.failure], pushed: [] };
     }
     if (await manifestDrifted(storage, manifestEtag)) {
       return { failures: [{ path: action.path, message: MANIFEST_DRIFT_MESSAGE }], pushed: [] };
+    }
+    // Checked last, immediately before the write: every check above this one is itself async and
+    // would otherwise widen the very race this exists to shrink (#86).
+    const drift = await checkLocalDrift(reader, action.path, localByPath.get(action.path));
+    if (drift !== null) {
+      return { failures: [drift], pushed: [] };
     }
     const failure = await applyLocalWrite(action.path, () =>
       localWriter.writeFile(action.path, fetched.body),

--- a/src/sync/execute.ts
+++ b/src/sync/execute.ts
@@ -22,10 +22,11 @@ const MANIFEST_MISSING_HASH_MESSAGE = "manifest missing expected hash for this p
 // specific blob by the hash the plan already decided on, which by construction always "succeeds"
 // with exactly that content, and pullDelete has no bucket object of its own to check at all, so
 // neither can notice on its own that a newer manifest has since pointed the path elsewhere or
-// repopulated it; that is what manifestDrifted checks for immediately before each such local write
-// or delete. The one CAS the plan ultimately depends on either way is the manifest's own conditional
-// PUT (sync.ts), the backstop that still catches anything a mid pass check's own race window lets
-// through.
+// repopulated it; that is what manifestDrifted checks for, immediately before each such local
+// delete and, for a write, immediately before the staged commit that actually changes the path
+// (see commitPulledContent). The one CAS the plan ultimately depends on either way is the
+// manifest's own conditional PUT (sync.ts), the backstop that still catches anything a mid pass
+// check's own race window lets through.
 export type ExecuteResult = {
   completed: SyncAction[];
   failed: SyncAction[];
@@ -34,11 +35,25 @@ export type ExecuteResult = {
 };
 
 // LocalWriter applies changes decided by a sync to the local vault. The real implementation
-// writes through the vault adapter (see vault/obsidian.ts); tests use an in-memory fake.
+// writes through the vault adapter (see vault/obsidian.ts); tests use an in-memory fake. A pulled
+// write is split across stageFile and StagedWrite.commit rather than exposed as one call, so the
+// payload reaches disk before the drift checks run and only the commit is left after them.
 export type LocalWriter = {
-  writeFile: (path: string, data: Uint8Array) => Promise<void>;
+  stageFile: (path: string, data: Uint8Array) => Promise<StagedWrite>;
   deleteFile: (path: string) => Promise<void>;
   renameFile: (path: string, newPath: string) => Promise<void>;
+};
+
+// StagedWrite is pulled content already written to a staging file beside its destination, waiting
+// to either claim that path or be thrown away. Splitting a pull's local write at this seam is what
+// makes checkLocalDrift's guarantee real rather than nominal. Writing the payload is the slow part,
+// and it used to sit between the drift check and the destination actually changing, so the window
+// the check was meant to close still spanned however long the write took: on a large attachment,
+// long enough for an edit to land in it and be silently overwritten (#86). Staging first leaves
+// only commit's rename in that window.
+export type StagedWrite = {
+  commit: () => Promise<void>;
+  discard: () => Promise<void>;
 };
 
 // SyncFailure is one action that could not be carried out.
@@ -157,6 +172,64 @@ async function checkLocalDrift(
   return null;
 }
 
+// commitPulledContent lands fetched remote bytes on a local path, in the only order that leaves
+// both drift checks meaningful. The payload is staged first, so by the time either check runs the
+// destination is still untouched and all that remains is commit's rename; staging afterwards, as
+// this used to, meant the whole payload write sat between the last check and the path changing,
+// which on a large attachment is ample room for the edit the check exists to protect.
+//
+// The two checks are then ordered by what losing each race costs. A manifest that moved on is
+// caught again regardless by syncOnce's conditional manifest PUT, so slipping past this check
+// costs a spurious conflict copy on the next pass and nothing else. A local edit landing after
+// checkLocalDrift has no such backstop: the action reports success, its path advances in
+// state.json at the pulled hash, and nothing afterwards can tell the edit ever existed. The
+// unrecoverable one therefore goes last, closest to the commit.
+//
+// checkLocal is injected rather than derived here because a conflict's restore lands on a path its
+// own rename just vacated and so has nothing to verify against (see vacatedByRename).
+async function commitPulledContent(
+  path: string,
+  body: Uint8Array,
+  checkLocal: () => Promise<SyncFailure | null>,
+  localWriter: LocalWriter,
+  storage: StorageClient,
+  manifestEtag: string | null,
+): Promise<SyncFailure | null> {
+  const staged = await stageForWrite(localWriter, path, body);
+  if (!staged.ok) {
+    return staged.failure;
+  }
+  if (await manifestDrifted(storage, manifestEtag)) {
+    await discardStaged(staged.write);
+    return { path, message: MANIFEST_DRIFT_MESSAGE };
+  }
+  const drift = await checkLocal();
+  if (drift !== null) {
+    await discardStaged(staged.write);
+    return drift;
+  }
+  const failure = await applyLocalWrite(path, () => staged.write.commit());
+  if (failure !== null) {
+    await discardStaged(staged.write);
+    return failure;
+  }
+
+  return null;
+}
+
+// discardStaged throws away content staged for a write the checks went on to refuse. A discard
+// that itself fails is swallowed rather than reported: the caller is already returning the reason
+// the write was refused, which is the failure worth surfacing, and a staging path is deterministic,
+// so a leftover is reclaimed by the next write to the same path rather than accumulating (see
+// hiddenSiblingPath in vault/obsidian.ts).
+async function discardStaged(staged: StagedWrite): Promise<void> {
+  try {
+    await staged.discard();
+  } catch {
+    // Deliberately ignored, see above.
+  }
+}
+
 // ensureBlobStored makes sure a blob holding bytes exists in the bucket at hash's key, uploading
 // only when it doesn't. The key is derived from the content itself, so an object already there is
 // guaranteed byte identical to what the caller would otherwise upload: a rename or a duplicate
@@ -233,17 +306,13 @@ async function executeAction(
     if (!fetched.ok) {
       return { failures: [fetched.failure], pushed: [] };
     }
-    if (await manifestDrifted(storage, manifestEtag)) {
-      return { failures: [{ path: action.path, message: MANIFEST_DRIFT_MESSAGE }], pushed: [] };
-    }
-    // Checked last, immediately before the write: every check above this one is itself async and
-    // would otherwise widen the very race this exists to shrink (#86).
-    const drift = await checkLocalDrift(reader, action.path, localByPath.get(action.path));
-    if (drift !== null) {
-      return { failures: [drift], pushed: [] };
-    }
-    const failure = await applyLocalWrite(action.path, () =>
-      localWriter.writeFile(action.path, fetched.body),
+    const failure = await commitPulledContent(
+      action.path,
+      fetched.body,
+      () => checkLocalDrift(reader, action.path, localByPath.get(action.path)),
+      localWriter,
+      storage,
+      manifestEtag,
     );
     if (failure !== null) {
       return { failures: [failure], pushed: [] };
@@ -280,17 +349,13 @@ async function executeAction(
     if (!fetched.ok) {
       return { failures: [fetched.failure], pushed: [] };
     }
-    if (await manifestDrifted(storage, manifestEtag)) {
-      return { failures: [{ path: action.path, message: MANIFEST_DRIFT_MESSAGE }], pushed: [] };
-    }
-    // Checked last, immediately before the write: every check above this one is itself async and
-    // would otherwise widen the very race this exists to shrink (#86).
-    const drift = await checkLocalDrift(reader, action.path, localByPath.get(action.path));
-    if (drift !== null) {
-      return { failures: [drift], pushed: [] };
-    }
-    const failure = await applyLocalWrite(action.path, () =>
-      localWriter.writeFile(action.path, fetched.body),
+    const failure = await commitPulledContent(
+      action.path,
+      fetched.body,
+      () => checkLocalDrift(reader, action.path, localByPath.get(action.path)),
+      localWriter,
+      storage,
+      manifestEtag,
     );
     if (failure !== null) {
       return { failures: [failure], pushed: [] };
@@ -340,12 +405,13 @@ async function executeAction(
     failures.push(fetched.failure);
     return { failures, pushed: pushedFiles };
   }
-  if (await manifestDrifted(storage, manifestEtag)) {
-    failures.push({ path: action.path, message: MANIFEST_DRIFT_MESSAGE });
-    return { failures, pushed: pushedFiles };
-  }
-  const writeFailure = await applyLocalWrite(action.path, () =>
-    localWriter.writeFile(action.path, fetched.body),
+  const writeFailure = await commitPulledContent(
+    action.path,
+    fetched.body,
+    vacatedByRename,
+    localWriter,
+    storage,
+    manifestEtag,
   );
   if (writeFailure !== null) {
     failures.push(writeFailure);
@@ -361,10 +427,10 @@ function failedAction(path: string, message: string): ActionResult {
 
 // localFailureMessage turns whatever a local vault operation threw into a SyncFailure message.
 // readFile throws when a file vanishes between the snapshot and now (a user deleting it mid sync),
-// and writeFile/deleteFile/renameFile can throw on a disk full or permission error; routing all of
-// them through failures keeps executeSyncPlan's "errors are values" contract, so one bad local
-// operation is a per file failure like any storage error, not an exception that abandons the rest
-// of the pass.
+// and staging, committing, deleting or renaming can throw on a disk full or permission error;
+// routing all of them through failures keeps executeSyncPlan's "errors are values" contract, so one
+// bad local operation is a per file failure like any storage error, not an exception that abandons
+// the rest of the pass.
 function localFailureMessage(err: unknown): string {
   if (err instanceof Error) {
     return err.message;
@@ -421,10 +487,34 @@ async function pushedFile(path: string, bytes: Uint8Array, mtime: number): Promi
   return { path, size: bytes.length, mtime, hash: await hashBytes(bytes) };
 }
 
+// stageForWrite writes fetched bytes to their staging file, converting a thrown I/O error into the
+// same SyncFailure shape every other local operation reports. A failure here has touched nothing at
+// the destination, so there is no staged write to hand back and nothing to unwind.
+async function stageForWrite(
+  localWriter: LocalWriter,
+  path: string,
+  body: Uint8Array,
+): Promise<{ ok: true; write: StagedWrite } | { ok: false; failure: SyncFailure }> {
+  try {
+    return { ok: true, write: await localWriter.stageFile(path, body) };
+  } catch (err) {
+    return { ok: false, failure: { path, message: localFailureMessage(err) } };
+  }
+}
+
 // successfulAction returns the zero failure result for a completed action, pushed carrying the
 // FileState of any bytes it wrote to the bucket, empty for an action that pushed nothing.
 function successfulAction(pushed: FileState[] = []): ActionResult {
   return { failures: [], pushed };
+}
+
+// vacatedByRename is the local check for a conflict's restore, which lands on a path the same
+// action renamed away moments earlier. There is no snapshot entry left to verify content against
+// and nothing at the path to overwrite, so there is nothing to check. Named rather than inlined as
+// a null so the absence of a drift check on this one path reads as a decision rather than an
+// oversight.
+async function vacatedByRename(): Promise<SyncFailure | null> {
+  return null;
 }
 
 // verifyFetch hashes fetched bytes and compares against the expected hash, closing the gap

--- a/src/sync/execute.ts
+++ b/src/sync/execute.ts
@@ -3,8 +3,11 @@ import { byPath, type FileState, hashBytes, type Reader, type Snapshot } from ".
 import { blobKeyFor, conflictCopyPath, MANIFEST_KEY, type SyncAction } from "./plan.ts";
 
 // DRIFT_MESSAGE is the failure reported when a local file changed after the snapshot an action
-// was planned from; the next sync re-snapshots and replans the path as a conflict.
-const DRIFT_MESSAGE = "changed locally mid sync; sync again to reconcile";
+// was planned from; the next sync re-snapshots and replans the path as a conflict. Exported
+// because a "create" mode commit reports the same thing from inside the writer, where a file that
+// appeared at the destination is visible to the adapter alone (see installStaged in
+// vault/obsidian.ts), and both are the same event to a user: something changed underneath us.
+export const DRIFT_MESSAGE = "changed locally mid sync; sync again to reconcile";
 
 const HASH_MISMATCH_MESSAGE = "fetched bytes do not match manifest hash; sync again to reconcile";
 const MANIFEST_DRIFT_MESSAGE = "changed remotely mid sync; sync again to reconcile";
@@ -37,9 +40,11 @@ export type ExecuteResult = {
 // LocalWriter applies changes decided by a sync to the local vault. The real implementation
 // writes through the vault adapter (see vault/obsidian.ts); tests use an in-memory fake. A pulled
 // write is split across stageFile and StagedWrite.commit rather than exposed as one call, so the
-// payload reaches disk before the drift checks run and only the commit is left after them.
+// payload reaches disk before the drift checks run and only the commit is left after them. The
+// write's WriteMode is declared at staging rather than passed to commit, so what the write is
+// allowed to do to its destination is stated once, where the write itself is described.
 export type LocalWriter = {
-  stageFile: (path: string, data: Uint8Array) => Promise<StagedWrite>;
+  stageFile: (path: string, data: Uint8Array, mode: WriteMode) => Promise<StagedWrite>;
   deleteFile: (path: string) => Promise<void>;
   renameFile: (path: string, newPath: string) => Promise<void>;
 };
@@ -61,6 +66,21 @@ export type SyncFailure = {
   path: string;
   message: string;
 };
+
+// WriteMode says what a staged write may do to its destination when it commits. "replace" installs
+// over whatever is there, which is what an ordinary pull wants: the path's old content is exactly
+// what the plan decided to move on from. "create" refuses to commit if anything is at the path, for
+// a write whose premise is that the path is empty; a conflict's restore lands on a path the same
+// action renamed away moments earlier, so a file sitting there now was created in the window since,
+// holds content no conflict copy preserved and no snapshot describes, and must not be replaced.
+//
+// The vacancy is checked by the writer rather than by a caller's drift check because only the
+// writer can see the destination as it actually is: a filesystem stat through the adapter, which
+// sees a file the instant it appears, where a Reader check goes through Obsidian's file index,
+// which lags the very rename this action just made and would refuse sound restores as often as it
+// caught real ones. Checking inside the writer also puts the check as close to the rename as the
+// adapter allows, a syscall rather than the fetch-and-stage a caller's own checks sit behind.
+export type WriteMode = "replace" | "create";
 
 type ActionResult = {
   failures: SyncFailure[];
@@ -186,16 +206,19 @@ async function checkLocalDrift(
 // unrecoverable one therefore goes last, closest to the commit.
 //
 // checkLocal is injected rather than derived here because a conflict's restore lands on a path its
-// own rename just vacated and so has nothing to verify against (see vacatedByRename).
+// own rename just vacated and so has no snapshot content to verify against (see vacatedByRename);
+// mode is what guards that path instead, refusing the commit outright if the destination turns out
+// not to be empty after all.
 async function commitPulledContent(
   path: string,
   body: Uint8Array,
+  mode: WriteMode,
   checkLocal: () => Promise<SyncFailure | null>,
   localWriter: LocalWriter,
   storage: StorageClient,
   manifestEtag: string | null,
 ): Promise<SyncFailure | null> {
-  const staged = await stageForWrite(localWriter, path, body);
+  const staged = await stageForWrite(localWriter, path, body, mode);
   if (!staged.ok) {
     return staged.failure;
   }
@@ -309,6 +332,7 @@ async function executeAction(
     const failure = await commitPulledContent(
       action.path,
       fetched.body,
+      "replace",
       () => checkLocalDrift(reader, action.path, localByPath.get(action.path)),
       localWriter,
       storage,
@@ -343,7 +367,9 @@ async function executeAction(
 
   // conflict, deletedSide "local": the user deleted their copy, so there is no local edit to
   // preserve; the remote edit simply wins and is restored onto the local path. The snapshot has
-  // no entry here, so any file found now was recreated after it and must not be overwritten.
+  // no entry here, so any file found now was recreated after it and must not be overwritten: the
+  // drift check catches one the snapshot's Reader can see, and the "create" commit catches one
+  // created too recently for that Reader to have indexed yet.
   if (action.deletedSide === "local") {
     const fetched = await pullBlob(storage, action.path, remoteByPath.get(action.path));
     if (!fetched.ok) {
@@ -352,6 +378,7 @@ async function executeAction(
     const failure = await commitPulledContent(
       action.path,
       fetched.body,
+      "create",
       () => checkLocalDrift(reader, action.path, localByPath.get(action.path)),
       localWriter,
       storage,
@@ -408,6 +435,7 @@ async function executeAction(
   const writeFailure = await commitPulledContent(
     action.path,
     fetched.body,
+    "create",
     vacatedByRename,
     localWriter,
     storage,
@@ -494,9 +522,10 @@ async function stageForWrite(
   localWriter: LocalWriter,
   path: string,
   body: Uint8Array,
+  mode: WriteMode,
 ): Promise<{ ok: true; write: StagedWrite } | { ok: false; failure: SyncFailure }> {
   try {
-    return { ok: true, write: await localWriter.stageFile(path, body) };
+    return { ok: true, write: await localWriter.stageFile(path, body, mode) };
   } catch (err) {
     return { ok: false, failure: { path, message: localFailureMessage(err) } };
   }
@@ -508,11 +537,14 @@ function successfulAction(pushed: FileState[] = []): ActionResult {
   return { failures: [], pushed };
 }
 
-// vacatedByRename is the local check for a conflict's restore, which lands on a path the same
-// action renamed away moments earlier. There is no snapshot entry left to verify content against
-// and nothing at the path to overwrite, so there is nothing to check. Named rather than inlined as
-// a null so the absence of a drift check on this one path reads as a decision rather than an
-// oversight.
+// vacatedByRename is the content check for a conflict's restore, which lands on a path the same
+// action renamed away moments earlier. There is no snapshot entry left to compare bytes against,
+// so this one has nothing to check and says so. What it must not do is conclude that the path is
+// therefore still empty: the rename is followed by a blob push, a fetch and a staged write, and
+// anything the user or another plugin creates at that path in the meantime holds content no
+// conflict copy preserved. That is the "create" commit's job, immediately before the rename that
+// would otherwise replace it. Named rather than inlined as a null so the absence of a content
+// check on this one path reads as a decision rather than an oversight.
 async function vacatedByRename(): Promise<SyncFailure | null> {
   return null;
 }

--- a/src/sync/fake.ts
+++ b/src/sync/fake.ts
@@ -1,7 +1,7 @@
 import type {
-  CopyResult,
   DeleteResult,
   GetResult,
+  HeadResult,
   ListResult,
   ObjectMeta,
   PutResult,
@@ -120,14 +120,10 @@ export function fakeStorage(objects: Record<string, string> = {}): {
         etag,
       };
     },
-    copyObject: async (sourceKey, destKey): Promise<CopyResult> => {
-      const content = store.get(sourceKey);
-      if (content === undefined) {
-        return { ok: false, status: "not_found", message: "Storage rejected the copy (404)" };
+    headObject: async (key): Promise<HeadResult> => {
+      if (!store.has(key)) {
+        return { ok: false, status: "not_found", message: "Storage rejected the head (404)" };
       }
-      revision++;
-      etags.set(destKey, `"v${revision}"`);
-      store.set(destKey, content);
       return { ok: true, status: "ok", message: "" };
     },
     deleteObject: async (key): Promise<DeleteResult> => {

--- a/src/sync/fake.ts
+++ b/src/sync/fake.ts
@@ -122,9 +122,19 @@ export function fakeStorage(objects: Record<string, string> = {}): {
     },
     headObject: async (key): Promise<HeadResult> => {
       if (!store.has(key)) {
-        return { ok: false, status: "not_found", message: "Storage rejected the head (404)" };
+        return {
+          ok: false,
+          status: "not_found",
+          message: "Storage rejected the head (404)",
+          etag: null,
+        };
       }
-      return { ok: true, status: "ok", message: "" };
+      let etag: string | null = null;
+      const stored = etags.get(key);
+      if (stored !== undefined) {
+        etag = stored;
+      }
+      return { ok: true, status: "ok", message: "", etag };
     },
     deleteObject: async (key): Promise<DeleteResult> => {
       store.delete(key);

--- a/src/sync/fake.ts
+++ b/src/sync/fake.ts
@@ -14,12 +14,29 @@ import type { LocalWriter } from "./execute.ts";
 export const empty: Snapshot = { files: [] };
 
 // fakeLocalWriter returns a LocalWriter backed by an in-memory map, and the map itself so tests
-// can assert on the result.
+// can assert on the result. Staged content is held aside and only reaches files on commit, the same
+// seam the real writer has, so a test asserting nothing landed on disk is really asserting the
+// destination was never touched rather than that a write happened to be skipped.
 export function fakeLocalWriter(): { writer: LocalWriter; files: Map<string, string> } {
   const files = new Map<string, string>();
+  const staged = new Map<string, string>();
   const writer: LocalWriter = {
-    writeFile: async (path, data) => {
-      files.set(path, new TextDecoder().decode(data));
+    stageFile: async (path, data) => {
+      staged.set(path, new TextDecoder().decode(data));
+
+      return {
+        commit: async () => {
+          const pending = staged.get(path);
+          if (pending === undefined) {
+            throw new Error(`nothing staged for ${path}`);
+          }
+          staged.delete(path);
+          files.set(path, pending);
+        },
+        discard: async () => {
+          staged.delete(path);
+        },
+      };
     },
     deleteFile: async (path) => {
       files.delete(path);

--- a/src/sync/fake.ts
+++ b/src/sync/fake.ts
@@ -8,7 +8,7 @@ import type {
   StorageClient,
 } from "../storage/storage.ts";
 import type { FileState, Reader, Snapshot } from "../vault/vault.ts";
-import type { LocalWriter } from "./execute.ts";
+import { DRIFT_MESSAGE, type LocalWriter } from "./execute.ts";
 
 // empty is the zero snapshot: a vault with no files.
 export const empty: Snapshot = { files: [] };
@@ -16,12 +16,14 @@ export const empty: Snapshot = { files: [] };
 // fakeLocalWriter returns a LocalWriter backed by an in-memory map, and the map itself so tests
 // can assert on the result. Staged content is held aside and only reaches files on commit, the same
 // seam the real writer has, so a test asserting nothing landed on disk is really asserting the
-// destination was never touched rather than that a write happened to be skipped.
+// destination was never touched rather than that a write happened to be skipped. A "create" write
+// refuses an occupied destination exactly as the real writer's adapter stat does, so a test can
+// drive the case the real one exists for: a path recreated after a conflict's rename vacated it.
 export function fakeLocalWriter(): { writer: LocalWriter; files: Map<string, string> } {
   const files = new Map<string, string>();
   const staged = new Map<string, string>();
   const writer: LocalWriter = {
-    stageFile: async (path, data) => {
+    stageFile: async (path, data, mode) => {
       staged.set(path, new TextDecoder().decode(data));
 
       return {
@@ -29,6 +31,9 @@ export function fakeLocalWriter(): { writer: LocalWriter; files: Map<string, str
           const pending = staged.get(path);
           if (pending === undefined) {
             throw new Error(`nothing staged for ${path}`);
+          }
+          if (mode === "create" && files.has(path)) {
+            throw new Error(DRIFT_MESSAGE);
           }
           staged.delete(path);
           files.set(path, pending);

--- a/src/sync/fake.ts
+++ b/src/sync/fake.ts
@@ -57,16 +57,28 @@ export function fakeLocalWriter(): { writer: LocalWriter; files: Map<string, str
   return { writer, files };
 }
 
-// fakeReader returns a Reader backed by an in-memory map of path to content.
-export function fakeReader(files: Record<string, string>): Reader {
+// fakeReader returns a Reader backed by an in-memory map of path to content. mtimes carries the
+// modification time of any path a test needs one for, defaulting to 1: a test simulating a mid sync
+// edit sets both maps, exactly as a real editor save moves both content and mtime, which is what
+// lets a same length rewrite still read as a change.
+export function fakeReader(
+  files: Record<string, string>,
+  mtimes: Record<string, number> = {},
+): Reader {
+  function mtimeOf(path: string): number {
+    const known = mtimes[path];
+    if (known === undefined) {
+      return 1;
+    }
+
+    return known;
+  }
+
   return {
-    fileExists: async (path) => {
-      return files[path] !== undefined;
-    },
     listFiles: async () => {
       const list = [];
       for (const [path, content] of Object.entries(files)) {
-        list.push({ path, size: content.length, mtime: 1 });
+        list.push({ path, size: content.length, mtime: mtimeOf(path) });
       }
       return list;
     },
@@ -77,12 +89,13 @@ export function fakeReader(files: Record<string, string>): Reader {
       }
       return new TextEncoder().encode(content);
     },
-    size: async (path) => {
+    stat: async (path) => {
       const content = files[path];
       if (content === undefined) {
-        return 0;
+        return { present: false, size: 0, mtime: 0 };
       }
-      return content.length;
+
+      return { present: true, size: content.length, mtime: mtimeOf(path) };
     },
   };
 }

--- a/src/sync/plan.test.ts
+++ b/src/sync/plan.test.ts
@@ -1,13 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import { empty, file, snapshot } from "./fake.ts";
-import {
-  conflictCopyPath,
-  MANIFEST_KEY,
-  manifestAfterSync,
-  planSync,
-  trashKeyFor,
-} from "./plan.ts";
+import { blobKeyFor, conflictCopyPath, MANIFEST_KEY, manifestAfterSync, planSync } from "./plan.ts";
 
 test("planSync: a path only changed locally is pushed", () => {
   const previous = empty;
@@ -95,19 +89,16 @@ test("planSync: the manifest's own path is never turned into an action", () => {
   assert.deepEqual(planSync(previous, local, remote), []);
 });
 
-test("planSync: a trashed copy under the reserved prefix is never turned into an action", () => {
+test("planSync: a blob key under the reserved prefix is never turned into an action", () => {
   const previous = empty;
-  const local = snapshot(file(".geode/trash/2020-01-01/a.md", "h1"));
-  const remote = snapshot(file(".geode/trash/2020-01-01/b.md", "h2"));
+  const local = snapshot(file(blobKeyFor("h1"), "h1"));
+  const remote = snapshot(file(blobKeyFor("h2"), "h2"));
 
   assert.deepEqual(planSync(previous, local, remote), []);
 });
 
-test("trashKeyFor: parks the path under the reserved trash prefix behind a timestamp folder", () => {
-  assert.equal(
-    trashKeyFor("notes/a.md", Date.UTC(2026, 0, 2, 3, 4, 5)),
-    ".geode/trash/2026-01-02T03-04-05-000Z/notes/a.md",
-  );
+test("blobKeyFor: keys content under the reserved blob prefix by its own hash", () => {
+  assert.equal(blobKeyFor("deadbeef"), ".geode/blobs/deadbeef");
 });
 
 test("manifestAfterSync: a push records the pushed file's entry", () => {

--- a/src/sync/plan.ts
+++ b/src/sync/plan.ts
@@ -6,20 +6,25 @@ import {
   type Snapshot,
 } from "../vault/vault.ts";
 
+// BLOB_PREFIX is where every file's content lives, keyed by its own SHA-256 hash rather than its
+// vault path: a rename touches no bytes (the manifest's path just points at the same key), a
+// duplicate attachment stores once (two paths, one key), and a delete never destroys bytes (the
+// manifest simply stops pointing at them; the blob is recoverable for as long as any retained
+// manifest, past or present, still names its hash). It sits under RESERVED_PREFIX, so blobs never
+// re-enter a sync as vault files.
+export const BLOB_PREFIX = ".geode/blobs/";
+
 // MANIFEST_KEY is the well known remote object holding the last synced snapshot, geode's source
-// of truth for "what does the other side think exists". Reserved: never treated as a real vault
-// path, on either side, even if a vault happens to contain a file at this exact path.
+// of truth for both "what does the other side think exists" and, since a FileState already pairs
+// a path with its content hash, "which blob a path's content lives at". Reserved: never treated
+// as a real vault path, on either side, even if a vault happens to contain a file at this exact
+// path.
 export const MANIFEST_KEY = ".geode/manifest.json";
 
-// RESERVED_PREFIX namespaces geode's own bookkeeping in the bucket: the manifest, and the trashed
-// copies of deleted objects. Nothing under it is ever a real vault file to sync, list as an
-// orphan, or diff, on either side, even if a vault happens to hold a file at a colliding path.
+// RESERVED_PREFIX namespaces geode's own bookkeeping in the bucket: the manifest and the content
+// addressed blobs. Nothing under it is ever a real vault file to sync, list as an orphan, or
+// diff, on either side, even if a vault happens to hold a file at a colliding path.
 export const RESERVED_PREFIX = ".geode/";
-
-// TRASH_PREFIX is where a pushed deletion parks the object before removing it from its live key,
-// giving a mistaken delete a recovery window instead of destroying the bytes outright (#53). It
-// sits under RESERVED_PREFIX, so trashed copies never re-enter a sync as vault files.
-export const TRASH_PREFIX = ".geode/trash/";
 
 // SyncAction is one thing a sync needs to do to bring local and remote back in step. A conflict
 // carries deletedSide so executeSyncPlan never has to guess, from a failed read, whether a deleted
@@ -31,6 +36,12 @@ export type SyncAction =
   | { kind: "pull"; path: string }
   | { kind: "pullDelete"; path: string }
   | { kind: "conflict"; path: string; deletedSide: "local" | "remote" | "none" };
+
+// blobKeyFor returns the reserved key content with the given hash lives at, the same key
+// regardless of which path, or how many paths, currently point at it.
+export function blobKeyFor(hash: string): string {
+  return `${BLOB_PREFIX}${hash}`;
+}
 
 // conflictCopyPath returns the name a locally diverged file is renamed to before the remote
 // version claims the original path, so neither edit is ever silently discarded. The extension,
@@ -139,17 +150,6 @@ export function planSync(previous: Snapshot, local: Snapshot, remote: Snapshot):
   }
 
   return actions;
-}
-
-// trashKeyFor returns the reserved key a pushed deletion parks path at before removing the live
-// object, timestamped so a later delete of a recreated path never overwrites an earlier trashed
-// copy. The original path is preserved under the stamped folder, so a recovery can see where the
-// object came from. now is passed in rather than read internally so the key is deterministic under
-// test, matching conflictCopyPath.
-export function trashKeyFor(path: string, now: number): string {
-  const stamp = new Date(now).toISOString().replace(/[:.]/g, "-");
-
-  return `${TRASH_PREFIX}${stamp}/${path}`;
 }
 
 // changesByPath builds a lookup from path to change, for matching a local change against a

--- a/src/sync/sync.itest.ts
+++ b/src/sync/sync.itest.ts
@@ -72,7 +72,8 @@ function newDevice(): Device {
 // byte length so a same millisecond, same size rewrite can never hide a change from mtime based
 // detection.
 async function writeLocal(d: Device, path: string, body: string): Promise<void> {
-  await d.writer.writeFile(path, new TextEncoder().encode(body));
+  const staged = await d.writer.stageFile(path, new TextEncoder().encode(body));
+  await staged.commit();
 }
 
 // readLocal returns a device file's contents, or undefined if it isn't there.

--- a/src/sync/sync.itest.ts
+++ b/src/sync/sync.itest.ts
@@ -16,9 +16,15 @@ import {
   createObsidianReader,
   createObsidianStore,
 } from "../vault/obsidian.ts";
-import { type Reader, type Store, takeSnapshot } from "../vault/vault.ts";
+import {
+  decodeSnapshot,
+  hashBytes,
+  type Reader,
+  type Store,
+  takeSnapshot,
+} from "../vault/vault.ts";
 import type { LocalWriter } from "./execute.ts";
-import { conflictCopyPath, MANIFEST_KEY } from "./plan.ts";
+import { blobKeyFor, conflictCopyPath, MANIFEST_KEY } from "./plan.ts";
 import { type SyncOutcome, syncOnce } from "./sync.ts";
 
 const SECRET = "geodedev";
@@ -28,9 +34,10 @@ const liveSettings: GeodeSettings = {
   provider: "custom",
   endpoint: "http://localhost:4568",
   region: "us-east-1",
-  // sync.itest has this bucket to itself: syncOnce's first sync path lists the whole bucket
-  // (#109), so sharing geode-test with storage.itest's leftover objects would trip the orphan
-  // refusal in every scenario here.
+  // sync.itest has this bucket to itself: syncOnce's first sync path lists the reserved blob
+  // prefix and refuses over anything it can't explain (#109), so sharing geode-test with
+  // storage.itest's leftover objects (harmless there, since none live under that prefix) is not
+  // worth the risk of a future test tripping the same refusal here.
   bucket: "geode-sync-test",
   accessKeyId: "geodedev",
 };
@@ -75,6 +82,12 @@ async function readLocal(d: Device, path: string): Promise<string | undefined> {
   } catch {
     return undefined;
   }
+}
+
+// hashOf returns the real content hash of text, for reading back the blob a given piece of
+// content lives under.
+async function hashOf(text: string): Promise<string> {
+  return hashBytes(new TextEncoder().encode(text));
 }
 
 // deleteLocal removes a file from a device's vault, the way a user deleting a note in Obsidian
@@ -195,9 +208,9 @@ test("sync: a two device conflict pushes the copy so the other device pulls it c
     assert.equal(await readLocal(b, "three/note.md"), "A edit");
     assert.equal(await readLocal(b, copyPath), "B side edit");
 
-    // Regression guard: the conflict copy reached the bucket, so the manifest B uploaded is not
-    // referencing a phantom object.
-    const remoteCopy = await storage.getObject(copyPath);
+    // Regression guard: the conflict copy's blob reached the bucket, so the manifest B uploaded is
+    // not referencing content that doesn't exist.
+    const remoteCopy = await storage.getObject(blobKeyFor(await hashOf("B side edit")));
     assert.equal(remoteCopy.ok, true);
     assert.equal(new TextDecoder().decode(remoteCopy.body ?? new Uint8Array()), "B side edit");
 
@@ -242,9 +255,13 @@ test("sync: a file deleted independently on both devices converges without a con
     assert.equal(await readLocal(a, "four/note.md"), undefined);
     assert.equal(await readLocal(b, "four/note.md"), undefined);
 
-    // No conflict copy was invented for a deletion both sides already agreed on.
-    const listed = await storage.listObjects("four/");
-    assert.deepEqual(listed.objects, []);
+    // No conflict copy was invented for a deletion both sides already agreed on: the converged
+    // manifest describes no files at all.
+    const manifestBody = await storage.getObject(MANIFEST_KEY);
+    assert.equal(manifestBody.ok, true);
+    const decoded = decodeSnapshot(new TextDecoder().decode(manifestBody.body ?? new Uint8Array()));
+    assert.ok(decoded.ok);
+    assert.deepEqual(decoded.snapshot.files, []);
   } finally {
     cleanup(a, b);
   }
@@ -300,9 +317,9 @@ test("sync: a stale state.json from an older build never deletes the vault on th
     assert.equal(await readLocal(a, "seven/one.md"), "first note");
     assert.equal(await readLocal(a, "seven/two.md"), "second note");
 
-    // Both files reached the bucket rather than being wiped from it.
-    const one = await storage.getObject("seven/one.md");
-    const two = await storage.getObject("seven/two.md");
+    // Both files' blobs reached the bucket rather than being wiped from it.
+    const one = await storage.getObject(blobKeyFor(await hashOf("first note")));
+    const two = await storage.getObject(blobKeyFor(await hashOf("second note")));
     assert.equal(new TextDecoder().decode(one.body ?? new Uint8Array()), "first note");
     assert.equal(new TextDecoder().decode(two.body ?? new Uint8Array()), "second note");
 
@@ -366,11 +383,13 @@ test("sync: two devices syncing at overlapping times never silently delete a fil
   }
 });
 
-test("sync: a deleted manifest with surviving objects refuses a first sync instead of orphaning them", async () => {
-  // Reproduces #109. A syncs a note up, then the manifest alone is deleted (a bucket lifecycle
-  // rule, manual cleanup, a partial restore) while the object survives. B, never synced, then
-  // sees what looks like a first sync; before the fix it pushed its own files and wrote a fresh
-  // manifest that never mentioned A's note, orphaning it forever.
+test("sync: a deleted manifest with unexplained blobs refuses a first sync instead of stranding them", async () => {
+  // Reproduces #109 for content addressed storage. A syncs a note up, then the manifest alone is
+  // deleted (a bucket lifecycle rule, manual cleanup, a partial restore) while its blob survives.
+  // B, never synced, then sees what looks like a first sync; its local vault has no file whose
+  // content explains that blob (a's note was never B's), so before the fix a naive first sync
+  // would push its own files and write a fresh manifest that never mentioned it, stranding it
+  // forever.
   await resetRemote();
   const a = newDevice();
   const b = newDevice();
@@ -383,31 +402,33 @@ test("sync: a deleted manifest with surviving objects refuses a first sync inste
 
     const outcome = await sync(b);
     assert.ok(!outcome.ok);
-    assert.equal(outcome.message, "bucket has files but no manifest; sync would orphan them");
+    assert.equal(outcome.message, "bucket has content but no manifest; sync would strand it");
+    const survivorKey = blobKeyFor(await hashOf("a's note"));
     assert.deepEqual(outcome.failures, [
-      { path: "nine/from-a.md", message: "in the bucket but not in the local vault" },
+      { path: survivorKey, message: "in the bucket but not in the local vault" },
     ]);
 
-    // Nothing was pushed and no manifest was written; A's object is untouched.
-    const kept = await storage.getObject("nine/from-a.md");
+    // Nothing was pushed and no manifest was written; A's blob is untouched.
+    const kept = await storage.getObject(survivorKey);
     assert.equal(new TextDecoder().decode(kept.body ?? new Uint8Array()), "a's note");
-    assert.equal((await storage.getObject("nine/from-b.md")).ok, false);
+    assert.equal((await storage.getObject(blobKeyFor(await hashOf("b's note")))).ok, false);
     assert.equal((await storage.getObject(MANIFEST_KEY)).ok, false);
   } finally {
     cleanup(a, b);
   }
 });
 
-test("sync: a deleted manifest over a divergent object conflicts instead of wedging the sync", async () => {
+test("sync: a deleted manifest over locally diverged content refuses rather than guessing a conflict", async () => {
   // A and B share a synced note, then the manifest alone is deleted (a lifecycle rule, manual
-  // cleanup) and B edits the note before its next sync. B sees objects and no manifest, so the
-  // path it is about to push already exists remotely holding different bytes. Before the fix that
-  // push's ifAbsent precondition failed, the 412 read as another device syncing, and B was told to
-  // sync again forever: nothing changed between attempts, so every retry failed identically.
+  // cleanup) and B edits the note before its next sync. Under the plaintext path keyed layout this
+  // replaced, the surviving object's key was the path itself, so this case could be resolved
+  // automatically as a conflict. Under content addressed storage the manifest was the only place
+  // that ever recorded which path a hash belonged to, so B's now-edited local file no longer
+  // explains the surviving blob, and the pass must refuse rather than guess at a conflict it has
+  // no path information to construct.
   await resetRemote();
   const a = newDevice();
   const b = newDevice();
-  const now = Date.parse("2026-07-14T11:00:00.000Z");
   try {
     await writeLocal(a, "ten/note.md", "from A");
     assert.equal((await sync(a)).ok, true);
@@ -416,22 +437,15 @@ test("sync: a deleted manifest over a divergent object conflicts instead of wedg
     await storage.deleteObject(MANIFEST_KEY);
     await writeLocal(b, "ten/note.md", "B's own edit");
 
-    const outcome = await sync(b, now);
-    assert.equal(outcome.ok, true);
+    const outcome = await sync(b);
+    assert.ok(!outcome.ok);
+    assert.equal(outcome.message, "bucket has content but no manifest; sync would strand it");
 
-    // The surviving object keeps the path on both sides, B's edit survives as a conflict copy, and
-    // the manifest B wrote describes both, so A converges on the same view rather than orphaning
-    // anything.
-    const copyPath = conflictCopyPath("ten/note.md", now);
-    assert.equal(await readLocal(b, "ten/note.md"), "from A");
-    assert.equal(await readLocal(b, copyPath), "B's own edit");
-    assert.equal((await sync(a)).ok, true);
-    assert.equal(await readLocal(a, "ten/note.md"), "from A");
-    assert.equal(await readLocal(a, copyPath), "B's own edit");
-
-    // And the pass that used to wedge is now genuinely idle on both devices.
-    assert.equal((await sync(b)).ok, true);
-    assert.equal((await sync(a)).ok, true);
+    // Nothing was pushed and no manifest was written; A's original content is untouched.
+    const survivorKey = blobKeyFor(await hashOf("from A"));
+    const kept = await storage.getObject(survivorKey);
+    assert.equal(new TextDecoder().decode(kept.body ?? new Uint8Array()), "from A");
+    assert.equal((await storage.getObject(MANIFEST_KEY)).ok, false);
   } finally {
     cleanup(a, b);
   }

--- a/src/sync/sync.itest.ts
+++ b/src/sync/sync.itest.ts
@@ -72,7 +72,7 @@ function newDevice(): Device {
 // byte length so a same millisecond, same size rewrite can never hide a change from mtime based
 // detection.
 async function writeLocal(d: Device, path: string, body: string): Promise<void> {
-  const staged = await d.writer.stageFile(path, new TextEncoder().encode(body));
+  const staged = await d.writer.stageFile(path, new TextEncoder().encode(body), "replace");
   await staged.commit();
 }
 

--- a/src/sync/sync.itest.ts
+++ b/src/sync/sync.itest.ts
@@ -383,13 +383,14 @@ test("sync: two devices syncing at overlapping times never silently delete a fil
   }
 });
 
-test("sync: a deleted manifest with unexplained blobs refuses a first sync instead of stranding them", async () => {
-  // Reproduces #109 for content addressed storage. A syncs a note up, then the manifest alone is
-  // deleted (a bucket lifecycle rule, manual cleanup, a partial restore) while its blob survives.
-  // B, never synced, then sees what looks like a first sync; its local vault has no file whose
-  // content explains that blob (a's note was never B's), so before the fix a naive first sync
-  // would push its own files and write a fresh manifest that never mentioned it, stranding it
-  // forever.
+test("sync: a deleted manifest with unexplained blobs reports and proceeds, rather than deadlocking B forever", async () => {
+  // Reproduces #109 for content addressed storage, and the regression an outright refusal here
+  // caused. A syncs a note up, then the manifest alone is deleted (a bucket lifecycle rule, manual
+  // cleanup, a partial restore) while its blob survives. B, never synced, then sees what looks
+  // like a first sync; its local vault has no file whose content explains that blob (a's note was
+  // never B's). A hard refusal here never writes a manifest, so every future attempt of B's would
+  // hit the identical refusal forever; the pass must instead proceed, push B's own files, and
+  // report the stranded content as a failure rather than silently going ok.
   await resetRemote();
   const a = newDevice();
   const b = newDevice();
@@ -402,30 +403,33 @@ test("sync: a deleted manifest with unexplained blobs refuses a first sync inste
 
     const outcome = await sync(b);
     assert.ok(!outcome.ok);
-    assert.equal(outcome.message, "bucket has content but no manifest; sync would strand it");
     const survivorKey = blobKeyFor(await hashOf("a's note"));
     assert.deepEqual(outcome.failures, [
       { path: survivorKey, message: "in the bucket but not in the local vault" },
     ]);
 
-    // Nothing was pushed and no manifest was written; A's blob is untouched.
+    // B's own file still pushed and a manifest still landed; A's blob is untouched, unreferenced
+    // but not destroyed.
     const kept = await storage.getObject(survivorKey);
     assert.equal(new TextDecoder().decode(kept.body ?? new Uint8Array()), "a's note");
-    assert.equal((await storage.getObject(blobKeyFor(await hashOf("b's note")))).ok, false);
-    assert.equal((await storage.getObject(MANIFEST_KEY)).ok, false);
+    assert.equal((await storage.getObject(blobKeyFor(await hashOf("b's note")))).ok, true);
+    assert.equal((await storage.getObject(MANIFEST_KEY)).ok, true);
+
+    // B is not stuck: the next sync is ordinary, not a repeat of the same refusal.
+    assert.equal((await sync(b)).ok, true);
   } finally {
     cleanup(a, b);
   }
 });
 
-test("sync: a deleted manifest over locally diverged content refuses rather than guessing a conflict", async () => {
+test("sync: a deleted manifest over locally diverged content reports and proceeds, rather than guessing a conflict", async () => {
   // A and B share a synced note, then the manifest alone is deleted (a lifecycle rule, manual
   // cleanup) and B edits the note before its next sync. Under the plaintext path keyed layout this
   // replaced, the surviving object's key was the path itself, so this case could be resolved
   // automatically as a conflict. Under content addressed storage the manifest was the only place
   // that ever recorded which path a hash belonged to, so B's now-edited local file no longer
-  // explains the surviving blob, and the pass must refuse rather than guess at a conflict it has
-  // no path information to construct.
+  // explains the surviving blob, and the pass has no path information left to construct a
+  // conflict from; it proceeds with B's edit as a plain push and reports the stranded original.
   await resetRemote();
   const a = newDevice();
   const b = newDevice();
@@ -439,13 +443,20 @@ test("sync: a deleted manifest over locally diverged content refuses rather than
 
     const outcome = await sync(b);
     assert.ok(!outcome.ok);
-    assert.equal(outcome.message, "bucket has content but no manifest; sync would strand it");
-
-    // Nothing was pushed and no manifest was written; A's original content is untouched.
     const survivorKey = blobKeyFor(await hashOf("from A"));
+    assert.deepEqual(outcome.failures, [
+      { path: survivorKey, message: "in the bucket but not in the local vault" },
+    ]);
+
+    // A's original content is untouched, unreferenced but not destroyed; B's edit still pushed
+    // under its own path.
     const kept = await storage.getObject(survivorKey);
     assert.equal(new TextDecoder().decode(kept.body ?? new Uint8Array()), "from A");
-    assert.equal((await storage.getObject(MANIFEST_KEY)).ok, false);
+    assert.equal(await readLocal(b, "ten/note.md"), "B's own edit");
+    assert.equal((await storage.getObject(MANIFEST_KEY)).ok, true);
+
+    // B is not stuck: the next sync is ordinary, not a repeat of the same refusal.
+    assert.equal((await sync(b)).ok, true);
   } finally {
     cleanup(a, b);
   }

--- a/src/sync/sync.test.ts
+++ b/src/sync/sync.test.ts
@@ -133,7 +133,7 @@ test("syncOnce: a manifest format this build doesn't know halts the pass before 
   writer.renameFile = async () => {
     throw new Error("unexpected local rename");
   };
-  writer.writeFile = async () => {
+  writer.stageFile = async () => {
     throw new Error("unexpected local write");
   };
 
@@ -478,10 +478,19 @@ test("syncOnce: a file edited mid sync is never overwritten by a pull, and the r
   files.set("b.md", "b v1");
   // Mirror pulls into the reader, as writing to a real vault would: the retry below re-snapshots
   // through the reader and must see what the first pass's completed pull actually left on disk.
-  const innerWrite = writer.writeFile;
-  writer.writeFile = async (path, data) => {
-    await innerWrite(path, data);
-    readerFiles[path] = new TextDecoder().decode(data);
+  // Mirrored on commit, not on staging, so the reader only ever sees content that reached the
+  // destination, exactly as the vault would.
+  const innerStage = writer.stageFile;
+  writer.stageFile = async (path, data) => {
+    const staged = await innerStage(path, data);
+
+    return {
+      commit: async () => {
+        await staged.commit();
+        readerFiles[path] = new TextDecoder().decode(data);
+      },
+      discard: staged.discard,
+    };
   };
   const inner = storage.getObject;
   let edited = false;
@@ -734,12 +743,19 @@ test("syncOnce: a failed pull records progress without the ancestor ever advanci
   const readerFiles: Record<string, string> = { "a.md": "a v1" };
   const reader = fakeReader(readerFiles);
   let lockA = true;
+  // The lock bites on commit rather than on staging: a lock is held on the destination, and
+  // staging only ever touches a temp file beside it.
   const writer: LocalWriter = {
-    writeFile: async (path, data) => {
-      if (path === "a.md" && lockA) {
-        throw new Error("EBUSY: resource busy or locked");
-      }
-      readerFiles[path] = new TextDecoder().decode(data);
+    stageFile: async (path, data) => {
+      return {
+        commit: async () => {
+          if (path === "a.md" && lockA) {
+            throw new Error("EBUSY: resource busy or locked");
+          }
+          readerFiles[path] = new TextDecoder().decode(data);
+        },
+        discard: async () => {},
+      };
     },
     deleteFile: async (path) => {
       delete readerFiles[path];

--- a/src/sync/sync.test.ts
+++ b/src/sync/sync.test.ts
@@ -3,17 +3,18 @@ import { test } from "node:test";
 import { encodeSnapshot, hashBytes, type Snapshot } from "../vault/vault.ts";
 import type { LocalWriter } from "./execute.ts";
 import { empty, fakeLocalWriter, fakeReader, fakeStorage, file, snapshot } from "./fake.ts";
-import { conflictCopyPath, MANIFEST_KEY } from "./plan.ts";
+import { blobKeyFor, conflictCopyPath, MANIFEST_KEY } from "./plan.ts";
 import {
   adoptLiveStats,
-  orphanedKeys,
   readRemoteManifest,
   revertFailedPaths,
   syncOnce,
+  unexplainedBlobs,
 } from "./sync.ts";
 
 // hashOf returns the real content hash of text, for snapshots whose entries executeSyncPlan's
-// drift check will verify against live bytes.
+// drift check will verify against live bytes, and for keying a fakeStorage seed at the blob key
+// content actually lives under.
 async function hashOf(text: string): Promise<string> {
   return hashBytes(new TextEncoder().encode(text));
 }
@@ -71,31 +72,49 @@ test("readRemoteManifest: JSON of the wrong shape is corrupt, not a snapshot wit
   }
 });
 
-test("readRemoteManifest: a pre-marker manifest with no version field is accepted as version 1", async () => {
-  // Buckets written before the format version marker existed (#91) are version 1 by definition;
-  // they must keep syncing, not read as corrupt.
+test("readRemoteManifest: a pre-marker manifest with no version field is refused, since only the current storage layout is understood", async () => {
+  // Buckets written before the format version marker existed (#91) are version 1 by definition:
+  // plaintext path keyed storage. This build only understands version 2, content addressed blobs,
+  // so a version 1 manifest must be refused rather than misread against a layout it never used.
   const want: Snapshot = snapshot(file("a.md", "h1"));
   const { storage } = fakeStorage({ [MANIFEST_KEY]: JSON.stringify(want) });
 
   const result = await readRemoteManifest(storage);
 
-  assert.deepEqual(result, { ok: true, snapshot: want, firstSync: false, etag: '"v1"' });
+  assert.deepEqual(result, {
+    ok: false,
+    message: "remote manifest is a format this version of geode can't read",
+  });
 });
 
-test("readRemoteManifest: a manifest from a newer format version refuses the pass", async () => {
-  // A bucket written in a format this build does not know must not be synced against, and the
-  // message points at the actual fix (update the plugin) instead of claiming corruption.
-  const { storage } = fakeStorage({ [MANIFEST_KEY]: JSON.stringify({ version: 2, files: [] }) });
+test("readRemoteManifest: a manifest from a format version this build doesn't know refuses the pass", async () => {
+  // A bucket written in a format this build does not know must not be synced against.
+  const { storage } = fakeStorage({ [MANIFEST_KEY]: JSON.stringify({ version: 3, files: [] }) });
 
   const result = await readRemoteManifest(storage);
 
   assert.deepEqual(result, {
     ok: false,
-    message: "remote manifest needs a newer version of geode",
+    message: "remote manifest is a format this version of geode can't read",
   });
 });
 
-test("syncOnce: a newer manifest version halts the pass before any sync work", async () => {
+test("readRemoteManifest: a non 404 failure is reported, never guessed at as empty", async () => {
+  const { storage } = fakeStorage();
+  storage.getObject = async () => ({
+    ok: false,
+    status: "server",
+    message: "Storage rejected the read (500)",
+    body: null,
+    etag: null,
+  });
+
+  const result = await readRemoteManifest(storage);
+
+  assert.deepEqual(result, { ok: false, message: "Storage rejected the read (500)" });
+});
+
+test("syncOnce: a manifest format this build doesn't know halts the pass before any sync work", async () => {
   const reader = fakeReader({ "local.md": "local" });
   reader.fileExists = async () => {
     throw new Error("unexpected local existence check");
@@ -119,16 +138,15 @@ test("syncOnce: a newer manifest version halts the pass before any sync work", a
   };
 
   const { storage } = fakeStorage({
-    [MANIFEST_KEY]: JSON.stringify({ version: 2, files: [] }),
-    "remote.md": "remote",
+    [MANIFEST_KEY]: JSON.stringify({ version: 3, files: [] }),
   });
   const getObject = storage.getObject;
   storage.getObject = async (key) => {
     assert.equal(key, MANIFEST_KEY);
     return getObject(key);
   };
-  storage.copyObject = async () => {
-    throw new Error("unexpected remote copy");
+  storage.headObject = async () => {
+    throw new Error("unexpected remote head");
   };
   storage.deleteObject = async () => {
     throw new Error("unexpected remote delete");
@@ -144,7 +162,7 @@ test("syncOnce: a newer manifest version halts the pass before any sync work", a
 
   assert.deepEqual(outcome, {
     ok: false,
-    message: "remote manifest needs a newer version of geode",
+    message: "remote manifest is a format this version of geode can't read",
     failures: [],
     snapshot: null,
   });
@@ -169,9 +187,9 @@ test("syncOnce: a stale ancestor is ignored on a first sync, so a populated vaul
   // Nothing was deleted locally.
   assert.equal(files.get("a.md"), "alpha");
   assert.equal(files.get("b.md"), "beta");
-  // Both files reached the previously empty bucket.
-  assert.equal(objects.get("a.md"), "alpha");
-  assert.equal(objects.get("b.md"), "beta");
+  // Both files' blobs reached the previously empty bucket.
+  assert.equal(objects.get(blobKeyFor(await hashOf("alpha"))), "alpha");
+  assert.equal(objects.get(blobKeyFor(await hashOf("beta"))), "beta");
 });
 
 test("syncOnce: a present but empty manifest still trusts the ancestor and pulls a real remote deletion", async () => {
@@ -193,12 +211,15 @@ test("syncOnce: a present but empty manifest still trusts the ancestor and pulls
   assert.equal(files.has("a.md"), false);
 });
 
-test("syncOnce: a missing manifest with surviving remote objects refuses, never orphans them", async () => {
-  // Reproduces #109. A lifecycle rule or manual cleanup deleted the manifest while file objects
-  // survived. Before the fix this read as a clean first sync: the pass pushed local files and
-  // wrote a manifest that never mentioned the survivors, so no device would ever pull, list, or
-  // delete them again. The pass must refuse instead, naming each stranded key.
-  const { storage, objects } = fakeStorage({ "keep/other-device.md": "not local" });
+test("syncOnce: a missing manifest with unexplained blobs refuses, never strands them", async () => {
+  // Reproduces #109 for content addressed storage. A lifecycle rule or manual cleanup deleted the
+  // manifest while a blob survived, and its hash matches nothing in this device's local vault: this
+  // device cannot say what path, if any, that content used to live at. Before the fix this read as
+  // a clean first sync: the pass pushed local files and wrote a manifest that never mentioned the
+  // survivor, so no device would ever pull, list, or delete it again. The pass must refuse instead,
+  // naming the stranded key.
+  const strayHash = await hashOf("not local");
+  const { storage, objects } = fakeStorage({ [blobKeyFor(strayHash)]: "not local" });
   const reader = fakeReader({ "a.md": "alpha" });
   const { writer } = fakeLocalWriter();
 
@@ -206,107 +227,33 @@ test("syncOnce: a missing manifest with surviving remote objects refuses, never 
 
   assert.deepEqual(outcome, {
     ok: false,
-    message: "bucket has files but no manifest; sync would orphan them",
+    message: "bucket has content but no manifest; sync would strand it",
     failures: [
-      { path: "keep/other-device.md", message: "in the bucket but not in the local vault" },
+      { path: blobKeyFor(strayHash), message: "in the bucket but not in the local vault" },
     ],
     snapshot: null,
   });
   // Nothing was pushed and no manifest was invented.
-  assert.equal(objects.has("a.md"), false);
+  assert.equal(objects.has(blobKeyFor(await hashOf("alpha"))), false);
   assert.equal(objects.has(MANIFEST_KEY), false);
 });
 
 test("syncOnce: an interrupted first sync's own uploads never block the retry", async () => {
-  // A first sync that pushed a.md and then died before its manifest upload leaves objects and no
-  // manifest, the same bucket signature as #109's hazard. Every such object matches a local path,
-  // so nothing can be orphaned; the retry must fold them in and complete, not refuse.
-  const { storage, objects } = fakeStorage({ "a.md": "alpha" });
+  // A first sync that pushed a.md's blob and then died before its manifest upload leaves a blob
+  // and no manifest, the same bucket signature as #109's hazard. Its hash matches what the local
+  // vault still holds, so nothing is unexplained; the retry must fold it in and complete, not
+  // refuse.
+  const aHash = await hashOf("alpha");
+  const { storage, objects } = fakeStorage({ [blobKeyFor(aHash)]: "alpha" });
   const reader = fakeReader({ "a.md": "alpha", "b.md": "beta" });
   const { writer } = fakeLocalWriter();
 
   const outcome = await syncOnce(empty, reader, writer, storage, 1);
 
   assert.equal(outcome.ok, true);
-  assert.equal(objects.get("a.md"), "alpha");
-  assert.equal(objects.get("b.md"), "beta");
+  assert.equal(objects.get(blobKeyFor(aHash)), "alpha");
+  assert.equal(objects.get(blobKeyFor(await hashOf("beta"))), "beta");
   assert.equal(objects.has(MANIFEST_KEY), true);
-});
-
-test("syncOnce: a missing manifest over divergent bytes conflicts instead of wedging the sync", async () => {
-  // The manifest is gone (a lifecycle rule, a second vault on the same bucket) but the object at
-  // a.md survived, holding bytes this vault has never seen. Before the fix the empty remote view
-  // made that path an ifAbsent push, the surviving object rejected it with a 412, and the pass read
-  // that as another device syncing and told the user to sync again: nothing about either side
-  // changed, so every retry hit the identical 412, a permanent wedge whose message named the one
-  // action that could not work. Planning against what the bucket really holds makes it a conflict.
-  const { storage, objects } = fakeStorage({ "a.md": "theirs" });
-  const reader = fakeReader({ "a.md": "ours" });
-  const { writer, files } = fakeLocalWriter();
-  files.set("a.md", "ours");
-
-  const outcome = await syncOnce(empty, reader, writer, storage, 1);
-
-  assert.equal(outcome.ok, true);
-  // Neither version was lost: the surviving object keeps the path, the local edit lives on under
-  // the conflict copy, both on disk and in the bucket, and a manifest now describes all of it.
-  const copy = conflictCopyPath("a.md", 1);
-  assert.equal(files.get("a.md"), "theirs");
-  assert.equal(files.get(copy), "ours");
-  assert.equal(objects.get("a.md"), "theirs");
-  assert.equal(objects.get(copy), "ours");
-  assert.equal(objects.has(MANIFEST_KEY), true);
-});
-
-test("syncOnce: an unreadable survivor on a first sync is reported, never guessed at as absent", async () => {
-  const { storage, objects } = fakeStorage({ "a.md": "theirs" });
-  const inner = storage.getObject;
-  storage.getObject = async (key) => {
-    if (key !== "a.md") {
-      return inner(key);
-    }
-    return {
-      ok: false,
-      status: "server",
-      message: "Storage rejected the read (500)",
-      body: null,
-      etag: null,
-    };
-  };
-  const reader = fakeReader({ "a.md": "ours" });
-  const { writer } = fakeLocalWriter();
-
-  const outcome = await syncOnce(empty, reader, writer, storage, 1);
-
-  assert.deepEqual(outcome, {
-    ok: false,
-    message: "Storage rejected the read (500)",
-    failures: [{ path: "a.md", message: "Storage rejected the read (500)" }],
-    snapshot: null,
-  });
-  // The survivor was left alone and no manifest was written over a view we could not read.
-  assert.equal(objects.get("a.md"), "theirs");
-  assert.equal(objects.has(MANIFEST_KEY), false);
-});
-
-test("syncOnce: a survivor deleted between the listing and the read is treated as gone", async () => {
-  // Another device removed the object in the window between the two calls. That is the absence the
-  // missing manifest already implied, so the pass proceeds and pushes the local file.
-  const { storage, objects } = fakeStorage({ "a.md": "theirs" });
-  const inner = storage.getObject;
-  storage.getObject = async (key) => {
-    if (key === "a.md") {
-      objects.delete(key);
-    }
-    return inner(key);
-  };
-  const reader = fakeReader({ "a.md": "ours" });
-  const { writer } = fakeLocalWriter();
-
-  const outcome = await syncOnce(empty, reader, writer, storage, 1);
-
-  assert.equal(outcome.ok, true);
-  assert.equal(objects.get("a.md"), "ours");
 });
 
 test("syncOnce: a failed bucket listing on a first sync is reported, never guessed at as empty", async () => {
@@ -330,31 +277,17 @@ test("syncOnce: a failed bucket listing on a first sync is reported, never guess
   });
 });
 
-test("orphanedKeys: keys with no local counterpart are orphans; local matches and reserved keys are not", () => {
+test("unexplainedBlobs: a blob whose hash matches nothing local is unexplained; a matching one is not", () => {
+  // syncOnce always calls this with an already prefix filtered listing (storage.listObjects is
+  // called with BLOB_PREFIX), so every key here is a blob key; the manifest itself is never among
+  // them.
   const objects = [
-    { key: "a.md", size: 5, lastModified: "" },
-    { key: "keep/b.md", size: 5, lastModified: "" },
-    { key: MANIFEST_KEY, size: 5, lastModified: "" },
-    { key: ".geode/trash/2020-01-01/gone.md", size: 5, lastModified: "" },
+    { key: blobKeyFor("h1"), size: 5, lastModified: "" },
+    { key: blobKeyFor("h2"), size: 5, lastModified: "" },
   ];
   const local = snapshot(file("a.md", "h1"));
 
-  assert.deepEqual(orphanedKeys(objects, local), ["keep/b.md"]);
-});
-
-test("readRemoteManifest: a non 404 failure is reported, never guessed at as empty", async () => {
-  const { storage } = fakeStorage();
-  storage.getObject = async () => ({
-    ok: false,
-    status: "server",
-    message: "Storage rejected the read (500)",
-    body: null,
-    etag: null,
-  });
-
-  const result = await readRemoteManifest(storage);
-
-  assert.deepEqual(result, { ok: false, message: "Storage rejected the read (500)" });
+  assert.deepEqual(unexplainedBlobs(objects, local), [blobKeyFor("h2")]);
 });
 
 test("syncOnce: a manifest overwritten by another device mid sync fails the pass instead of clobbering it", async () => {
@@ -365,13 +298,14 @@ test("syncOnce: a manifest overwritten by another device mid sync fails the pass
   // deleted. A's conditional upload must instead lose the race and fail the pass.
   const ancestor = snapshot(file("a.md", "h1"));
   const { storage, objects } = fakeStorage({ [MANIFEST_KEY]: encodeSnapshot(ancestor) });
-  const bManifest = encodeSnapshot(snapshot(file("a.md", "h1"), file("b.md", await hashOf("bee"))));
+  const beeHash = await hashOf("bee");
+  const bManifest = encodeSnapshot(snapshot(file("a.md", "h1"), file("b.md", beeHash)));
   const inner = storage.putObject;
   let raced = false;
   storage.putObject = async (key, body, condition) => {
     if (key === MANIFEST_KEY && !raced) {
       raced = true;
-      await inner("b.md", new TextEncoder().encode("bee"));
+      await inner(blobKeyFor(beeHash), new TextEncoder().encode("bee"));
       await inner(MANIFEST_KEY, new TextEncoder().encode(bManifest));
     }
     return inner(key, body, condition);
@@ -394,7 +328,7 @@ test("syncOnce: a manifest overwritten by another device mid sync fails the pass
   // B's manifest survived; A's never landed.
   assert.equal(objects.get(MANIFEST_KEY), bManifest);
   // A's push still reached the bucket (harmless: the next pass folds it into the manifest).
-  assert.equal(objects.get("c.md"), "ccc");
+  assert.equal(objects.get(blobKeyFor(await hashOf("ccc"))), "ccc");
   // Nothing was touched locally.
   assert.equal(files.get("a.md"), "xy");
   assert.equal(files.get("c.md"), "ccc");
@@ -407,17 +341,19 @@ test("syncOnce: a manifest overwritten by another device mid sync fails the pass
   assert.equal(files.get("a.md"), "xy");
 });
 
-test("syncOnce: retry adopts an identical orphaned upload without another file PUT", async () => {
+test("syncOnce: retry adopts an identical orphaned upload with a HEAD, not another PUT", async () => {
+  // Reproduces #110's shape for content addressed storage. The file's blob PUT lands before the
+  // manifest CAS is even attempted, so it survives a pass that then fails on the manifest race; a
+  // naive retry that always PUTs again would waste the upload a second time. ensureBlobStored's
+  // HEAD-before-PUT is what makes the retry free.
   const ancestor = snapshot({ path: "a.md", size: 4, mtime: 1, hash: await hashOf("base") });
-  const { storage, objects } = fakeStorage({
-    [MANIFEST_KEY]: encodeSnapshot(ancestor),
-    "a.md": "base",
-  });
+  const { storage, objects } = fakeStorage({ [MANIFEST_KEY]: encodeSnapshot(ancestor) });
+  const oursHash = await hashOf("ours!");
   const inner = storage.putObject;
   let filePuts = 0;
   let raceManifest = true;
   storage.putObject = async (key, body, condition) => {
-    if (key === "a.md") {
+    if (key === blobKeyFor(oursHash)) {
       filePuts++;
     }
     if (key === MANIFEST_KEY && raceManifest) {
@@ -437,63 +373,23 @@ test("syncOnce: retry adopts an identical orphaned upload without another file P
     failures: [],
     snapshot: null,
   });
-  assert.equal(objects.get("a.md"), "ours!");
+  assert.equal(objects.get(blobKeyFor(oursHash)), "ours!");
   assert.equal(filePuts, 1);
 
-  // The manifest is still at the ancestor while a.md already contains our bytes, so the retry's
-  // pre-PUT check must return `done` and adopt the orphan instead of issuing another file PUT.
+  // The manifest is still at the ancestor while the blob already holds our bytes, so the retry's
+  // HEAD must find it and skip the PUT entirely.
   const retry = await syncOnce(ancestor, reader, writer, storage, 1);
 
   assert.deepEqual(retry, {
     ok: true,
     snapshot: {
-      files: [{ path: "a.md", size: 5, mtime: 1, hash: await hashOf("ours!") }],
+      files: [{ path: "a.md", size: 5, mtime: 1, hash: oursHash }],
     },
     changeCount: 1,
   });
-  assert.equal(filePuts, 1, "retry replaced an identical orphaned upload");
+  assert.equal(filePuts, 1, "retry replaced an identical orphaned upload with a HEAD, not a PUT");
   assert.ok(retry.ok);
   assert.equal(objects.get(MANIFEST_KEY), encodeSnapshot(retry.snapshot));
-});
-
-test("syncOnce: losing the manifest race cannot overwrite the winner's file", async () => {
-  // Reproduces #110. Both passes plan an update to a.md from the same manifest. The winning pass
-  // uploads its file and manifest just as the losing pass starts its file PUT. The file PUT must
-  // be tied to the object version the loser planned from, so it fails instead of leaving bytes
-  // that disagree with the winning manifest.
-  const baseHash = await hashOf("base");
-  const winnerHash = await hashOf("winner");
-  const ancestor = snapshot({ path: "a.md", size: 4, mtime: 1, hash: baseHash });
-  const winnerManifest = encodeSnapshot(
-    snapshot({ path: "a.md", size: 6, mtime: 1, hash: winnerHash }),
-  );
-  const { storage, objects } = fakeStorage({
-    [MANIFEST_KEY]: encodeSnapshot(ancestor),
-    "a.md": "base",
-  });
-  const inner = storage.putObject;
-  let raced = false;
-  storage.putObject = async (key, body, condition) => {
-    if (key === "a.md" && !raced) {
-      raced = true;
-      await inner("a.md", new TextEncoder().encode("winner"));
-      await inner(MANIFEST_KEY, new TextEncoder().encode(winnerManifest));
-    }
-    return inner(key, body, condition);
-  };
-  const reader = fakeReader({ "a.md": "loser" });
-  const { writer } = fakeLocalWriter();
-
-  const outcome = await syncOnce(ancestor, reader, writer, storage, 1);
-
-  assert.deepEqual(outcome, {
-    ok: false,
-    message: "another device synced at the same time; sync again",
-    failures: [{ path: "a.md", message: "Storage rejected the write (412)" }],
-    snapshot: null,
-  });
-  assert.equal(objects.get("a.md"), "winner", "losing pass overwrote winning file object");
-  assert.equal(objects.get(MANIFEST_KEY), winnerManifest);
 });
 
 test("syncOnce: a file changed mid sync is not recorded in the manifest and is pushed next pass", async () => {
@@ -504,10 +400,11 @@ test("syncOnce: a file changed mid sync is not recorded in the manifest and is p
   // with the manifest), and another device could push the stale bucket copy of a.md back over the
   // edit. The manifest must instead keep claiming only what the bucket holds, leaving both files
   // as local changes for the next pass to push.
-  const ancestor = snapshot({ path: "a.md", size: 2, mtime: 1, hash: await hashOf("xy") });
+  const xyHash = await hashOf("xy");
+  const ancestor = snapshot({ path: "a.md", size: 2, mtime: 1, hash: xyHash });
   const { storage, objects } = fakeStorage({
     [MANIFEST_KEY]: encodeSnapshot(ancestor),
-    "a.md": "xy",
+    [blobKeyFor(xyHash)]: "xy",
   });
   // a.md matches the ancestor's size and mtime so takeSnapshot reuses its hash and sees no local
   // change there; b.md is the new local file whose push is the mid sync moment to interleave on.
@@ -515,9 +412,10 @@ test("syncOnce: a file changed mid sync is not recorded in the manifest and is p
   const reader = fakeReader(readerFiles);
   const { writer } = fakeLocalWriter();
   const inner = storage.putObject;
+  const betaHash = await hashOf("beta");
   let edited = false;
   storage.putObject = async (key, body, condition) => {
-    if (key === "b.md" && !edited) {
+    if (key === blobKeyFor(betaHash) && !edited) {
       edited = true;
       readerFiles["a.md"] = "edited mid sync";
       readerFiles["c.md"] = "created mid sync";
@@ -539,13 +437,13 @@ test("syncOnce: a file changed mid sync is not recorded in the manifest and is p
     manifest.files.filter((f) => f.path === "a.md"),
     ancestor.files,
   );
-  assert.equal(objects.has("c.md"), false);
+  assert.equal(objects.has(blobKeyFor(await hashOf("created mid sync"))), false);
 
   // The next pass sees both as plain local changes and pushes them.
   const retry = await syncOnce(outcome.snapshot, reader, writer, storage, 1);
   assert.equal(retry.ok, true);
-  assert.equal(objects.get("a.md"), "edited mid sync");
-  assert.equal(objects.get("c.md"), "created mid sync");
+  assert.equal(objects.get(blobKeyFor(await hashOf("edited mid sync"))), "edited mid sync");
+  assert.equal(objects.get(blobKeyFor(await hashOf("created mid sync"))), "created mid sync");
 });
 
 test("syncOnce: a file edited mid sync is never overwritten by a pull, and the retry preserves it as a conflict copy", async () => {
@@ -554,17 +452,17 @@ test("syncOnce: a file edited mid sync is never overwritten by a pull, and the r
   // for b.md then overwrote that edit with the remote version, silently discarding it. The pass
   // must refuse that pull and fail instead, and because state.json never advances, the retry sees
   // b.md changed on both sides and preserves the edit as a conflict copy.
+  const aV2Hash = await hashOf("a v2");
+  const bV2Hash = await hashOf("b v2");
   const ancestor = snapshot(
     { path: "a.md", size: 4, mtime: 1, hash: await hashOf("a v1") },
     { path: "b.md", size: 4, mtime: 1, hash: await hashOf("b v1") },
   );
-  const remoteManifest = encodeSnapshot(
-    snapshot(file("a.md", await hashOf("a v2")), file("b.md", await hashOf("b v2"))),
-  );
+  const remoteManifest = encodeSnapshot(snapshot(file("a.md", aV2Hash), file("b.md", bV2Hash)));
   const { storage, objects } = fakeStorage({
     [MANIFEST_KEY]: remoteManifest,
-    "a.md": "a v2",
-    "b.md": "b v2",
+    [blobKeyFor(aV2Hash)]: "a v2",
+    [blobKeyFor(bV2Hash)]: "b v2",
   });
   const readerFiles: Record<string, string> = { "a.md": "a v1", "b.md": "b v1" };
   const reader = fakeReader(readerFiles);
@@ -581,7 +479,7 @@ test("syncOnce: a file edited mid sync is never overwritten by a pull, and the r
   const inner = storage.getObject;
   let edited = false;
   storage.getObject = async (key) => {
-    if (key === "a.md" && !edited) {
+    if (key === blobKeyFor(aV2Hash) && !edited) {
       edited = true;
       readerFiles["b.md"] = "edited mid sync";
       files.set("b.md", "edited mid sync");
@@ -602,8 +500,8 @@ test("syncOnce: a file edited mid sync is never overwritten by a pull, and the r
   assert.ok(manifestBody !== undefined);
   const manifest = JSON.parse(manifestBody) as Snapshot;
   const hashes = new Map(manifest.files.map((f) => [f.path, f.hash]));
-  assert.equal(hashes.get("a.md"), await hashOf("a v2"));
-  assert.equal(hashes.get("b.md"), await hashOf("b v2"));
+  assert.equal(hashes.get("a.md"), aV2Hash);
+  assert.equal(hashes.get("b.md"), bV2Hash);
 
   // The pass still returned a snapshot recording its progress, with b.md held at the ancestor's
   // view. The retry diffs b.md against that same ancestor: changed locally and remotely, a
@@ -615,7 +513,7 @@ test("syncOnce: a file edited mid sync is never overwritten by a pull, and the r
   assert.equal(retry.ok, true);
   const copyPath = conflictCopyPath("b.md", now);
   assert.equal(files.get(copyPath), "edited mid sync");
-  assert.equal(objects.get(copyPath), "edited mid sync");
+  assert.equal(objects.get(blobKeyFor(await hashOf("edited mid sync"))), "edited mid sync");
   assert.equal(files.get("b.md"), "b v2");
 });
 
@@ -629,14 +527,16 @@ test("syncOnce: a failed push doesn't discard the progress of the rest of the pa
   const reader = fakeReader({ "a.md": "alpha", "b.md": "world" });
   const { writer } = fakeLocalWriter();
   const { storage, objects } = fakeStorage();
+  const alphaHash = await hashOf("alpha");
+  const worldHash = await hashOf("world");
   const inner = storage.putObject;
   let rejectA = true;
   let bPushes = 0;
   storage.putObject = async (key, body, condition) => {
-    if (key === "a.md" && rejectA) {
+    if (key === blobKeyFor(alphaHash) && rejectA) {
       return { ok: false, status: "server", message: "Storage rejected the write (500)" };
     }
-    if (key === "b.md") {
+    if (key === blobKeyFor(worldHash)) {
       bPushes++;
     }
     return inner(key, body, condition);
@@ -650,7 +550,7 @@ test("syncOnce: a failed push doesn't discard the progress of the rest of the pa
   ]);
   // b.md's push landed and the manifest records it, so other devices can already see it; a.md
   // never reached the bucket and the manifest doesn't claim it.
-  assert.equal(objects.get("b.md"), "world");
+  assert.equal(objects.get(blobKeyFor(worldHash)), "world");
   const manifestBody = objects.get(MANIFEST_KEY);
   assert.ok(manifestBody !== undefined);
   const manifest = JSON.parse(manifestBody) as Snapshot;
@@ -672,7 +572,7 @@ test("syncOnce: a failed push doesn't discard the progress of the rest of the pa
   const retry = await syncOnce(outcome.snapshot, reader, writer, storage, 1);
 
   assert.equal(retry.ok, true);
-  assert.equal(objects.get("a.md"), "alpha");
+  assert.equal(objects.get(blobKeyFor(alphaHash)), "alpha");
   assert.equal(bPushes, 1);
 });
 
@@ -698,7 +598,7 @@ test("syncOnce: a conflict's copy push survives into the uploaded manifest even 
     { path: "a.md", message: "Storage rejected the read (404)" },
   ]);
   // The copy really did reach the bucket.
-  assert.equal(objects.get(copyPath), "a local");
+  assert.equal(objects.get(blobKeyFor(await hashOf("a local"))), "a local");
   // The uploaded manifest names it, even though the conflict as a whole is reported failed.
   const manifestBody = objects.get(MANIFEST_KEY);
   assert.ok(manifestBody !== undefined);
@@ -718,10 +618,10 @@ test("syncOnce: the failure message counts files, not operation failures", async
   // is rejected by the override below. Both sides changed relative to the ancestor, so the plan is
   // a single conflict (deletedSide "none") for a.md.
   const { storage } = fakeStorage({ [MANIFEST_KEY]: remoteManifest });
-  const copyPath = conflictCopyPath("a.md", 1);
+  const copyBlobKey = blobKeyFor(await hashOf("a local"));
   const inner = storage.putObject;
   storage.putObject = async (key, body, condition) => {
-    if (key === copyPath) {
+    if (key === copyBlobKey) {
       return { ok: false, status: "server", message: "Storage rejected the write (500)" };
     }
     return inner(key, body, condition);
@@ -733,7 +633,7 @@ test("syncOnce: the failure message counts files, not operation failures", async
 
   assert.ok(!outcome.ok);
   assert.deepEqual(outcome.failures, [
-    { path: copyPath, message: "Storage rejected the write (500)" },
+    { path: conflictCopyPath("a.md", 1), message: "Storage rejected the write (500)" },
     { path: "a.md", message: "Storage rejected the read (404)" },
   ]);
   assert.equal(outcome.message, "1 file(s) failed to sync");
@@ -745,22 +645,25 @@ test("syncOnce: a failed pull records progress without the ancestor ever advanci
   // remotely and pulls fine. The pass must record b.md's progress, but if a.md's entry advanced
   // to the manifest's view the unchanged local copy would read as a fresh local edit on the next
   // pass and be pushed over the newer remote version, quietly undoing the remote edit.
-  const ancestor = snapshot({ path: "a.md", size: 4, mtime: 1, hash: await hashOf("a v1") });
+  const aV1Hash = await hashOf("a v1");
+  const aV2Hash = await hashOf("a v2");
+  const beeHash = await hashOf("bee");
+  const ancestor = snapshot({ path: "a.md", size: 4, mtime: 1, hash: aV1Hash });
   const remoteManifest = encodeSnapshot(
     snapshot(
-      { path: "a.md", size: 4, mtime: 1, hash: await hashOf("a v2") },
-      { path: "b.md", size: 3, mtime: 1, hash: await hashOf("bee") },
+      { path: "a.md", size: 4, mtime: 1, hash: aV2Hash },
+      { path: "b.md", size: 3, mtime: 1, hash: beeHash },
     ),
   );
   const { storage, objects } = fakeStorage({
     [MANIFEST_KEY]: remoteManifest,
-    "a.md": "a v2",
-    "b.md": "bee",
+    [blobKeyFor(aV2Hash)]: "a v2",
+    [blobKeyFor(beeHash)]: "bee",
   });
   const inner = storage.putObject;
   let aPushes = 0;
   storage.putObject = async (key, body, condition) => {
-    if (key === "a.md") {
+    if (key === blobKeyFor(aV1Hash)) {
       aPushes++;
     }
     return inner(key, body, condition);
@@ -791,8 +694,8 @@ test("syncOnce: a failed pull records progress without the ancestor ever advanci
   assert.equal(readerFiles["b.md"], "bee");
   assert.ok(outcome.snapshot !== null);
   const entries = new Map(outcome.snapshot.files.map((f) => [f.path, f.hash]));
-  assert.equal(entries.get("a.md"), await hashOf("a v1"));
-  assert.equal(entries.get("b.md"), await hashOf("bee"));
+  assert.equal(entries.get("a.md"), aV1Hash);
+  assert.equal(entries.get("b.md"), beeHash);
 
   // Once the file unlocks, the retry pulls the newer remote version; the stale local copy is
   // never pushed over it.
@@ -801,7 +704,7 @@ test("syncOnce: a failed pull records progress without the ancestor ever advanci
 
   assert.equal(retry.ok, true);
   assert.equal(readerFiles["a.md"], "a v2");
-  assert.equal(objects.get("a.md"), "a v2");
+  assert.equal(objects.get(blobKeyFor(aV2Hash)), "a v2");
   assert.equal(aPushes, 0);
 });
 

--- a/src/sync/sync.test.ts
+++ b/src/sync/sync.test.ts
@@ -481,8 +481,8 @@ test("syncOnce: a file edited mid sync is never overwritten by a pull, and the r
   // Mirrored on commit, not on staging, so the reader only ever sees content that reached the
   // destination, exactly as the vault would.
   const innerStage = writer.stageFile;
-  writer.stageFile = async (path, data) => {
-    const staged = await innerStage(path, data);
+  writer.stageFile = async (path, data, mode) => {
+    const staged = await innerStage(path, data, mode);
 
     return {
       commit: async () => {

--- a/src/sync/sync.test.ts
+++ b/src/sync/sync.test.ts
@@ -211,13 +211,16 @@ test("syncOnce: a present but empty manifest still trusts the ancestor and pulls
   assert.equal(files.has("a.md"), false);
 });
 
-test("syncOnce: a missing manifest with unexplained blobs refuses, never strands them", async () => {
-  // Reproduces #109 for content addressed storage. A lifecycle rule or manual cleanup deleted the
-  // manifest while a blob survived, and its hash matches nothing in this device's local vault: this
-  // device cannot say what path, if any, that content used to live at. Before the fix this read as
-  // a clean first sync: the pass pushed local files and wrote a manifest that never mentioned the
-  // survivor, so no device would ever pull, list, or delete it again. The pass must refuse instead,
-  // naming the stranded key.
+test("syncOnce: a missing manifest with unexplained blobs reports and proceeds, rather than deadlocking every future sync", async () => {
+  // Reproduces #109 for content addressed storage, and the regression an outright refusal here
+  // caused. A lifecycle rule or manual cleanup deleted the manifest while a blob survived, and its
+  // hash matches nothing in this device's local vault: this device cannot say what path, if any,
+  // that content used to live at. A blanket refusal here never writes a manifest, so
+  // remote.firstSync stays true and every future attempt hits the identical refusal, forever, even
+  // once the explanation is entirely mundane (an interrupted first sync's blob, whose local file
+  // was deleted before the retry) rather than another vault's stray data. The pass must instead
+  // proceed, push what is local, and report the stranded content as a failure so a human can still
+  // notice it without every future sync being blocked on it.
   const strayHash = await hashOf("not local");
   const { storage, objects } = fakeStorage({ [blobKeyFor(strayHash)]: "not local" });
   const reader = fakeReader({ "a.md": "alpha" });
@@ -225,17 +228,21 @@ test("syncOnce: a missing manifest with unexplained blobs refuses, never strands
 
   const outcome = await syncOnce(empty, reader, writer, storage, 1);
 
-  assert.deepEqual(outcome, {
-    ok: false,
-    message: "bucket has content but no manifest; sync would strand it",
-    failures: [
-      { path: blobKeyFor(strayHash), message: "in the bucket but not in the local vault" },
-    ],
-    snapshot: null,
-  });
-  // Nothing was pushed and no manifest was invented.
-  assert.equal(objects.has(blobKeyFor(await hashOf("alpha"))), false);
-  assert.equal(objects.has(MANIFEST_KEY), false);
+  assert.ok(!outcome.ok);
+  assert.equal(outcome.message, "1 file(s) failed to sync");
+  assert.deepEqual(outcome.failures, [
+    { path: blobKeyFor(strayHash), message: "in the bucket but not in the local vault" },
+  ]);
+  // The local file still pushed and a manifest still landed, ending firstSync state; the stray
+  // blob is left exactly where it was, unreferenced but undestroyed.
+  assert.equal(objects.get(blobKeyFor(await hashOf("alpha"))), "alpha");
+  assert.equal(objects.has(MANIFEST_KEY), true);
+
+  // Because a manifest now exists, the next sync is an ordinary sync rather than a repeat of the
+  // same refusal: it completes cleanly, not deadlocked on content it will never be able to explain.
+  assert.ok(outcome.snapshot !== null);
+  const retry = await syncOnce(outcome.snapshot, reader, writer, storage, 1);
+  assert.equal(retry.ok, true);
 });
 
 test("syncOnce: an interrupted first sync's own uploads never block the retry", async () => {
@@ -515,6 +522,62 @@ test("syncOnce: a file edited mid sync is never overwritten by a pull, and the r
   assert.equal(files.get(copyPath), "edited mid sync");
   assert.equal(objects.get(blobKeyFor(await hashOf("edited mid sync"))), "edited mid sync");
   assert.equal(files.get("b.md"), "b v2");
+});
+
+test("syncOnce: a manifest that moves on mid pull is caught before stale content lands on disk", async () => {
+  // A blob fetched by its own hash always reads back exactly that content, so unlike the plaintext
+  // path keyed layout this replaced, a pull can never notice on its own that a newer manifest has
+  // since pointed the path at a different hash. Another device completes an entire sync (new
+  // content, new manifest) in the window between this pass reading the manifest and its pull's
+  // fetch finishing; the drift check right before the write must catch this rather than let the
+  // now stale content land on disk, only to be discovered afterward when this pass's own manifest
+  // upload fails.
+  const aV1Hash = await hashOf("a v1");
+  const aV2Hash = await hashOf("a v2");
+  const aV3Hash = await hashOf("a v3");
+  const ancestor = snapshot({ path: "a.md", size: 4, mtime: 1, hash: aV1Hash });
+  const remoteManifestV2 = encodeSnapshot(
+    snapshot({ path: "a.md", size: 4, mtime: 1, hash: aV2Hash }),
+  );
+  const { storage, objects } = fakeStorage({
+    [MANIFEST_KEY]: remoteManifestV2,
+    [blobKeyFor(aV2Hash)]: "a v2",
+  });
+  const reader = fakeReader({ "a.md": "a v1" });
+  const { writer, files } = fakeLocalWriter();
+  files.set("a.md", "a v1");
+
+  const inner = storage.getObject;
+  let raced = false;
+  storage.getObject = async (key) => {
+    if (key === blobKeyFor(aV2Hash) && !raced) {
+      raced = true;
+      // Another device wins outright: its own blob and manifest both land before this pass's pull
+      // gets to write anything locally.
+      await storage.putObject(blobKeyFor(aV3Hash), new TextEncoder().encode("a v3"));
+      await storage.putObject(
+        MANIFEST_KEY,
+        new TextEncoder().encode(encodeSnapshot(snapshot(file("a.md", aV3Hash)))),
+      );
+    }
+    return inner(key);
+  };
+
+  const outcome = await syncOnce(ancestor, reader, writer, storage, 1);
+
+  assert.ok(!outcome.ok);
+  assert.deepEqual(outcome.failures, [
+    { path: "a.md", message: "changed remotely mid sync; sync again to reconcile" },
+  ]);
+  // The stale v2 content was never written; the local file is untouched.
+  assert.equal(files.get("a.md"), "a v1");
+  assert.equal(objects.get(MANIFEST_KEY), encodeSnapshot(snapshot(file("a.md", aV3Hash))));
+
+  // The failed pass never advanced state.json, so the retry re-reads the now current manifest and
+  // pulls the real latest version.
+  const retry = await syncOnce(ancestor, reader, writer, storage, 1);
+  assert.equal(retry.ok, true);
+  assert.equal(files.get("a.md"), "a v3");
 });
 
 test("syncOnce: a failed push doesn't discard the progress of the rest of the pass", async () => {

--- a/src/sync/sync.test.ts
+++ b/src/sync/sync.test.ts
@@ -649,26 +649,37 @@ test("syncOnce: a failed push doesn't discard the progress of the rest of the pa
 });
 
 test("syncOnce: a conflict's copy push survives into the uploaded manifest even when the restore fails", async () => {
-  // Reproduces #177: the copy push succeeds, but the manifest claims a remote version that isn't
-  // actually there, so the restore's GET 404s and the conflict is reported failed overall. The
-  // copy still landed in the bucket; if the manifest this pass uploads doesn't name it, the object
-  // sits there forever, invisible to every other device, until this same one syncs again.
+  // Reproduces #177: the local edit is moved aside and its copy pushed, but installing the remote
+  // version over the vacated path fails (a locked destination here, a note recreated in the gap in
+  // production). The copy still landed in the bucket; if the manifest this pass uploads doesn't
+  // name it, the object sits there forever, invisible to every other device, until this same one
+  // syncs again.
+  const aV2Hash = await hashOf("a v2");
   const ancestor = snapshot({ path: "a.md", size: 4, mtime: 1, hash: await hashOf("a v1") });
   const remoteManifest = encodeSnapshot(
-    snapshot({ path: "a.md", size: 4, mtime: 1, hash: await hashOf("a v2") }),
+    snapshot({ path: "a.md", size: 4, mtime: 1, hash: aV2Hash }),
   );
-  const { storage, objects } = fakeStorage({ [MANIFEST_KEY]: remoteManifest });
+  const { storage, objects } = fakeStorage({
+    [MANIFEST_KEY]: remoteManifest,
+    [blobKeyFor(aV2Hash)]: "a v2",
+  });
   const reader = fakeReader({ "a.md": "a local" });
   const { writer } = fakeLocalWriter();
+  writer.stageFile = async () => {
+    return {
+      commit: async () => {
+        throw new Error("EACCES: permission denied");
+      },
+      discard: async () => {},
+    };
+  };
   const now = 1;
   const copyPath = conflictCopyPath("a.md", now);
 
   const outcome = await syncOnce(ancestor, reader, writer, storage, now);
 
   assert.ok(!outcome.ok);
-  assert.deepEqual(outcome.failures, [
-    { path: "a.md", message: "Storage rejected the read (404)" },
-  ]);
+  assert.deepEqual(outcome.failures, [{ path: "a.md", message: "EACCES: permission denied" }]);
   // The copy really did reach the bucket.
   assert.equal(objects.get(blobKeyFor(await hashOf("a local"))), "a local");
   // The uploaded manifest names it, even though the conflict as a whole is reported failed.
@@ -680,16 +691,20 @@ test("syncOnce: a conflict's copy push survives into the uploaded manifest even 
 });
 
 test("syncOnce: the failure message counts files, not operation failures", async () => {
-  // A conflict whose copy push and pull both fail reports two operation failures for one vault
+  // A conflict whose restore and copy push both fail reports two operation failures for one vault
   // path. The user facing message must count the one file, not the two operations.
+  const aV2Hash = await hashOf("a v2");
   const ancestor = snapshot({ path: "a.md", size: 4, mtime: 1, hash: await hashOf("a v1") });
   const remoteManifest = encodeSnapshot(
-    snapshot({ path: "a.md", size: 4, mtime: 1, hash: await hashOf("a v2") }),
+    snapshot({ path: "a.md", size: 4, mtime: 1, hash: aV2Hash }),
   );
-  // The manifest claims a.md but the object is absent, so the conflict's pull 404s; the copy push
-  // is rejected by the override below. Both sides changed relative to the ancestor, so the plan is
-  // a single conflict (deletedSide "none") for a.md.
-  const { storage } = fakeStorage({ [MANIFEST_KEY]: remoteManifest });
+  // Both sides changed relative to the ancestor, so the plan is a single conflict (deletedSide
+  // "none") for a.md. Its restore fails on the commit and its copy push is rejected by the
+  // override below.
+  const { storage } = fakeStorage({
+    [MANIFEST_KEY]: remoteManifest,
+    [blobKeyFor(aV2Hash)]: "a v2",
+  });
   const copyBlobKey = blobKeyFor(await hashOf("a local"));
   const inner = storage.putObject;
   storage.putObject = async (key, body, condition) => {
@@ -700,13 +715,21 @@ test("syncOnce: the failure message counts files, not operation failures", async
   };
   const reader = fakeReader({ "a.md": "a local" });
   const { writer } = fakeLocalWriter();
+  writer.stageFile = async () => {
+    return {
+      commit: async () => {
+        throw new Error("EACCES: permission denied");
+      },
+      discard: async () => {},
+    };
+  };
 
   const outcome = await syncOnce(ancestor, reader, writer, storage, 1);
 
   assert.ok(!outcome.ok);
   assert.deepEqual(outcome.failures, [
+    { path: "a.md", message: "EACCES: permission denied" },
     { path: conflictCopyPath("a.md", 1), message: "Storage rejected the write (500)" },
-    { path: "a.md", message: "Storage rejected the read (404)" },
   ]);
   assert.equal(outcome.message, "1 file(s) failed to sync");
 });

--- a/src/sync/sync.test.ts
+++ b/src/sync/sync.test.ts
@@ -116,8 +116,8 @@ test("readRemoteManifest: a non 404 failure is reported, never guessed at as emp
 
 test("syncOnce: a manifest format this build doesn't know halts the pass before any sync work", async () => {
   const reader = fakeReader({ "local.md": "local" });
-  reader.fileExists = async () => {
-    throw new Error("unexpected local existence check");
+  reader.stat = async () => {
+    throw new Error("unexpected local stat");
   };
   reader.listFiles = async () => {
     throw new Error("unexpected local listing");

--- a/src/sync/sync.ts
+++ b/src/sync/sync.ts
@@ -4,19 +4,12 @@ import {
   decodeSnapshot,
   encodeSnapshot,
   type FileState,
-  hashBytes,
   type Reader,
   type Snapshot,
   takeSnapshot,
 } from "../vault/vault.ts";
 import { executeSyncPlan, type LocalWriter, type SyncFailure } from "./execute.ts";
-import {
-  MANIFEST_KEY,
-  manifestAfterSync,
-  planSync,
-  RESERVED_PREFIX,
-  type SyncAction,
-} from "./plan.ts";
+import { BLOB_PREFIX, MANIFEST_KEY, manifestAfterSync, planSync, type SyncAction } from "./plan.ts";
 
 // SyncOutcome is the result of a single sync pass. On success it carries the new snapshot to
 // persist as the next sync's starting point and how many actions were applied; on failure it
@@ -55,28 +48,6 @@ export function adoptLiveStats(manifest: Snapshot, live: Snapshot): Snapshot {
   return { files };
 }
 
-// orphanedKeys returns the bucket keys a first sync would strand: objects with no local file at
-// their key, which a manifest built purely from local files would never mention, so no device
-// would ever pull, list, or delete them again (#109). Keys under the reserved prefix are geode's
-// own bookkeeping (the manifest, trashed deletions), never vault files, and are not counted; if
-// the manifest appears in the listing (another device's first sync landing mid pass) the
-// conditional manifest upload catches it loudly. Exported for its tests; syncOnce is the only
-// production caller.
-export function orphanedKeys(objects: ObjectMeta[], local: Snapshot): string[] {
-  const localByPath = byPath(local.files);
-  const orphans: string[] = [];
-  for (const object of objects) {
-    if (object.key.startsWith(RESERVED_PREFIX)) {
-      continue;
-    }
-    if (!localByPath.has(object.key)) {
-      orphans.push(object.key);
-    }
-  }
-
-  return orphans;
-}
-
 // readRemoteManifest fetches and parses the remote manifest. A confirmed 404 means no manifest
 // has ever been written, the safe assumption for a first sync against an empty bucket, so that's
 // treated as an empty snapshot flagged firstSync. Any other failure (network, auth, a real 5xx)
@@ -107,7 +78,10 @@ export async function readRemoteManifest(
     const decoded = decodeSnapshot(new TextDecoder().decode(fetched.body));
     if (!decoded.ok) {
       if (decoded.reason === "unsupportedVersion") {
-        return { ok: false, message: "remote manifest needs a newer version of geode" };
+        return {
+          ok: false,
+          message: "remote manifest is a format this version of geode can't read",
+        };
       }
       return { ok: false, message: "remote manifest is corrupt" };
     }
@@ -185,48 +159,35 @@ export async function syncOnce(
   const local = await takeSnapshot(reader, ancestor);
 
   // A missing manifest usually means a fresh bucket, but not always: a lifecycle rule, manual
-  // cleanup, or partial restore can remove the manifest while file objects survive (#109). The
-  // pass below would build a manifest purely from local files, leaving every surviving object
-  // invisible: never pulled, never listed, orphaned forever. Refuse loudly instead when the
-  // bucket holds objects no local file accounts for.
-  //
-  // Objects that do match a local path are safe to proceed over, but only once the plan knows
-  // what they hold. The empty snapshot a missing manifest implies claims the bucket has nothing
-  // at that key, so the path plans as an ifAbsent push the surviving object can only reject; the
-  // 412 reads as concurrency and aborts the pass telling the user to sync again, and since
-  // nothing about either side changes, every retry reproduces it exactly: a permanent wedge whose
-  // error message names the one action that cannot work. Reading those objects instead makes the
-  // plan honest, and the ordinary machinery does the rest: identical bytes need no action at all,
-  // divergent bytes are a conflict, and neither side's version is lost.
-  let remoteView = remote.snapshot;
+  // cleanup, or partial restore can remove the manifest while blob objects survive (#109). Unlike
+  // the plaintext path keyed layout this replaced, that survival is not automatically a hazard: a
+  // blob's key is its own content hash, so a survivor whose hash matches something the local
+  // vault still holds needs no recovery at all, the ordinary push below finds it already there
+  // (one HEAD, no re-upload) and the manifest this pass writes describes it correctly. What
+  // remains dangerous is a survivor whose hash matches nothing local: unexplained content this
+  // device cannot account for, most plausibly a different vault's data that once shared this
+  // bucket, or the very race #109 first named. Building a manifest that silently ignores it would
+  // make that content unreachable forever, the same failure #109 fixed, just for content the local
+  // vault never had, so this refuses loudly and names it rather than guessing it away.
+  const remoteView = remote.snapshot;
   if (remote.firstSync) {
-    const listed = await storage.listObjects();
+    const listed = await storage.listObjects(BLOB_PREFIX);
     if (!listed.ok) {
       return { ok: false, message: listed.message, failures: [], snapshot: null };
     }
-    const orphans = orphanedKeys(listed.objects, local);
-    if (orphans.length > 0) {
+    const unexplained = unexplainedBlobs(listed.objects, local);
+    if (unexplained.length > 0) {
       const failures: SyncFailure[] = [];
-      for (const key of orphans) {
+      for (const key of unexplained) {
         failures.push({ path: key, message: "in the bucket but not in the local vault" });
       }
       return {
         ok: false,
-        message: "bucket has files but no manifest; sync would orphan them",
+        message: "bucket has content but no manifest; sync would strand it",
         failures,
         snapshot: null,
       };
     }
-    const survivors = await bucketView(listed.objects, local, storage);
-    if (!survivors.ok) {
-      return {
-        ok: false,
-        message: survivors.failure.message,
-        failures: [survivors.failure],
-        snapshot: null,
-      };
-    }
-    remoteView = survivors.snapshot;
   }
 
   const actions = planSync(ancestor, local, remoteView);
@@ -239,18 +200,6 @@ export async function syncOnce(
     now,
     remoteView,
   );
-
-  // A failed file precondition means the plan's remote snapshot is no longer current. Do not
-  // upload any manifest from that stale view, even if its own CAS has not lost yet: another pass
-  // may have uploaded the file object but still be about to upload its manifest.
-  if (executed.concurrent) {
-    return {
-      ok: false,
-      message: "another device synced at the same time; sync again",
-      failures: executed.failures,
-      snapshot: null,
-    };
-  }
 
   // The manifest is derived from what the plan just did to the bucket, never from a fresh disk
   // snapshot: a file edited while the plan ran would land in a re-snapshot claiming content the
@@ -311,46 +260,24 @@ export async function syncOnce(
   return { ok: true, snapshot: final, changeCount: actions.length };
 }
 
-// bucketView returns the remote snapshot a first sync should plan against: what the bucket really
-// holds, read from the objects that outlived the manifest, rather than the empty snapshot a missing
-// manifest implies. Only keys with a local file at the same path are read; anything else is either
-// geode's own bookkeeping or an orphan the caller has already refused over. The objects are fetched
-// and hashed because a plan needs content identity, not just a key: an ETag is a provider specific
-// opaque string and a listed size cannot tell two same length edits apart. That costs one GET per
-// surviving object, on a path only ever taken when a bucket has lost its manifest, and no more than
-// the failed conditional PUT plus its verifying GET that the same objects cost before. mtime is 0
-// because a remote object has no local mtime to speak of: any entry that survives into the manifest
-// therefore misses takeSnapshot's stat check next pass and is rehashed, the safe direction to err
-// in, and adoptLiveStats replaces it with the live entry wherever the content already agrees.
-async function bucketView(
-  objects: ObjectMeta[],
-  local: Snapshot,
-  storage: StorageClient,
-): Promise<{ ok: true; snapshot: Snapshot } | { ok: false; failure: SyncFailure }> {
-  const localByPath = byPath(local.files);
-  const files: FileState[] = [];
-
-  for (const object of objects) {
-    if (object.key.startsWith(RESERVED_PREFIX) || !localByPath.has(object.key)) {
-      continue;
-    }
-    const fetched = await storage.getObject(object.key, object.size);
-    if (!fetched.ok || fetched.body === null) {
-      // Listed a moment ago and gone now means another device deleted it in between, which is
-      // exactly the absence the missing manifest already implied; anything else is a real failure
-      // and must not be read as "the bucket holds nothing here", the guess that orphans files.
-      if (fetched.status === "not_found") {
-        continue;
-      }
-      return { ok: false, failure: { path: object.key, message: fetched.message } };
-    }
-    files.push({
-      path: object.key,
-      size: fetched.body.length,
-      mtime: 0,
-      hash: await hashBytes(fetched.body),
-    });
+// unexplainedBlobs returns the blob keys a first sync cannot account for: survivors whose content
+// hash matches nothing in the local vault, so nothing this pass is about to do would ever
+// reference them. Every other survivor, whose hash a local file already carries, needs no special
+// handling: the ordinary push below finds it already there and folds it into the manifest for
+// free. Exported for its tests; syncOnce is the only production caller.
+export function unexplainedBlobs(objects: ObjectMeta[], local: Snapshot): string[] {
+  const localHashes = new Set<string>();
+  for (const entry of local.files) {
+    localHashes.add(entry.hash);
   }
 
-  return { ok: true, snapshot: { files } };
+  const unexplained: string[] = [];
+  for (const object of objects) {
+    const hash = object.key.slice(BLOB_PREFIX.length);
+    if (!localHashes.has(hash)) {
+      unexplained.push(object.key);
+    }
+  }
+
+  return unexplained;
 }

--- a/src/sync/sync.ts
+++ b/src/sync/sync.ts
@@ -166,30 +166,38 @@ export async function syncOnce(
   // (one HEAD, no re-upload) and the manifest this pass writes describes it correctly. What
   // remains dangerous is a survivor whose hash matches nothing local: unexplained content this
   // device cannot account for, most plausibly a different vault's data that once shared this
-  // bucket, or the very race #109 first named. Building a manifest that silently ignores it would
-  // make that content unreachable forever, the same failure #109 fixed, just for content the local
-  // vault never had, so this refuses loudly and names it rather than guessing it away.
+  // bucket, or the very race #109 first named.
+  //
+  // This is reported rather than refused outright. An earlier version blocked the whole pass on
+  // any unexplained survivor, but that has no path back to a clean state when the explanation is
+  // mundane rather than sinister: an interrupted first sync leaves a blob behind, the local file
+  // it belonged to is deleted before the retry, and now nothing local will ever explain it again.
+  // Since remote.firstSync only flips to false once a manifest actually lands, a hard refusal here
+  // never writes one, so every retry hits the identical refusal forever, a permanent deadlock over
+  // an entirely ordinary local edit, worse than the silent stranding #109 fixed. Proceeding lets a
+  // real first sync complete and end firstSync state, at the cost that content #109 would have
+  // caught explicitly now stays unreferenced instead: still sitting in the bucket, never destroyed,
+  // just unreachable through any manifest until someone notices this failure and investigates.
   const remoteView = remote.snapshot;
+  const strandedFailures: SyncFailure[] = [];
   if (remote.firstSync) {
     const listed = await storage.listObjects(BLOB_PREFIX);
     if (!listed.ok) {
       return { ok: false, message: listed.message, failures: [], snapshot: null };
     }
-    const unexplained = unexplainedBlobs(listed.objects, local);
-    if (unexplained.length > 0) {
-      const failures: SyncFailure[] = [];
-      for (const key of unexplained) {
-        failures.push({ path: key, message: "in the bucket but not in the local vault" });
-      }
-      return {
-        ok: false,
-        message: "bucket has content but no manifest; sync would strand it",
-        failures,
-        snapshot: null,
-      };
+    for (const key of unexplainedBlobs(listed.objects, local)) {
+      strandedFailures.push({ path: key, message: "in the bucket but not in the local vault" });
     }
   }
 
+  // A pull family action re-checks this etag immediately before it writes fetched content locally
+  // (execute.ts's manifestDrifted), so a manifest another device replaces mid pass is caught before
+  // stale content lands on disk rather than only afterward, when this pass's own manifest upload
+  // fails. null on a first sync: there is no manifest yet for a pull to have gone stale against.
+  let manifestEtag: string | null = null;
+  if (!remote.firstSync) {
+    manifestEtag = remote.etag;
+  }
   const actions = planSync(ancestor, local, remoteView);
   const executed = await executeSyncPlan(
     actions,
@@ -199,6 +207,7 @@ export async function syncOnce(
     storage,
     now,
     remoteView,
+    manifestEtag,
   );
 
   // The manifest is derived from what the plan just did to the bucket, never from a fresh disk
@@ -248,11 +257,15 @@ export async function syncOnce(
 
   // The count comes from failed (one entry per planned path), not failures: a conflict can report
   // two operation failures (copy push and pull) for the same file, and the message counts files.
-  if (executed.failed.length > 0) {
+  // strandedFailures adds to it without adding to failed: there is no action, planned or
+  // otherwise, for a path a stranded blob doesn't have, so there is nothing for revertFailedPaths
+  // to revert; it is folded in here purely so the pass reports itself failed and names what it
+  // could not explain, rather than returning ok on a first sync that left content unreferenced.
+  if (executed.failed.length > 0 || strandedFailures.length > 0) {
     return {
       ok: false,
-      message: `${executed.failed.length} file(s) failed to sync`,
-      failures: executed.failures,
+      message: `${executed.failed.length + strandedFailures.length} file(s) failed to sync`,
+      failures: [...executed.failures, ...strandedFailures],
       snapshot: revertFailedPaths(final, ancestor, executed.failed),
     };
   }

--- a/src/vault/obsidian.test.ts
+++ b/src/vault/obsidian.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import type { DataAdapter, Workspace } from "obsidian";
 import { DEFAULT_SETTINGS } from "../settings/settings.ts";
+import type { LocalWriter } from "../sync/execute.ts";
 import { createObsidianLocalWriter, createObsidianStore, flushOpenEditors } from "./obsidian.ts";
 import { fingerprintSettings, type Snapshot } from "./vault.ts";
 
@@ -83,9 +84,16 @@ function fakeWriterAdapter(
   return { adapter: adapter as unknown as DataAdapter, files, ops };
 }
 
-// bytes encodes body for a writeFile call.
+// bytes encodes body for a staged write.
 function bytes(body: string): Uint8Array {
   return new TextEncoder().encode(body);
+}
+
+// writeThrough stages body at path and commits it, the two step sequence a pull runs its drift
+// checks between, collapsed for tests that only care about where the bytes end up.
+async function writeThrough(writer: LocalWriter, path: string, body: string): Promise<void> {
+  const staged = await writer.stageFile(path, bytes(body));
+  await staged.commit();
 }
 
 const STATE_PATH = "state.json";
@@ -99,7 +107,7 @@ test("createObsidianLocalWriter: a pull is staged to a hidden temp file and rena
   });
   const writer = createObsidianLocalWriter(adapter);
 
-  await writer.writeFile("notes/a.md", bytes("pulled content"));
+  await writeThrough(writer, "notes/a.md", "pulled content");
 
   assert.equal(files.get("notes/a.md"), "pulled content");
   assert.equal(files.has("notes/.a.md.geode-tmp"), false);
@@ -118,7 +126,7 @@ test("createObsidianLocalWriter: a pull into a path whose ancestors don't exist 
   });
   const writer = createObsidianLocalWriter(adapter);
 
-  await writer.writeFile("a/b/c/d.md", bytes("pulled content"));
+  await writeThrough(writer, "a/b/c/d.md", "pulled content");
 
   assert.equal(files.get("a/b/c/d.md"), "pulled content");
   assert.deepEqual(ops, [
@@ -137,7 +145,7 @@ test("createObsidianLocalWriter: overwriting an existing file replaces it throug
   );
   const writer = createObsidianLocalWriter(adapter);
 
-  await writer.writeFile("a.md", bytes("new content"));
+  await writeThrough(writer, "a.md", "new content");
 
   assert.equal(files.get("a.md"), "new content");
   assert.equal(files.has(".a.md.geode-tmp"), false);
@@ -151,7 +159,7 @@ test("createObsidianLocalWriter: an adapter whose rename refuses to overwrite re
   );
   const writer = createObsidianLocalWriter(adapter);
 
-  await writer.writeFile("a.md", bytes("new content"));
+  await writeThrough(writer, "a.md", "new content");
 
   assert.equal(files.get("a.md"), "new content");
   assert.equal(files.has(".a.md.geode-tmp"), false);
@@ -175,7 +183,7 @@ test("createObsidianLocalWriter: a rename that keeps failing for another reason 
   );
   const writer = createObsidianLocalWriter(adapter);
 
-  await assert.rejects(writer.writeFile("a.md", bytes("new content")));
+  await assert.rejects(writeThrough(writer, "a.md", "new content"));
 
   assert.equal(files.get("a.md"), "old content");
   assert.equal(files.has(".a.md.geode-old"), false);
@@ -197,9 +205,44 @@ test("createObsidianLocalWriter: a failed write of the staged bytes leaves the d
   );
   const writer = createObsidianLocalWriter(adapter);
 
-  await assert.rejects(writer.writeFile("a.md", bytes("new content")));
+  await assert.rejects(writeThrough(writer, "a.md", "new content"));
 
   assert.equal(files.get("a.md"), "old content");
+});
+
+test("createObsidianLocalWriter: discarding a staged write removes the temp file and never touches the destination", async () => {
+  // The path taken whenever a drift check refuses a pull after its payload is already staged: the
+  // staged bytes must go, and the destination must be exactly as it was, since the whole point of
+  // staging before the checks is that nothing at the destination has happened yet.
+  const { adapter, files, ops } = fakeWriterAdapter(
+    { renameOverwrites: true, stagedRenameFails: false, writeBinaryFails: false },
+    { "a.md": "old content" },
+  );
+  const writer = createObsidianLocalWriter(adapter);
+
+  const staged = await writer.stageFile("a.md", bytes("new content"));
+  await staged.discard();
+
+  assert.equal(files.get("a.md"), "old content");
+  assert.equal(files.has(".a.md.geode-tmp"), false);
+  assert.deepEqual(ops, ["writeBinary .a.md.geode-tmp", "remove .a.md.geode-tmp"]);
+});
+
+test("createObsidianLocalWriter: discarding a staged write twice is not an error", async () => {
+  // discardStaged runs on every refused path and its result is deliberately ignored, so a second
+  // discard (a retry, an unwind that already ran) must be a no-op rather than a throw over a temp
+  // file that is already gone.
+  const { adapter } = fakeWriterAdapter({
+    renameOverwrites: true,
+    stagedRenameFails: false,
+    writeBinaryFails: false,
+  });
+  const writer = createObsidianLocalWriter(adapter);
+
+  const staged = await writer.stageFile("a.md", bytes("new content"));
+  await staged.discard();
+
+  await assert.doesNotReject(staged.discard());
 });
 
 // fakeDeleteAdapter returns a DataAdapter for exercising deleteFile: trashSystemAvailable mimics an

--- a/src/vault/obsidian.test.ts
+++ b/src/vault/obsidian.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import type { DataAdapter, Workspace } from "obsidian";
 import { DEFAULT_SETTINGS } from "../settings/settings.ts";
-import type { LocalWriter } from "../sync/execute.ts";
+import type { LocalWriter, WriteMode } from "../sync/execute.ts";
 import { createObsidianLocalWriter, createObsidianStore, flushOpenEditors } from "./obsidian.ts";
 import { fingerprintSettings, type Snapshot } from "./vault.ts";
 
@@ -90,9 +90,15 @@ function bytes(body: string): Uint8Array {
 }
 
 // writeThrough stages body at path and commits it, the two step sequence a pull runs its drift
-// checks between, collapsed for tests that only care about where the bytes end up.
-async function writeThrough(writer: LocalWriter, path: string, body: string): Promise<void> {
-  const staged = await writer.stageFile(path, bytes(body));
+// checks between, collapsed for tests that only care about where the bytes end up. mode defaults to
+// the ordinary pull's "replace"; the "create" cases pass it explicitly.
+async function writeThrough(
+  writer: LocalWriter,
+  path: string,
+  body: string,
+  mode: WriteMode = "replace",
+): Promise<void> {
+  const staged = await writer.stageFile(path, bytes(body), mode);
   await staged.commit();
 }
 
@@ -148,6 +154,40 @@ test("createObsidianLocalWriter: overwriting an existing file replaces it throug
   await writeThrough(writer, "a.md", "new content");
 
   assert.equal(files.get("a.md"), "new content");
+  assert.equal(files.has(".a.md.geode-tmp"), false);
+  assert.deepEqual(ops, ["writeBinary .a.md.geode-tmp", "rename .a.md.geode-tmp -> a.md"]);
+});
+
+test("createObsidianLocalWriter: a create write onto an occupied destination refuses, never touching what is there", async () => {
+  // A conflict's restore stages its bytes for a path its own rename vacated moments earlier, so a
+  // file at that path was created in the window since and holds content no conflict copy
+  // preserved. The commit must refuse rather than rename over it, and must refuse before the
+  // rename, not after: the destination's own bytes are never in play.
+  const { adapter, files, ops } = fakeWriterAdapter(
+    { renameOverwrites: true, stagedRenameFails: false, writeBinaryFails: false },
+    { "a.md": "recreated mid sync" },
+  );
+  const writer = createObsidianLocalWriter(adapter);
+
+  await assert.rejects(writeThrough(writer, "a.md", "restored content", "create"), {
+    message: "changed locally mid sync; sync again to reconcile",
+  });
+
+  assert.equal(files.get("a.md"), "recreated mid sync");
+  assert.deepEqual(ops, ["writeBinary .a.md.geode-tmp"]);
+});
+
+test("createObsidianLocalWriter: a create write onto a free path renames straight in, with no aside dance", async () => {
+  const { adapter, files, ops } = fakeWriterAdapter({
+    renameOverwrites: true,
+    stagedRenameFails: false,
+    writeBinaryFails: false,
+  });
+  const writer = createObsidianLocalWriter(adapter);
+
+  await writeThrough(writer, "a.md", "restored content", "create");
+
+  assert.equal(files.get("a.md"), "restored content");
   assert.equal(files.has(".a.md.geode-tmp"), false);
   assert.deepEqual(ops, ["writeBinary .a.md.geode-tmp", "rename .a.md.geode-tmp -> a.md"]);
 });
@@ -220,7 +260,7 @@ test("createObsidianLocalWriter: discarding a staged write removes the temp file
   );
   const writer = createObsidianLocalWriter(adapter);
 
-  const staged = await writer.stageFile("a.md", bytes("new content"));
+  const staged = await writer.stageFile("a.md", bytes("new content"), "replace");
   await staged.discard();
 
   assert.equal(files.get("a.md"), "old content");
@@ -239,7 +279,7 @@ test("createObsidianLocalWriter: discarding a staged write twice is not an error
   });
   const writer = createObsidianLocalWriter(adapter);
 
-  const staged = await writer.stageFile("a.md", bytes("new content"));
+  const staged = await writer.stageFile("a.md", bytes("new content"), "replace");
   await staged.discard();
 
   await assert.doesNotReject(staged.discard());

--- a/src/vault/obsidian.ts
+++ b/src/vault/obsidian.ts
@@ -1,6 +1,6 @@
 import type { DataAdapter, Vault, Workspace } from "obsidian";
 import type { GeodeSettings } from "../settings/settings.ts";
-import type { LocalWriter } from "../sync/execute.ts";
+import { DRIFT_MESSAGE, type LocalWriter, type WriteMode } from "../sync/execute.ts";
 import {
   decodeSnapshot,
   encodeSnapshot,
@@ -23,7 +23,7 @@ import {
 // between the last check and the destination changing (see commitPulledContent in sync/execute.ts).
 export function createObsidianLocalWriter(adapter: DataAdapter): LocalWriter {
   return {
-    stageFile: async (path, data) => {
+    stageFile: async (path, data, mode) => {
       await ensureParentDir(adapter, path);
       const buffer = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength);
       const tempPath = hiddenSiblingPath(path, ".geode-tmp");
@@ -31,7 +31,7 @@ export function createObsidianLocalWriter(adapter: DataAdapter): LocalWriter {
 
       return {
         commit: async () => {
-          await installStaged(adapter, tempPath, path);
+          await installStaged(adapter, tempPath, path, mode);
         },
         discard: async () => {
           const exists = await adapter.exists(tempPath);
@@ -229,7 +229,29 @@ async function replaceViaAside(
 // replaceViaAside, shrinking the exposure from the whole download and write to the instant between
 // the two renames, where a crash leaves the path absent and the next sync replans the pull instead
 // of pushing corruption.
-async function installStaged(adapter: DataAdapter, tempPath: string, path: string): Promise<void> {
+//
+// A "create" write refuses that replacement entirely: its caller staged these bytes for a path it
+// had reason to believe was empty, so a file being there means one appeared since, and installing
+// over it would destroy content nothing else holds. The existence check is the adapter's own stat,
+// the only view that sees a file the moment it lands rather than when Obsidian's index catches up,
+// and it sits one call before the rename, which is as tight as an adapter with no create-exclusive
+// rename allows. Throwing is how every failure leaves this layer; executeSyncPlan turns it back
+// into an ordinary per file failure the moment it crosses the boundary.
+async function installStaged(
+  adapter: DataAdapter,
+  tempPath: string,
+  path: string,
+  mode: WriteMode,
+): Promise<void> {
+  if (mode === "create") {
+    const occupied = await adapter.exists(path);
+    if (occupied) {
+      throw new Error(DRIFT_MESSAGE);
+    }
+    await adapter.rename(tempPath, path);
+
+    return;
+  }
   try {
     await adapter.rename(tempPath, path);
   } catch (err) {

--- a/src/vault/obsidian.ts
+++ b/src/vault/obsidian.ts
@@ -17,12 +17,30 @@ import {
 // staged to a hidden temp file and renamed into place, never written directly to its destination,
 // so an interrupted pull cannot leave torn bytes for the next snapshot to read as a local edit
 // and push to the bucket (#88).
+//
+// Staging and installing are separate calls rather than one writeFile, so the caller can run its
+// drift checks in between: the payload is already on disk by then, leaving only commit's rename
+// between the last check and the destination changing (see commitPulledContent in sync/execute.ts).
 export function createObsidianLocalWriter(adapter: DataAdapter): LocalWriter {
   return {
-    writeFile: async (path, data) => {
+    stageFile: async (path, data) => {
       await ensureParentDir(adapter, path);
       const buffer = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength);
-      await writeThroughTemp(adapter, path, buffer as ArrayBuffer);
+      const tempPath = hiddenSiblingPath(path, ".geode-tmp");
+      await adapter.writeBinary(tempPath, buffer as ArrayBuffer);
+
+      return {
+        commit: async () => {
+          await installStaged(adapter, tempPath, path);
+        },
+        discard: async () => {
+          const exists = await adapter.exists(tempPath);
+          if (!exists) {
+            return;
+          }
+          await adapter.remove(tempPath);
+        },
+      };
     },
     deleteFile: async (path) => {
       const exists = await adapter.exists(path);
@@ -204,19 +222,14 @@ async function replaceViaAside(
   await adapter.remove(asidePath);
 }
 
-// writeThroughTemp stages data at a hidden temp path beside its destination, then renames it into
-// place, so a crash mid write leaves the destination either untouched or fully written, never
-// holding torn bytes (#88). Desktop's adapter rename replaces an existing destination atomically;
-// a rename that fails while the destination exists is retried through replaceViaAside, shrinking
-// the exposure from the whole download and write to the instant between the two renames, where a
-// crash leaves the path absent and the next sync replans the pull instead of pushing corruption.
-async function writeThroughTemp(
-  adapter: DataAdapter,
-  path: string,
-  data: ArrayBuffer,
-): Promise<void> {
-  const tempPath = hiddenSiblingPath(path, ".geode-tmp");
-  await adapter.writeBinary(tempPath, data);
+// installStaged renames an already staged file onto its destination, the step that actually changes
+// what the vault holds, so a crash mid write leaves the destination either untouched or fully
+// written, never holding torn bytes (#88). Desktop's adapter rename replaces an existing
+// destination atomically; a rename that fails while the destination exists is retried through
+// replaceViaAside, shrinking the exposure from the whole download and write to the instant between
+// the two renames, where a crash leaves the path absent and the next sync replans the pull instead
+// of pushing corruption.
+async function installStaged(adapter: DataAdapter, tempPath: string, path: string): Promise<void> {
   try {
     await adapter.rename(tempPath, path);
   } catch (err) {

--- a/src/vault/obsidian.ts
+++ b/src/vault/obsidian.ts
@@ -70,9 +70,6 @@ export function createObsidianLocalWriter(adapter: DataAdapter): LocalWriter {
 // lives inside .obsidian/plugins/geode/) never shows up as a vault file to snapshot.
 export function createObsidianReader(vault: Vault): Reader {
   return {
-    fileExists: async (path) => {
-      return vault.getFileByPath(path) !== null;
-    },
     listFiles: async () => {
       const files: FileInfo[] = [];
       for (const file of vault.getFiles()) {
@@ -88,12 +85,15 @@ export function createObsidianReader(vault: Vault): Reader {
       const buffer = await vault.readBinary(file);
       return new Uint8Array(buffer);
     },
-    size: async (path) => {
+    // Both fields come from the TFile the vault already holds in memory, so this is an index
+    // lookup rather than a filesystem call: cheap enough to run immediately before a destructive
+    // write, which is the whole reason a pull can confirm a path is untouched without rereading it.
+    stat: async (path) => {
       const file = vault.getFileByPath(path);
       if (file === null) {
-        return 0;
+        return { present: false, size: 0, mtime: 0 };
       }
-      return file.stat.size;
+      return { present: true, size: file.stat.size, mtime: file.stat.mtime };
     },
   };
 }

--- a/src/vault/vault.test.ts
+++ b/src/vault/vault.test.ts
@@ -21,9 +21,6 @@ function fakeReader(files: Record<string, { content: string; mtime: number }>): 
 } {
   let reads = 0;
   const reader: Reader = {
-    fileExists: async (path) => {
-      return files[path] !== undefined;
-    },
     listFiles: async () => {
       const list: FileInfo[] = [];
       for (const [path, file] of Object.entries(files)) {
@@ -39,12 +36,12 @@ function fakeReader(files: Record<string, { content: string; mtime: number }>): 
       }
       return new TextEncoder().encode(file.content);
     },
-    size: async (path) => {
+    stat: async (path) => {
       const file = files[path];
       if (file === undefined) {
-        return 0;
+        return { present: false, size: 0, mtime: 0 };
       }
-      return file.content.length;
+      return { present: true, size: file.content.length, mtime: file.mtime };
     },
   };
   return { reader, readCount: () => reads };
@@ -200,9 +197,6 @@ test("takeSnapshot: concurrency is bounded by the limit", async () => {
   let inflight = 0;
   let peakInflight = 0;
   const reader: Reader = {
-    fileExists: async (path) => {
-      return files[path] !== undefined;
-    },
     listFiles: async () => {
       const list: FileInfo[] = [];
       for (const [path, file] of Object.entries(files)) {
@@ -223,12 +217,12 @@ test("takeSnapshot: concurrency is bounded by the limit", async () => {
       }
       return new TextEncoder().encode(file.content);
     },
-    size: async (path) => {
+    stat: async (path) => {
       const file = files[path];
       if (file === undefined) {
-        return 0;
+        return { present: false, size: 0, mtime: 0 };
       }
-      return file.content.length;
+      return { present: true, size: file.content.length, mtime: file.mtime };
     },
   };
 
@@ -249,9 +243,6 @@ test("takeSnapshot: in-flight bytes are bounded by the byte budget", async () =>
   let inflightBytes = 0;
   let peakBytes = 0;
   const reader: Reader = {
-    fileExists: async (path) => {
-      return files[path] !== undefined;
-    },
     listFiles: async () => {
       const list: FileInfo[] = [];
       for (const [path, file] of Object.entries(files)) {
@@ -273,12 +264,12 @@ test("takeSnapshot: in-flight bytes are bounded by the byte budget", async () =>
 
       return new TextEncoder().encode(file.content);
     },
-    size: async (path) => {
+    stat: async (path) => {
       const file = files[path];
       if (file === undefined) {
-        return 0;
+        return { present: false, size: 0, mtime: 0 };
       }
-      return file.content.length;
+      return { present: true, size: file.content.length, mtime: file.mtime };
     },
   };
 
@@ -308,7 +299,6 @@ test("takeSnapshot: a small read does not jump a queued large read", async () =>
   const sizes: Record<string, number> = { hog: 60, big: 60, small: 10 };
   const started: string[] = [];
   const reader: Reader = {
-    fileExists: async () => true,
     // hog fills most of the budget and is held open; big cannot fit and queues; small then arrives
     // and, with fair admission, must wait behind big rather than slipping into the gap hog left.
     listFiles: async () => [
@@ -324,8 +314,8 @@ test("takeSnapshot: a small read does not jump a queued large read", async () =>
 
       return new Uint8Array(sizes[path]);
     },
-    size: async (path) => {
-      return sizes[path];
+    stat: async (path) => {
+      return { present: true, size: sizes[path], mtime: 1 };
     },
   };
 
@@ -351,9 +341,6 @@ test("takeSnapshot: growth since listing is bounded by the fresh size", async ()
   let inflightBytes = 0;
   let peakBytes = 0;
   const reader: Reader = {
-    fileExists: async (path) => {
-      return files[path] !== undefined;
-    },
     // Every file lists as 10 bytes but has since grown to 400. Reserving on the listed 10 would let
     // several read at once and blow past the budget; reserving on the fresh size read now must not.
     listFiles: async () => {
@@ -377,12 +364,12 @@ test("takeSnapshot: growth since listing is bounded by the fresh size", async ()
 
       return new Uint8Array(file.actual);
     },
-    size: async (path) => {
+    stat: async (path) => {
       const file = files[path];
       if (file === undefined) {
-        return 0;
+        return { present: false, size: 0, mtime: 0 };
       }
-      return file.actual;
+      return { present: true, size: file.actual, mtime: file.mtime };
     },
   };
 

--- a/src/vault/vault.test.ts
+++ b/src/vault/vault.test.ts
@@ -129,22 +129,31 @@ test("encodeSnapshot: the wire format carries the version marker and round-trips
   assert.deepEqual(decodeSnapshot(raw), { ok: true, snapshot });
 });
 
-test("decodeSnapshot: version handling accepts the marker, treats absence as version 1, and refuses the unknown", () => {
+test("decodeSnapshot: only the current version is accepted; version 1, missing, and newer are all refused", () => {
   const files = [{ path: "a.md", size: 1, mtime: 2, hash: "h" }];
   const cases: { name: string; raw: string; want: DecodedSnapshot }[] = [
     {
       name: "the current versioned format",
-      raw: JSON.stringify({ version: 1, files }),
+      raw: JSON.stringify({ version: 2, files }),
       want: { ok: true, snapshot: { files } },
     },
     {
-      name: "a pre-marker snapshot with no version field, version 1 by definition",
+      // Version 1, plaintext path keyed storage, predates the marker (#91) and is version 1 by
+      // definition. Its JSON shape is identical to version 2's (both are `{files: [...]}`), only
+      // the marker distinguishes them, so this build refuses it rather than misread its paths as
+      // content addressed keys.
+      name: "a pre-marker snapshot with no version field",
       raw: JSON.stringify({ files }),
-      want: { ok: true, snapshot: { files } },
+      want: { ok: false, reason: "unsupportedVersion" },
+    },
+    {
+      name: "an explicit version 1, plaintext path keyed storage",
+      raw: JSON.stringify({ version: 1, files }),
+      want: { ok: false, reason: "unsupportedVersion" },
     },
     {
       name: "a version from a newer build",
-      raw: JSON.stringify({ version: 2, files }),
+      raw: JSON.stringify({ version: 3, files }),
       want: { ok: false, reason: "unsupportedVersion" },
     },
     {
@@ -152,7 +161,7 @@ test("decodeSnapshot: version handling accepts the marker, treats absence as ver
       // itself (files as an encrypted blob, say), and it must read as "needs a newer build",
       // never as corrupt.
       name: "a newer version whose shape this build does not understand",
-      raw: JSON.stringify({ version: 2, files: "ciphertext" }),
+      raw: JSON.stringify({ version: 3, files: "ciphertext" }),
       want: { ok: false, reason: "unsupportedVersion" },
     },
     {
@@ -162,8 +171,16 @@ test("decodeSnapshot: version handling accepts the marker, treats absence as ver
     },
     { name: "bytes that aren't JSON", raw: "not json", want: { ok: false, reason: "corrupt" } },
     {
-      name: "JSON of the wrong shape",
-      raw: JSON.stringify({ version: 1 }),
+      name: "JSON of the wrong shape at the current version",
+      raw: JSON.stringify({ version: 2 }),
+      want: { ok: false, reason: "corrupt" },
+    },
+    {
+      // Genuinely malformed data with no version field must still read as corrupt, not as "an old
+      // but well formed version 1 manifest": shape is checked before the missing-version case is
+      // resolved to unsupportedVersion.
+      name: "JSON of the wrong shape with no version field",
+      raw: JSON.stringify({}),
       want: { ok: false, reason: "corrupt" },
     },
   ];

--- a/src/vault/vault.ts
+++ b/src/vault/vault.ts
@@ -3,8 +3,14 @@ import { endpointFor, type GeodeSettings, regionFor } from "../settings/settings
 // SNAPSHOT_VERSION is the format version stamped into every serialized snapshot, remote manifest
 // and local state.json alike, so a future format change (encryption, chunked upload) has
 // something to branch on when it meets an existing bucket (#91). A serialized snapshot with no
-// version field predates the marker and is this same format, version 1.
-export const SNAPSHOT_VERSION = 1;
+// version field predates the marker and is version 1, plaintext path keyed storage. Version 2
+// moved file content off the vault path and onto a content addressed key under the manifest's own
+// bucket (`.geode/blobs/<hash>`, see sync/plan.ts); a version 1 manifest is refused rather than
+// read, since its paths point at objects this build never looks for again, and reading it as
+// version 2 would plan every push and pull against keys that were never written. There is no
+// migration path at this version: a bucket written before this change needs a fresh bucket, not an
+// upgrade.
+export const SNAPSHOT_VERSION = 2;
 
 // SNAPSHOT_BYTE_BUDGET caps how many bytes takeSnapshot buffers across its concurrent reads, low
 // enough that a vault of large attachments cannot pile eight full files into memory at once and
@@ -85,11 +91,13 @@ export function byPath(files: FileState[]): Map<string, FileState> {
 }
 
 // decodeSnapshot parses a serialized snapshot (a remote manifest, a local state.json) and checks
-// its format version. A missing version is accepted as version 1, the format every build before
-// the marker existed wrote; any other unknown version is refused rather than guessed at, so this
-// build never misreads a bucket written in a newer format as garbage or, worse, as valid. The
-// version check runs before the shape check on purpose: a future format is free to change the
-// shape itself, and its snapshots must still read as "needs a newer build", never as corrupt.
+// its format version. An explicit version other than SNAPSHOT_VERSION is refused before the shape
+// is even looked at: a future format is free to change the shape itself (files as an encrypted
+// blob, say), and its snapshots must still read as "needs a different build", never as corrupt.
+// A missing version field means version 1, the format every build before the marker existed
+// wrote, and shares version 2's JSON shape exactly (`{files: [...]}`), so the two can only be
+// told apart by the marker itself; that check runs after the shape check, so a merely malformed
+// payload with no version field still reads as corrupt rather than as a well formed old manifest.
 // The returned snapshot carries only the in-memory shape; the version is a wire concern that
 // encodeSnapshot stamps back on at the next write.
 export function decodeSnapshot(raw: string): DecodedSnapshot {
@@ -108,6 +116,9 @@ export function decodeSnapshot(raw: string): DecodedSnapshot {
   }
   if (!isSnapshot(parsed)) {
     return { ok: false, reason: "corrupt" };
+  }
+  if (version === undefined) {
+    return { ok: false, reason: "unsupportedVersion" };
   }
   const settingsFingerprint = (parsed as { settingsFingerprint?: unknown }).settingsFingerprint;
   const fingerprintStr = typeof settingsFingerprint === "string" ? settingsFingerprint : undefined;

--- a/src/vault/vault.ts
+++ b/src/vault/vault.ts
@@ -38,6 +38,16 @@ export type FileInfo = {
   mtime: number;
 };
 
+// FileStat is everything the vault index knows about one path without reading it: whether anything
+// is there at all, and the size and mtime it carries if so. An absent path is present false with
+// zero values rather than a null to unpack, so callers compare fields instead of branching on
+// absence first.
+export type FileStat = {
+  present: boolean;
+  size: number;
+  mtime: number;
+};
+
 // FileState is what geode remembers about one vault file as of the last snapshot.
 export type FileState = {
   path: string;
@@ -46,17 +56,19 @@ export type FileState = {
   hash: string;
 };
 
-// Reader lists files present in the vault right now, reads their bytes, answers whether a path
-// currently exists (so a failed read on a present file is never mistaken for absence), and reports
-// a single path's current size on demand — fresher than the listing, so a snapshot can reserve
-// memory against what it is about to read rather than a size that may have grown since. A vanished
-// path reports size 0, letting the read that follows raise the real disappearance error. The real
+// Reader lists files present in the vault right now, reads their bytes, and reports what the index
+// already knows about a single path without touching its content. stat answers all three of the
+// questions sync asks between reads: whether the path is there at all (so a failed read on a
+// present file is never mistaken for absence), how big it is right now (fresher than the listing,
+// so a snapshot reserves memory against what it is about to read rather than a size that may have
+// grown since), and when it last changed (so a pull can confirm nothing moved underneath it
+// without rereading the file, see confirmLocalUnchanged in sync/execute.ts). A vanished path
+// reports a zero stat, letting the read that follows raise the real disappearance error. The real
 // implementation wraps Obsidian's Vault API (see obsidian.ts); tests use an in-memory fake.
 export type Reader = {
-  fileExists: (path: string) => Promise<boolean>;
   listFiles: () => Promise<FileInfo[]>;
   readFile: (path: string) => Promise<Uint8Array>;
-  size: (path: string) => Promise<number>;
+  stat: (path: string) => Promise<FileStat>;
 };
 
 // Snapshot is every file geode saw the last time it took a snapshot.
@@ -237,9 +249,10 @@ export async function takeSnapshot(
 
     // Reserve against the size read now, not the one listed at the start of the pass, so a file
     // that has since grown cannot slip past the budget on a stale, smaller number; resize then
-    // corrects for any change in the narrow window between this probe and the read itself.
-    const reserved = await reader.size(file.path);
-    const hold = await budget.acquire(reserved);
+    // corrects for any change in the narrow window between this probe and the read itself. A path
+    // that has vanished reserves nothing and lets the read raise the real error.
+    const live = await reader.stat(file.path);
+    const hold = await budget.acquire(live.size);
     try {
       const bytes = await reader.readFile(file.path);
       hold.resize(bytes.length);


### PR DESCRIPTION
## Problem

- Bucket object keys were the vault path, so a rename read as a delete and a full re-upload rather than a rename
- Identical attachments at different paths stored their bytes twice
- Deleting a file moved its bytes into a path keyed trash copy before removing the live object

## Changes

- Object content now lives at `.geode/blobs/<hash>` keys, with the manifest as the only path to hash mapping
- `push` checks for an existing blob with `headObject` before uploading, so a rename or a duplicate costs one HEAD instead of a re upload
- `pushDelete` no longer touches storage, since dropping a path is now purely a manifest change and blobs are never destroyed
- Removed `copyObject`, the trash prefix, and the per file drift and concurrency checks that existed to protect a shared path key, since a content addressed key can no longer be raced
- Bumped the manifest format version so a bucket written under the old layout is refused rather than misread
- Reworked the missing manifest recovery check to compare surviving blob hashes against the local vault instead of matching paths

## Why

- Renames and duplicate attachments were the visible cost, but object keys were also going to have to be revisited for mobile support and for encryption, so making the change now is cheaper than making it twice
- A content addressed key carries no path information, which removes the need to separately encrypt file paths when encryption lands

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves synchronized content to hash-addressed blob keys.
- Adds blob existence checks and manifest-to-blob mapping.
- Makes pushed deletions manifest-only operations and removes path-keyed trash copies.
- Stages pulled content before drift checks and adds manifest ETag checks before local mutations.
- Bumps the snapshot format and revises missing-manifest recovery.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because previously reported local data-loss races remain reachable after the new drift checks.

Manifest and destination checks remain separate from the destructive operations they authorize, so concurrent remote changes or path recreation can still be applied from stale state; the stat-only local guard can also miss an edit when size and indexed mtime remain unchanged.

**Files Needing Attention:** src/sync/execute.ts, src/sync/sync.ts, src/vault/obsidian.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/sync/execute.ts | Implements blob-addressed execution and stronger drift checks, but previously reported check-then-act races remain. |
| src/sync/sync.ts | Orchestrates blob recovery and manifest CAS publication; the CAS still cannot reverse local mutations performed before it. |
| src/vault/obsidian.ts | Adds staged create/replace commits, but create-mode vacancy checking is not atomic with installation. |
| src/storage/storage.ts | Replaces server-side copy support with a consistent HEAD operation for blob and manifest checks. |
| src/sync/plan.ts | Introduces reserved content-addressed blob keys and removes path-keyed trash naming. |
| src/vault/vault.ts | Bumps the persisted format and expands reader stats to include presence, size, and mtime. |

<sub>Reviews (8): Last reviewed commit: ["Address comment"](https://github.com/8thpark/geode/commit/3a92f33fb5157ba6cc902c957ecd3e5f5c0876ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49239590)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Sync flow](https://app.greptile.com/8thpark/-/custom-context/knowledge-base/8thpark/geode/-/docs/sync-flow.md)
- Knowledge Base — [Storage module](https://app.greptile.com/8thpark/-/custom-context/knowledge-base/8thpark/geode/-/docs/storage-module.md)
- Knowledge Base — [Vault module](https://app.greptile.com/8thpark/-/custom-context/knowledge-base/8thpark/geode/-/docs/vault-module.md)
</details>

<!-- /greptile_comment -->