### PR TITLE
[#132] Sync → Reject unsafe paths from a decoded snapshot

### DIFF
--- a/src/sync/sync.test.ts
+++ b/src/sync/sync.test.ts
@@ -99,6 +99,23 @@ test("readRemoteManifest: a manifest from a format version this build doesn't kn
   });
 });
 
+test("readRemoteManifest: a manifest entry with a traversal path refuses the pass (#132)", async () => {
+  // A remote manifest is untrusted input: anyone who can write to the bucket can shape it. A
+  // crafted path must never reach a local file operation.
+  const raw = JSON.stringify({
+    version: 2,
+    files: [{ path: "../../etc/passwd", size: 1, mtime: 2, hash: "h" }],
+  });
+  const { storage } = fakeStorage({ [MANIFEST_KEY]: raw });
+
+  const result = await readRemoteManifest(storage);
+
+  assert.deepEqual(result, {
+    ok: false,
+    message: "remote manifest contains a path unsafe to write",
+  });
+});
+
 test("readRemoteManifest: a non 404 failure is reported, never guessed at as empty", async () => {
   const { storage } = fakeStorage();
   storage.getObject = async () => ({

--- a/src/sync/sync.ts
+++ b/src/sync/sync.ts
@@ -83,6 +83,9 @@ export async function readRemoteManifest(
           message: "remote manifest is a format this version of geode can't read",
         };
       }
+      if (decoded.reason === "unsafePath") {
+        return { ok: false, message: "remote manifest contains a path unsafe to write" };
+      }
       return { ok: false, message: "remote manifest is corrupt" };
     }
     // Every S3 compatible server returns an ETag on a successful read; without one (a stripping

--- a/src/vault/vault.test.ts
+++ b/src/vault/vault.test.ts
@@ -131,6 +131,7 @@ test("isSafePath: traversal, absolute paths, reserved prefixes, and unsafe segme
     { name: "a trailing slash producing an empty segment", path: "notes/", want: false },
     { name: "a backslash", path: "notes\\a.md", want: false },
     { name: "the reserved .geode prefix", path: ".geode/blobs/abc", want: false },
+    { name: "the exact reserved .geode root, no trailing slash", path: ".geode", want: false },
     { name: "the .obsidian folder itself", path: ".obsidian", want: false },
     { name: "a file under .obsidian", path: ".obsidian/plugins/evil/main.js", want: false },
     { name: "a Windows reserved device name", path: "notes/CON.md", want: false },
@@ -231,6 +232,18 @@ test("decodeSnapshot: only the current version is accepted; version 1, missing, 
       // decodeSnapshot's own loop and must read as corrupt rather than crash there.
       name: "an entry whose path isn't a string",
       raw: JSON.stringify({ version: 2, files: [{ path: 42, size: 1, mtime: 2, hash: "h" }] }),
+      want: { ok: false, reason: "corrupt" },
+    },
+    {
+      // A bare `null` array element reads .path on null, which throws rather than returning
+      // undefined; the entry shape check must catch this before that property read happens.
+      name: "a null entry",
+      raw: JSON.stringify({ version: 2, files: [null] }),
+      want: { ok: false, reason: "corrupt" },
+    },
+    {
+      name: "a non-object entry",
+      raw: JSON.stringify({ version: 2, files: ["not-an-object"] }),
       want: { ok: false, reason: "corrupt" },
     },
   ];

--- a/src/vault/vault.test.ts
+++ b/src/vault/vault.test.ts
@@ -134,6 +134,19 @@ test("isSafePath: traversal, absolute paths, reserved prefixes, and unsafe segme
     { name: "the exact reserved .geode root, no trailing slash", path: ".geode", want: false },
     { name: "the .obsidian folder itself", path: ".obsidian", want: false },
     { name: "a file under .obsidian", path: ".obsidian/plugins/evil/main.js", want: false },
+    {
+      // macOS (APFS) and Windows (NTFS) both default to case insensitive filesystems, so a
+      // differently cased root lands on the same directory on disk as the lowercase one.
+      name: "a differently cased .geode root",
+      path: ".GEODE/blobs/abc",
+      want: false,
+    },
+    {
+      name: "a differently cased .obsidian root",
+      path: ".OBSIDIAN/plugins/evil/main.js",
+      want: false,
+    },
+    { name: "a mixed case .obsidian root with no trailing slash", path: ".Obsidian", want: false },
     { name: "a Windows reserved device name", path: "notes/CON.md", want: false },
     { name: "a Windows reserved device name, lowercase", path: "con", want: false },
     { name: "a Windows reserved device name in a middle segment", path: "com1/a.md", want: false },

--- a/src/vault/vault.test.ts
+++ b/src/vault/vault.test.ts
@@ -6,6 +6,7 @@ import {
   diffSnapshots,
   encodeSnapshot,
   type FileInfo,
+  isSafePath,
   isSnapshot,
   type Reader,
   SNAPSHOT_VERSION,
@@ -117,6 +118,33 @@ test("isSnapshot: only a non-null object with a files array is accepted", () => 
   }
 });
 
+test("isSafePath: traversal, absolute paths, reserved prefixes, and unsafe segments are all rejected", () => {
+  const cases: { name: string; path: string; want: boolean }[] = [
+    { name: "an ordinary nested path", path: "notes/a.md", want: true },
+    { name: "an ordinary top level path", path: "a.md", want: true },
+    { name: "an empty path", path: "", want: false },
+    { name: "an absolute path", path: "/etc/passwd", want: false },
+    { name: "a leading traversal segment", path: "../outside.md", want: false },
+    { name: "a mid path traversal segment", path: "notes/../../outside.md", want: false },
+    { name: "a bare current dir segment", path: "notes/./a.md", want: false },
+    { name: "a double slash producing an empty segment", path: "notes//a.md", want: false },
+    { name: "a trailing slash producing an empty segment", path: "notes/", want: false },
+    { name: "a backslash", path: "notes\\a.md", want: false },
+    { name: "the reserved .geode prefix", path: ".geode/blobs/abc", want: false },
+    { name: "the .obsidian folder itself", path: ".obsidian", want: false },
+    { name: "a file under .obsidian", path: ".obsidian/plugins/evil/main.js", want: false },
+    { name: "a Windows reserved device name", path: "notes/CON.md", want: false },
+    { name: "a Windows reserved device name, lowercase", path: "con", want: false },
+    { name: "a Windows reserved device name in a middle segment", path: "com1/a.md", want: false },
+    { name: "a segment ending in a dot", path: "notes/a.md.", want: false },
+    { name: "a segment ending in a space", path: "notes/a.md ", want: false },
+  ];
+
+  for (const { name, path, want } of cases) {
+    assert.equal(isSafePath(path), want, name);
+  }
+});
+
 test("encodeSnapshot: the wire format carries the version marker and round-trips", () => {
   const snapshot: Snapshot = { files: [{ path: "a.md", size: 1, mtime: 2, hash: "h" }] };
 
@@ -178,6 +206,31 @@ test("decodeSnapshot: only the current version is accepted; version 1, missing, 
       // resolved to unsupportedVersion.
       name: "JSON of the wrong shape with no version field",
       raw: JSON.stringify({}),
+      want: { ok: false, reason: "corrupt" },
+    },
+    {
+      // isSnapshot only confirms files is an array; a crafted manifest can still put a traversal
+      // segment in an otherwise well formed entry (#132).
+      name: "a traversal segment in an entry's path",
+      raw: JSON.stringify({
+        version: 2,
+        files: [{ path: "../../etc/passwd", size: 1, mtime: 2, hash: "h" }],
+      }),
+      want: { ok: false, reason: "unsafePath" },
+    },
+    {
+      name: "one unsafe entry fails the whole snapshot, not just that entry",
+      raw: JSON.stringify({
+        version: 2,
+        files: [...files, { path: "/etc/passwd", size: 1, mtime: 2, hash: "h" }],
+      }),
+      want: { ok: false, reason: "unsafePath" },
+    },
+    {
+      // isSnapshot doesn't validate each entry's shape, so a path that isn't even a string reaches
+      // decodeSnapshot's own loop and must read as corrupt rather than crash there.
+      name: "an entry whose path isn't a string",
+      raw: JSON.stringify({ version: 2, files: [{ path: 42, size: 1, mtime: 2, hash: "h" }] }),
       want: { ok: false, reason: "corrupt" },
     },
   ];

--- a/src/vault/vault.ts
+++ b/src/vault/vault.ts
@@ -18,6 +18,34 @@ export const SNAPSHOT_VERSION = 2;
 // has to be, there is no streaming read on the platform), just never alongside another.
 const SNAPSHOT_BYTE_BUDGET = 64 * 1024 * 1024;
 
+// WINDOWS_RESERVED_NAMES are device names Windows reserves regardless of extension (`con.txt` is
+// still `con`), checked case-insensitively by isSafePath so a manifest entry can never collide
+// with one on a machine that syncs there.
+const WINDOWS_RESERVED_NAMES = new Set([
+  "aux",
+  "com1",
+  "com2",
+  "com3",
+  "com4",
+  "com5",
+  "com6",
+  "com7",
+  "com8",
+  "com9",
+  "con",
+  "lpt1",
+  "lpt2",
+  "lpt3",
+  "lpt4",
+  "lpt5",
+  "lpt6",
+  "lpt7",
+  "lpt8",
+  "lpt9",
+  "nul",
+  "prn",
+]);
+
 // Change describes one path whose state differs between two snapshots.
 export type Change = {
   path: string;
@@ -25,11 +53,11 @@ export type Change = {
 };
 
 // DecodedSnapshot is the result of parsing a serialized snapshot: the snapshot itself, or why it
-// cannot be used — bytes that don't parse into the expected shape, or a format version this
-// build does not know how to read.
+// cannot be used — bytes that don't parse into the expected shape, an entry whose path is unsafe
+// to ever write to disk, or a format version this build does not know how to read.
 export type DecodedSnapshot =
   | { ok: true; snapshot: Snapshot }
-  | { ok: false; reason: "corrupt" | "unsupportedVersion" };
+  | { ok: false; reason: "corrupt" | "unsafePath" | "unsupportedVersion" };
 
 // FileInfo is one file as seen live in the vault, before hashing.
 export type FileInfo = {
@@ -112,6 +140,12 @@ export function byPath(files: FileState[]): Map<string, FileState> {
 // payload with no version field still reads as corrupt rather than as a well formed old manifest.
 // The returned snapshot carries only the in-memory shape; the version is a wire concern that
 // encodeSnapshot stamps back on at the next write.
+//
+// Every entry's path is checked with isSafePath before the snapshot is handed back: both callers
+// are untrusted input (a remote manifest can be shaped by anyone who can write to the bucket, and
+// state.json flows through this same decoder), and a single unsafe path fails the whole snapshot
+// rather than being silently dropped, so nothing downstream ever has to re-check what decode
+// already promised (#132).
 export function decodeSnapshot(raw: string): DecodedSnapshot {
   let parsed: unknown;
   try {
@@ -131,6 +165,17 @@ export function decodeSnapshot(raw: string): DecodedSnapshot {
   }
   if (version === undefined) {
     return { ok: false, reason: "unsupportedVersion" };
+  }
+  for (const file of parsed.files) {
+    // isSnapshot only confirms files is an array, not that every entry is shaped like a
+    // FileState, so an attacker-controlled manifest can still put a non-string here despite what
+    // the narrowed type above claims.
+    if (typeof file.path !== "string") {
+      return { ok: false, reason: "corrupt" };
+    }
+    if (!isSafePath(file.path)) {
+      return { ok: false, reason: "unsafePath" };
+    }
   }
   const settingsFingerprint = (parsed as { settingsFingerprint?: unknown }).settingsFingerprint;
   const fingerprintStr = typeof settingsFingerprint === "string" ? settingsFingerprint : undefined;
@@ -208,6 +253,35 @@ export async function hashBytes(data: Uint8Array): Promise<string> {
     hex += byte.toString(16).padStart(2, "0");
   }
   return hex;
+}
+
+// isSafePath reports whether path is safe to write to disk from untrusted input (a remote
+// manifest, a local state.json): no traversal or empty segment, no absolute path, no backslash,
+// nothing under the reserved .geode/ prefix (mirrors RESERVED_PREFIX in sync/plan.ts by value;
+// vault.ts cannot import it without a layering cycle) or under .obsidian/ (a file written there is
+// loadable plugin code), and no segment a filesystem geode runs on could resolve to something
+// other than a plain file — a Windows reserved device name, or a segment ending in a dot or space,
+// which Windows silently strips on write.
+export function isSafePath(path: string): boolean {
+  if (path === "" || path.startsWith("/") || path.includes("\\")) {
+    return false;
+  }
+  if (path === ".obsidian" || path.startsWith(".obsidian/") || path.startsWith(".geode/")) {
+    return false;
+  }
+  for (const segment of path.split("/")) {
+    if (segment === "" || segment === "." || segment === "..") {
+      return false;
+    }
+    if (segment.endsWith(".") || segment.endsWith(" ")) {
+      return false;
+    }
+    if (isWindowsReservedName(segment)) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 // isSnapshot reports whether a value parsed from untrusted JSON (a remote manifest, a local
@@ -336,6 +410,15 @@ function byteSemaphore(budget: number): { acquire: (bytes: number) => Promise<Ho
       });
     },
   };
+}
+
+// isWindowsReservedName reports whether segment is a Windows reserved device name, matched
+// case-insensitively and ignoring any extension, since Windows treats "con.txt" the same as "con".
+function isWindowsReservedName(segment: string): boolean {
+  const dot = segment.indexOf(".");
+  const base = dot === -1 ? segment : segment.slice(0, dot);
+
+  return WINDOWS_RESERVED_NAMES.has(base.toLowerCase());
 }
 
 // mapWithConcurrency runs fn over each item with at most limit concurrent invocations, preserving

--- a/src/vault/vault.ts
+++ b/src/vault/vault.ts
@@ -260,21 +260,19 @@ export async function hashBytes(data: Uint8Array): Promise<string> {
 // manifest, a local state.json): no traversal or empty segment, no absolute path, no backslash,
 // nothing at or under the reserved .geode root (mirrors RESERVED_PREFIX in sync/plan.ts by value;
 // vault.ts cannot import it without a layering cycle) or at or under .obsidian (a file written
-// there is loadable plugin code) — the exact root is checked separately from its prefix, since a
-// path equal to ".geode" starts with neither ".geode/" nor ".obsidian/" and would otherwise pass
-// through to a local write planned as ordinary vault content — and no segment a filesystem geode
-// runs on could resolve to something other than a plain file: a Windows reserved device name, or a
-// segment ending in a dot or space, which Windows silently strips on write.
+// there is loadable plugin code), and no segment a filesystem geode runs on could resolve to
+// something other than a plain file: a Windows reserved device name, or a segment ending in a dot
+// or space, which Windows silently strips on write. The reserved root is matched on its first path
+// segment alone, lowercased, rather than the whole path: both macOS (APFS) and Windows (NTFS)
+// default to case insensitive filesystems, so ".OBSIDIAN" and ".obsidian" are the same directory on
+// disk even though they compare unequal as strings, and a case sensitive check would let a
+// differently cased manifest entry plan straight into either reserved root.
 export function isSafePath(path: string): boolean {
   if (path === "" || path.startsWith("/") || path.includes("\\")) {
     return false;
   }
-  if (
-    path === ".obsidian" ||
-    path.startsWith(".obsidian/") ||
-    path === ".geode" ||
-    path.startsWith(".geode/")
-  ) {
+  const root = path.split("/", 1)[0].toLowerCase();
+  if (root === ".obsidian" || root === ".geode") {
     return false;
   }
   for (const segment of path.split("/")) {

--- a/src/vault/vault.ts
+++ b/src/vault/vault.ts
@@ -168,9 +168,10 @@ export function decodeSnapshot(raw: string): DecodedSnapshot {
   }
   for (const file of parsed.files) {
     // isSnapshot only confirms files is an array, not that every entry is shaped like a
-    // FileState, so an attacker-controlled manifest can still put a non-string here despite what
-    // the narrowed type above claims.
-    if (typeof file.path !== "string") {
+    // FileState, so an attacker-controlled manifest can still put a non-object entry (reading
+    // .path off null or undefined throws) or a non-string path here despite what the narrowed
+    // type above claims.
+    if (typeof file !== "object" || file === null || typeof file.path !== "string") {
       return { ok: false, reason: "corrupt" };
     }
     if (!isSafePath(file.path)) {
@@ -257,16 +258,23 @@ export async function hashBytes(data: Uint8Array): Promise<string> {
 
 // isSafePath reports whether path is safe to write to disk from untrusted input (a remote
 // manifest, a local state.json): no traversal or empty segment, no absolute path, no backslash,
-// nothing under the reserved .geode/ prefix (mirrors RESERVED_PREFIX in sync/plan.ts by value;
-// vault.ts cannot import it without a layering cycle) or under .obsidian/ (a file written there is
-// loadable plugin code), and no segment a filesystem geode runs on could resolve to something
-// other than a plain file — a Windows reserved device name, or a segment ending in a dot or space,
-// which Windows silently strips on write.
+// nothing at or under the reserved .geode root (mirrors RESERVED_PREFIX in sync/plan.ts by value;
+// vault.ts cannot import it without a layering cycle) or at or under .obsidian (a file written
+// there is loadable plugin code) — the exact root is checked separately from its prefix, since a
+// path equal to ".geode" starts with neither ".geode/" nor ".obsidian/" and would otherwise pass
+// through to a local write planned as ordinary vault content — and no segment a filesystem geode
+// runs on could resolve to something other than a plain file: a Windows reserved device name, or a
+// segment ending in a dot or space, which Windows silently strips on write.
 export function isSafePath(path: string): boolean {
   if (path === "" || path.startsWith("/") || path.includes("\\")) {
     return false;
   }
-  if (path === ".obsidian" || path.startsWith(".obsidian/") || path.startsWith(".geode/")) {
+  if (
+    path === ".obsidian" ||
+    path.startsWith(".obsidian/") ||
+    path === ".geode" ||
+    path.startsWith(".geode/")
+  ) {
     return false;
   }
   for (const segment of path.split("/")) {


### PR DESCRIPTION
Resolves [#132](https://github.com/8thpark/geode/issues/132)

## Problem

A path in the remote manifest reached local file operations with no validation, and `state.json` shares the same decoder so it carried the same exposure; nothing rejected traversal segments, absolute paths, backslashes, the reserved `.geode/` and `.obsidian/` prefixes, or segment names unsafe on other platforms, so a single crafted or corrupted manifest entry could reach `adapter.write` for a path outside the vault

## Why

- The project's threat model includes a bucket the user does not fully trust, and this closes the one place a crafted entry could still reach disk
- Validating once at decode time means every downstream caller, planning, pulling, and state persistence, inherits the guarantee for free rather than each needing its own check
- Refusing the whole pass on an unsafe entry matches the existing posture for other manifest level problems: stop and say why, never guess

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR validates snapshot paths at decode time so unsafe remote-manifest and local-state entries cannot reach downstream file operations.
- Rejects traversal, absolute, malformed, reserved-root, case-insensitive reserved-root, Windows device-name, and platform-unsafe paths.
- Distinguishes unsafe-path failures from corrupt and unsupported snapshot formats.
- Adds focused decoder, validator, and remote-manifest tests, including regressions for all previously reported findings.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/vault/vault.ts | Adds decode-time entry-shape and path validation; the previously reported malformed-entry and reserved-root bypasses are fixed. |
| src/vault/vault.test.ts | Adds comprehensive regression coverage for malformed entries, traversal, reserved roots, case variants, and cross-platform unsafe segments. |
| src/sync/sync.ts | Maps the new unsafe-path decode result to a clear remote-manifest error without changing other failure handling. |
| src/sync/sync.test.ts | Confirms an unsafe remote-manifest path aborts the sync pass with the intended error. |

<sub>Reviews (3): Last reviewed commit: ["Address comments"](https://github.com/8thpark/geode/commit/515e427cb53d82eb7fa6e4c6abb6099a7ddca250) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49452800)</sub>

**Context used:**

- Knowledge Base — [Sync flow](https://app.greptile.com/8thpark/-/custom-context/knowledge-base/8thpark/geode/-/docs/sync-flow.md)
- Knowledge Base — [Vault module](https://app.greptile.com/8thpark/-/custom-context/knowledge-base/8thpark/geode/-/docs/vault-module.md)

<!-- /greptile_comment -->