### PR TITLE
[#136] Vault → Write state.json atomically

### DIFF
--- a/src/vault/obsidian.test.ts
+++ b/src/vault/obsidian.test.ts
@@ -23,6 +23,14 @@ function fakeAdapter(seed: Record<string, string> = {}): DataAdapter {
     write: async (path: string, data: string) => {
       files.set(path, data);
     },
+    rename: async (path: string, newPath: string) => {
+      const data = files.get(path);
+      if (data === undefined) {
+        throw new Error(`no such file: ${path}`);
+      }
+      files.delete(path);
+      files.set(newPath, data);
+    },
   };
   return adapter as unknown as DataAdapter;
 }
@@ -388,6 +396,25 @@ test("createObsidianStore: a well shaped snapshot round-trips through write and 
     settingsFingerprint: fingerprintSettings(DEFAULT_SETTINGS),
   };
   assert.deepEqual(await store.read(), want);
+});
+
+test("createObsidianStore: an interrupted write leaves the previous state.json untouched, never torn (#136)", async () => {
+  // The write must be staged and installed via rename, the same atomic pattern pulled vault
+  // content already uses, so a failure between the two steps never leaves a half written file for
+  // the next sync to misread as a corrupt or empty ancestor.
+  const previous = JSON.stringify({
+    version: 2,
+    files: [{ path: "a.md", size: 1, mtime: 2, hash: "h" }],
+  });
+  const adapter = fakeAdapter({ [STATE_PATH]: previous });
+  adapter.rename = async () => {
+    throw new Error("disk full");
+  };
+  const store = createObsidianStore(adapter, STATE_PATH, DEFAULT_SETTINGS);
+
+  await assert.rejects(() => store.write({ files: [] }));
+
+  assert.equal(await adapter.read(STATE_PATH), previous);
 });
 
 test("createObsidianStore: a fingerprint mismatch reads back as empty", async () => {

--- a/src/vault/obsidian.ts
+++ b/src/vault/obsidian.ts
@@ -104,6 +104,13 @@ export function createObsidianReader(vault: Vault): Reader {
 // to crash sync: an empty ancestor can at worst produce conflict copies, never data loss, and a
 // state.json from a newer format only ever appears alongside a newer format manifest, which
 // readRemoteManifest refuses before the ancestor matters.
+//
+// write stages the new content to a hidden temp file and installs it the same way a pulled file
+// is installed (#136): statePath is the one file every sync's safety reasoning rests on as the
+// common ancestor, so a crash mid write must never leave it torn. A torn read used to fall back to
+// "no snapshot" above, which is safe on its own but still turns every remotely deleted file into a
+// resurrection and every divergence into a conflict copy; atomic writes mean that fallback is
+// never actually exercised by an interrupted write.
 export function createObsidianStore(
   adapter: DataAdapter,
   statePath: string,
@@ -138,7 +145,9 @@ export function createObsidianStore(
         ...snapshot,
         settingsFingerprint: fingerprintSettings(settings),
       };
-      await adapter.write(statePath, encodeSnapshot(withFingerprint));
+      const tempPath = hiddenSiblingPath(statePath, ".geode-tmp");
+      await adapter.write(tempPath, encodeSnapshot(withFingerprint));
+      await installStaged(adapter, tempPath, statePath, "replace");
     },
   };
 }


### PR DESCRIPTION
Resolves [#136](https://github.com/8thpark/geode/issues/136)

## Problem

`state.json` is written straight through the vault adapter, so a crash mid write can leave it torn; that file is the common ancestor every sync diffs against, and a torn read already falls back to an empty snapshot, which turns every remotely deleted file into a resurrection and every real divergence into a conflict copy

## Why

- State corruption here is silent, it only ever surfaces later as confusing sync behaviour, never as an error at write time
- Reusing the existing install path means no new failure handling was invented, the same guarantee just gained a second caller

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes persisted vault snapshots crash-safe by staging encoded state in a hidden sibling file and installing it through the existing replacement path.
- Reuses the vault writer's staged rename behavior for `state.json`.
- Adds adapter rename support to the store test fixture.
- Verifies a failed installation preserves the previous snapshot.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with snapshot writes now preserving the prior state when installation fails.

The changed store path writes the complete encoded snapshot to a sibling temporary file before invoking the existing replacement logic, while production synchronization serializes store writes and the tests verify prior-state preservation on failure.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/vault/obsidian.ts | Replaces direct snapshot writes with deterministic temporary-file staging and the established replacement helper; no actionable defect was found. |
| src/vault/obsidian.test.ts | Extends the fake adapter with rename behavior and verifies that an interrupted snapshot installation leaves the previous state intact. |

<sub>Reviews (1): Last reviewed commit: ["Write state.json atomically"](https://github.com/8thpark/geode/commit/d916aade5d58b232f7e234b439f16cd0d092615a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49454333)</sub>

**Context used:**

- Knowledge Base — [Vault module](https://app.greptile.com/8thpark/-/custom-context/knowledge-base/8thpark/geode/-/docs/vault-module.md)

<!-- /greptile_comment -->