### PR TITLE
[#101] Sync → Prove the whole reserved prefix is excluded from planning

### DIFF
--- a/src/sync/plan.test.ts
+++ b/src/sync/plan.test.ts
@@ -1,7 +1,14 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import { empty, file, snapshot } from "./fake.ts";
-import { blobKeyFor, conflictCopyPath, MANIFEST_KEY, manifestAfterSync, planSync } from "./plan.ts";
+import {
+  blobKeyFor,
+  conflictCopyPath,
+  MANIFEST_KEY,
+  manifestAfterSync,
+  planSync,
+  RESERVED_PREFIX,
+} from "./plan.ts";
 
 test("planSync: a path only changed locally is pushed", () => {
   const previous = empty;
@@ -99,6 +106,17 @@ test("planSync: a blob key under the reserved prefix is never turned into an act
 
 test("blobKeyFor: keys content under the reserved blob prefix by its own hash", () => {
   assert.equal(blobKeyFor("deadbeef"), ".geode/blobs/deadbeef");
+});
+
+test("planSync: any key under the reserved prefix is excluded, not just the manifest and blobs it knows about today (#101)", () => {
+  // isReservedPath matches on the whole prefix, so a bookkeeping object this build has never heard
+  // of (a future lock file, say) is excluded the same way the manifest and blob keys are, rather
+  // than needing its own carve out the day it's introduced.
+  const previous = empty;
+  const local = snapshot(file(`${RESERVED_PREFIX}locks/device-1`, "h1"));
+  const remote = snapshot(file(`${RESERVED_PREFIX}locks/device-1`, "h2"));
+
+  assert.deepEqual(planSync(previous, local, remote), []);
 });
 
 test("manifestAfterSync: a push records the pushed file's entry", () => {

--- a/src/sync/plan.test.ts
+++ b/src/sync/plan.test.ts
@@ -108,10 +108,11 @@ test("blobKeyFor: keys content under the reserved blob prefix by its own hash", 
   assert.equal(blobKeyFor("deadbeef"), ".geode/blobs/deadbeef");
 });
 
-test("planSync: any key under the reserved prefix is excluded, not just the manifest and blobs it knows about today (#101)", () => {
-  // isReservedPath matches on the whole prefix, so a bookkeeping object this build has never heard
-  // of (a future lock file, say) is excluded the same way the manifest and blob keys are, rather
-  // than needing its own carve out the day it's introduced.
+test("planSync: any key under the reserved prefix is excluded (#101)", () => {
+  // isReservedPath matches on the whole prefix, not just the manifest and blob keys this build
+  // happens to know about today, so a bookkeeping object it has never heard of (a future lock
+  // file, say) is excluded the same way, rather than needing its own carve out the day it's
+  // introduced.
   const previous = empty;
   const local = snapshot(file(`${RESERVED_PREFIX}locks/device-1`, "h1"));
   const remote = snapshot(file(`${RESERVED_PREFIX}locks/device-1`, "h2"));


### PR DESCRIPTION
Resolves [#101](https://github.com/8thpark/geode/issues/101)

## Problem

`planSync` already excludes the whole reserved prefix from planning, not only the manifest key, but the only coverage proving that was two tests for the two keys this build happens to know about today, the manifest and a blob; a future bookkeeping key would be correct by construction but had nothing asserting it

## Why

- The exclusion is a prefix match, general by design, and the test suite should say so directly instead of only demonstrating it through the two keys that already exist
- Locks this in ahead of any future bookkeeping object, so introducing one never needs its own carve out or its own test to stay safe

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds explicit test coverage proving that `planSync` excludes arbitrary bookkeeping keys beneath the entire reserved prefix.
- Imports `RESERVED_PREFIX` for constructing a representative future bookkeeping key.
- Verifies that differing local and remote entries under that prefix produce no sync action.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/sync/plan.test.ts | Adds focused reserved-prefix planning coverage and fixes the previously reported overlong test declaration. |

<sub>Reviews (2): Last reviewed commit: ["Address comment"](https://github.com/8thpark/geode/commit/1a32a600ae8f677c2e9bcca625f354726e85717e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49454658)</sub>

**Context used:**

- Knowledge Base — [Sync flow](https://app.greptile.com/8thpark/-/custom-context/knowledge-base/8thpark/geode/-/docs/sync-flow.md)

<!-- /greptile_comment -->