### PR TITLE
[#94] Vault → Refuse a snapshot with two paths differing only by case

### DIFF
--- a/src/sync/sync.test.ts
+++ b/src/sync/sync.test.ts
@@ -116,6 +116,26 @@ test("readRemoteManifest: a manifest entry with a traversal path refuses the pas
   });
 });
 
+test("readRemoteManifest: two paths differing only by case refuse the pass (#94)", async () => {
+  // Bucket keys are case sensitive; macOS, Windows, and Android are not by default. Pulling both
+  // would silently let one overwrite the other with no conflict ever raised.
+  const raw = JSON.stringify({
+    version: 2,
+    files: [
+      { path: "notes/Todo.md", size: 1, mtime: 2, hash: "h1" },
+      { path: "notes/todo.md", size: 1, mtime: 2, hash: "h2" },
+    ],
+  });
+  const { storage } = fakeStorage({ [MANIFEST_KEY]: raw });
+
+  const result = await readRemoteManifest(storage);
+
+  assert.deepEqual(result, {
+    ok: false,
+    message: "remote manifest contains two paths that differ only by case",
+  });
+});
+
 test("readRemoteManifest: a non 404 failure is reported, never guessed at as empty", async () => {
   const { storage } = fakeStorage();
   storage.getObject = async () => ({

--- a/src/sync/sync.ts
+++ b/src/sync/sync.ts
@@ -86,6 +86,12 @@ export async function readRemoteManifest(
       if (decoded.reason === "unsafePath") {
         return { ok: false, message: "remote manifest contains a path unsafe to write" };
       }
+      if (decoded.reason === "caseCollision") {
+        return {
+          ok: false,
+          message: "remote manifest contains two paths that differ only by case",
+        };
+      }
       return { ok: false, message: "remote manifest is corrupt" };
     }
     // Every S3 compatible server returns an ETag on a successful read; without one (a stripping

--- a/src/vault/vault.test.ts
+++ b/src/vault/vault.test.ts
@@ -259,6 +259,30 @@ test("decodeSnapshot: only the current version is accepted; version 1, missing, 
       raw: JSON.stringify({ version: 2, files: ["not-an-object"] }),
       want: { ok: false, reason: "corrupt" },
     },
+    {
+      // Bucket keys are case sensitive but macOS, Windows, and Android default to case
+      // insensitive filesystems, so pulling both would silently let one overwrite the other (#94).
+      name: "two paths differing only by case",
+      raw: JSON.stringify({
+        version: 2,
+        files: [
+          { path: "notes/Todo.md", size: 1, mtime: 2, hash: "h1" },
+          { path: "notes/todo.md", size: 1, mtime: 2, hash: "h2" },
+        ],
+      }),
+      want: { ok: false, reason: "caseCollision" },
+    },
+    {
+      name: "paths that share a case fold but are otherwise identical are still a collision",
+      raw: JSON.stringify({
+        version: 2,
+        files: [
+          { path: "A.md", size: 1, mtime: 2, hash: "h1" },
+          { path: "a.md", size: 1, mtime: 2, hash: "h2" },
+        ],
+      }),
+      want: { ok: false, reason: "caseCollision" },
+    },
   ];
 
   for (const { name, raw, want } of cases) {

--- a/src/vault/vault.ts
+++ b/src/vault/vault.ts
@@ -53,11 +53,12 @@ export type Change = {
 };
 
 // DecodedSnapshot is the result of parsing a serialized snapshot: the snapshot itself, or why it
-// cannot be used — bytes that don't parse into the expected shape, an entry whose path is unsafe
-// to ever write to disk, or a format version this build does not know how to read.
+// cannot be used — bytes that don't parse into the expected shape, two entries whose paths differ
+// only by case, an entry whose path is unsafe to ever write to disk, or a format version this
+// build does not know how to read.
 export type DecodedSnapshot =
   | { ok: true; snapshot: Snapshot }
-  | { ok: false; reason: "corrupt" | "unsafePath" | "unsupportedVersion" };
+  | { ok: false; reason: "caseCollision" | "corrupt" | "unsafePath" | "unsupportedVersion" };
 
 // FileInfo is one file as seen live in the vault, before hashing.
 export type FileInfo = {
@@ -146,6 +147,13 @@ export function byPath(files: FileState[]): Map<string, FileState> {
 // state.json flows through this same decoder), and a single unsafe path fails the whole snapshot
 // rather than being silently dropped, so nothing downstream ever has to re-check what decode
 // already promised (#132).
+//
+// Two entries whose paths differ only by case are refused the same way (#94): bucket keys are
+// case sensitive, but macOS, Windows, and Android filesystems are case insensitive by default, so
+// pulling both onto a device with any of those would silently let the second write replace the
+// first with no conflict ever raised. This is checked for every snapshot regardless of which
+// filesystem decodes it, since a manifest a case sensitive device wrote is still headed for
+// whichever device syncs it next, and geode has no way to know in advance which that will be.
 export function decodeSnapshot(raw: string): DecodedSnapshot {
   let parsed: unknown;
   try {
@@ -166,6 +174,7 @@ export function decodeSnapshot(raw: string): DecodedSnapshot {
   if (version === undefined) {
     return { ok: false, reason: "unsupportedVersion" };
   }
+  const foldedPaths = new Set<string>();
   for (const file of parsed.files) {
     // isSnapshot only confirms files is an array, not that every entry is shaped like a
     // FileState, so an attacker-controlled manifest can still put a non-object entry (reading
@@ -177,6 +186,11 @@ export function decodeSnapshot(raw: string): DecodedSnapshot {
     if (!isSafePath(file.path)) {
       return { ok: false, reason: "unsafePath" };
     }
+    const folded = file.path.toLowerCase();
+    if (foldedPaths.has(folded)) {
+      return { ok: false, reason: "caseCollision" };
+    }
+    foldedPaths.add(folded);
   }
   const settingsFingerprint = (parsed as { settingsFingerprint?: unknown }).settingsFingerprint;
   const fingerprintStr = typeof settingsFingerprint === "string" ? settingsFingerprint : undefined;


### PR DESCRIPTION
Resolves [#94](https://github.com/8thpark/geode/issues/94)

## Problem

Bucket keys are case sensitive, but macOS, Windows, and Android filesystems are case insensitive by default; a manifest containing two paths that differ only by case pulls both onto the same local path on any of those, and the second write silently replaces the first with no conflict ever raised

## Why

- The refusal has to hold regardless of which filesystem decodes the manifest, since the bucket is shared and there is no way to know in advance which device syncs it next
- This is the same choke point and the same posture `unsafePath` already established, so a new class of unsafe manifest gets caught without adding a new validation path
- Silently letting one file overwrite the other is exactly the kind of lost edit the project's sync guarantees exist to prevent

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR rejects snapshots containing paths that differ only by case, preventing case-sensitive bucket keys from overwriting one another when pulled onto case-insensitive filesystems.
- Adds case-collision detection to the shared snapshot decoder.
- Propagates a specific remote-manifest error through the sync boundary.
- Adds decoder and sync-level regression coverage for colliding paths.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the new validation consistently enforced at the shared snapshot-decoding boundary.

The decoder rejects case-colliding entries before planning or local writes, and every production decoder consumer safely handles the new failure reason.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/vault/vault.ts | Adds centralized lowercase-path collision detection and extends the typed decoder failure reasons. |
| src/vault/vault.test.ts | Covers case collisions in nested and root-level snapshot paths. |
| src/sync/sync.ts | Converts the new decoder failure into a specific remote-manifest refusal message. |
| src/sync/sync.test.ts | Verifies that reading a colliding remote manifest refuses the sync pass. |

<sub>Reviews (1): Last reviewed commit: ["Refuse a snapshot with two paths differi..."](https://github.com/8thpark/geode/commit/b59a33ec10a0eb68f14d193362b38517b40372ec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49455584)</sub>

**Context used:**

- Knowledge Base — [Sync flow](https://app.greptile.com/8thpark/-/custom-context/knowledge-base/8thpark/geode/-/docs/sync-flow.md)
- Knowledge Base — [Vault module](https://app.greptile.com/8thpark/-/custom-context/knowledge-base/8thpark/geode/-/docs/vault-module.md)

<!-- /greptile_comment -->