### PR TITLE
[#67] Logs → Preserve text selection during refresh

### DIFF
--- a/src/log/selection.test.ts
+++ b/src/log/selection.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { selectionOverlaps } from "./selection.ts";
+
+const container = {} as Node;
+
+function fakeSelection(collapsed: boolean, rangeCount: number, intersects: boolean): Selection {
+  const range = {
+    intersectsNode: (node: Node) => intersects && node === container,
+  } as Range;
+
+  return {
+    isCollapsed: collapsed,
+    rangeCount,
+    getRangeAt: () => range,
+  } as unknown as Selection;
+}
+
+test("selectionOverlaps: null selection does not defer rendering", () => {
+  assert.equal(selectionOverlaps(container, null), false);
+});
+
+test("selectionOverlaps: collapsed caret does not defer rendering", () => {
+  const selection = fakeSelection(true, 1, true);
+
+  assert.equal(selectionOverlaps(container, selection), false);
+});
+
+test("selectionOverlaps: selection without a range does not defer rendering", () => {
+  const selection = fakeSelection(false, 0, true);
+
+  assert.equal(selectionOverlaps(container, selection), false);
+});
+
+test("selectionOverlaps: selection outside the log does not defer rendering", () => {
+  const selection = fakeSelection(false, 1, false);
+
+  assert.equal(selectionOverlaps(container, selection), false);
+});
+
+test("selectionOverlaps: selection intersecting the log defers rendering", () => {
+  const selection = fakeSelection(false, 1, true);
+
+  assert.equal(selectionOverlaps(container, selection), true);
+});

--- a/src/log/selection.test.ts
+++ b/src/log/selection.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { selectionOverlaps } from "./selection.ts";
+import { nextRender, selectionOverlaps } from "./selection.ts";
 
 const container = {} as Node;
 
@@ -42,4 +42,18 @@ test("selectionOverlaps: selection intersecting the log defers rendering", () =>
   const selection = fakeSelection(false, 1, true);
 
   assert.equal(selectionOverlaps(container, selection), true);
+});
+
+test("nextRender: a deferred draw requests one refresh when selection clears", () => {
+  const deferred = nextRender(false, "render", true);
+  assert.deepEqual(deferred, { action: "wait", deferred: true });
+
+  const stillSelected = nextRender(deferred.deferred, "selectionchange", true);
+  assert.deepEqual(stillSelected, { action: "wait", deferred: true });
+
+  const cleared = nextRender(stillSelected.deferred, "selectionchange", false);
+  assert.deepEqual(cleared, { action: "refresh", deferred: false });
+
+  const alreadyCaughtUp = nextRender(cleared.deferred, "selectionchange", false);
+  assert.deepEqual(alreadyCaughtUp, { action: "wait", deferred: false });
 });

--- a/src/log/selection.ts
+++ b/src/log/selection.ts
@@ -1,3 +1,35 @@
+// RenderAction describes what the log view should do after a selection-state transition.
+export type RenderAction = "draw" | "refresh" | "wait";
+
+// RenderDecision carries the next deferred state and the action the log view should take.
+export type RenderDecision = {
+  action: RenderAction;
+  deferred: boolean;
+};
+
+// RenderEvent identifies whether a transition came from a requested render or selection change.
+export type RenderEvent = "render" | "selectionchange";
+
+// nextRender returns the action and deferred state for a log-view selection transition.
+export function nextRender(
+  deferred: boolean,
+  event: RenderEvent,
+  selected: boolean,
+): RenderDecision {
+  if (event === "render") {
+    if (selected) {
+      return { action: "wait", deferred: true };
+    }
+
+    return { action: "draw", deferred: false };
+  }
+  if (!deferred || selected) {
+    return { action: "wait", deferred };
+  }
+
+  return { action: "refresh", deferred: false };
+}
+
 // selectionOverlaps reports whether a non-collapsed browser selection intersects node.
 export function selectionOverlaps(node: Node, selection: Selection | null): boolean {
   if (selection === null || selection.isCollapsed || selection.rangeCount === 0) {

--- a/src/log/selection.ts
+++ b/src/log/selection.ts
@@ -1,0 +1,8 @@
+// selectionOverlaps reports whether a non-collapsed browser selection intersects node.
+export function selectionOverlaps(node: Node, selection: Selection | null): boolean {
+  if (selection === null || selection.isCollapsed || selection.rangeCount === 0) {
+    return false;
+  }
+
+  return selection.getRangeAt(0).intersectsNode(node);
+}

--- a/src/log/view.ts
+++ b/src/log/view.ts
@@ -1,5 +1,6 @@
 import { ItemView, type WorkspaceLeaf } from "obsidian";
 import type { LogBus, LogEntry, LogSink } from "./log.ts";
+import { selectionOverlaps } from "./selection.ts";
 
 // LOG_VIEW_TYPE identifies geode's log pane to Obsidian's workspace leaf API.
 export const LOG_VIEW_TYPE = "geode-log-view";
@@ -30,9 +31,9 @@ function renderRow(list: HTMLElement, entry: LogEntry): void {
 
 // GeodeLogView renders geode's persisted log as a plain, most recent first list, updating live as
 // entries are logged. The pane is always a straight render of what the sink holds: every change
-// re-reads and redraws rather than mutating the DOM in place, so the pane can never drift from the
-// persisted log. Read only: it has no way to write log entries, only display what the sink
-// recorded.
+// re-reads and redraws rather than mutating the DOM in place. A redraw waits while the user has
+// selected log text, then catches up from the sink as soon as that selection clears. Read only: it
+// has no way to write log entries, only display what the sink recorded.
 export class GeodeLogView extends ItemView {
   private sink: LogSink;
   private bus: LogBus;
@@ -40,6 +41,7 @@ export class GeodeLogView extends ItemView {
   // refreshQueued records that another pass is owed because an entry arrived while one was running.
   private refreshInFlight: Promise<void> | null = null;
   private refreshQueued = false;
+  private renderDeferred = false;
 
   constructor(leaf: WorkspaceLeaf, sink: LogSink, bus: LogBus) {
     super(leaf);
@@ -65,6 +67,16 @@ export class GeodeLogView extends ItemView {
     // then still triggers a refresh, rather than being missed until the pane is reopened. register
     // runs the unsubscribe on pane close, so a closed view stops receiving entries.
     this.register(this.bus.subscribe(() => void this.refresh()));
+    this.registerDomEvent(document, "selectionchange", () => {
+      if (!this.renderDeferred) {
+        return;
+      }
+      if (selectionOverlaps(this.contentEl, document.getSelection())) {
+        return;
+      }
+      this.renderDeferred = false;
+      void this.refresh();
+    });
     await this.refresh();
   }
 
@@ -108,6 +120,11 @@ export class GeodeLogView extends ItemView {
   // render does the actual read and draw, split out so runRefresh can own the coalescing loop.
   private async render(): Promise<void> {
     const entries = await this.sink.read();
+    if (selectionOverlaps(this.contentEl, document.getSelection())) {
+      this.renderDeferred = true;
+      return;
+    }
+    this.renderDeferred = false;
     renderLogView(this.contentEl, entries);
   }
 }

--- a/src/log/view.ts
+++ b/src/log/view.ts
@@ -1,6 +1,6 @@
 import { ItemView, type WorkspaceLeaf } from "obsidian";
 import type { LogBus, LogEntry, LogSink } from "./log.ts";
-import { selectionOverlaps } from "./selection.ts";
+import { nextRender, selectionOverlaps } from "./selection.ts";
 
 // LOG_VIEW_TYPE identifies geode's log pane to Obsidian's workspace leaf API.
 export const LOG_VIEW_TYPE = "geode-log-view";
@@ -71,10 +71,12 @@ export class GeodeLogView extends ItemView {
       if (!this.renderDeferred) {
         return;
       }
-      if (selectionOverlaps(this.contentEl, document.getSelection())) {
+      const selected = selectionOverlaps(this.contentEl, document.getSelection());
+      const decision = nextRender(this.renderDeferred, "selectionchange", selected);
+      this.renderDeferred = decision.deferred;
+      if (decision.action !== "refresh") {
         return;
       }
-      this.renderDeferred = false;
       void this.refresh();
     });
     await this.refresh();
@@ -120,11 +122,12 @@ export class GeodeLogView extends ItemView {
   // render does the actual read and draw, split out so runRefresh can own the coalescing loop.
   private async render(): Promise<void> {
     const entries = await this.sink.read();
-    if (selectionOverlaps(this.contentEl, document.getSelection())) {
-      this.renderDeferred = true;
+    const selected = selectionOverlaps(this.contentEl, document.getSelection());
+    const decision = nextRender(this.renderDeferred, "render", selected);
+    this.renderDeferred = decision.deferred;
+    if (decision.action !== "draw") {
       return;
     }
-    this.renderDeferred = false;
     renderLogView(this.contentEl, entries);
   }
 }


### PR DESCRIPTION
Resolves [#67](https://github.com/8thpark/geode/issues/67)

## Problem

The log pane rebuilds its DOM when new entries arrive. If a user is selecting a log line to copy into a support request, that redraw destroys the selection before it can be copied. The polling described in the original issue has since been replaced by live log events, but an event arriving during selection still causes the same failure.

## Changes

- Detect a non-collapsed browser selection that intersects the log pane
- Defer redraws while that selection remains active
- Refresh from the persisted sink as soon as the selection clears, so deferred entries are not lost
- Add focused tests for collapsed, empty, outside, and intersecting selections

## Validation

- `npm run lint`
- `npm run build`
- `npm test` (279 tests)
- `npm run check-versions`
- `npm run audit`

`npm run test:integration` was not run locally because this is an isolated log-view change with no storage or sync behavior; the repository CI will still run that Docker-backed suite.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR preserves log text selection by deferring log-pane redraws while an intersecting browser selection is active and refreshing from the persisted sink when it clears.
- Adds selection-overlap and render-transition helpers.
- Integrates deferred rendering with the log view's existing refresh coalescing.
- Adds focused unit tests for selection states and transition decisions.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains.

The reply stating “Addressed in 58dfd77” does not fully resolve the previously reported coverage gap: the new test drives `nextRender` directly, while the actual `GeodeLogView` listener, deferred state, and catch-up refresh remain unexercised.

**Files Needing Attention:** src/log/selection.test.ts, src/log/view.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/log/selection.ts | Adds pure helpers for detecting selection overlap and deciding deferred render transitions. |
| src/log/view.ts | Integrates selection-aware deferral and catch-up refreshes with the existing log-view refresh loop. |
| src/log/selection.test.ts | Covers selection-overlap cases and the deferred render-state transition sequence. |

<sub>Reviews (2): Last reviewed commit: ["Logs: cover deferred refresh lifecycle"](https://github.com/8thpark/geode/commit/58dfd778c674f32e189eb718b56fc99152de062d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49512309)</sub>

**Context used:**

- Knowledge Base — [Log module](https://app.greptile.com/8thpark/-/custom-context/knowledge-base/8thpark/geode/-/docs/log-module.md)

<!-- /greptile_comment -->