### PR TITLE
[#183] Sync → Distinguish an unused bucket from a wiped one

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,12 +94,16 @@ With `npm run dev` running:
 
    Object keys are content addressed (`.geode/blobs/<sha256>`), not vault paths, so this listing
    won't show your note names; `.geode/manifest.json` is what maps a path to the blob holding its
-   content.
+   content, and `.geode/sentinel.json` is a small marker written once on a bucket's first sync,
+   proving it has been synced before independent of whether the manifest itself currently exists
+   (see `resolveVaultIdentity` in `src/sync/plan.ts`).
 
 Obsidian's plugin data file (`data.json`), geode's own vault state file (`state.json`), and its
 log file (`geode.log`), all of which land at the repo root because the dev vault symlinks the
-whole repo in as the plugin folder, are gitignored and should never be committed. The MinIO
-container's data lives in a Docker volume, not a repo folder — `npm run dev:s3:reset` clears it.
+whole repo in as the plugin folder, are gitignored and should never be committed. `state.json`
+also carries a `vaultId`, the identity of the bucket this device last trusted, so it can tell a
+bucket it has genuinely never seen from one that now looks wrong. The MinIO container's data
+lives in a Docker volume, not a repo folder — `npm run dev:s3:reset` clears it.
 
 ## Windows
 

--- a/src/sync/plan.test.ts
+++ b/src/sync/plan.test.ts
@@ -4,10 +4,15 @@ import { empty, file, snapshot } from "./fake.ts";
 import {
   blobKeyFor,
   conflictCopyPath,
+  type DecodedSentinel,
+  decodeSentinel,
+  encodeSentinel,
   MANIFEST_KEY,
   manifestAfterSync,
   planSync,
   RESERVED_PREFIX,
+  resolveVaultIdentity,
+  type Sentinel,
 } from "./plan.ts";
 
 test("planSync: a path only changed locally is pushed", () => {
@@ -264,4 +269,97 @@ test("conflictCopyPath: a dotfile at the vault root isn't mistaken for an extens
     conflictCopyPath(".editorconfig", Date.parse("2026-07-14T10:00:00.000Z")),
     ".editorconfig (conflicted copy 2026-07-14T10-00-00-000Z)",
   );
+});
+
+test("encodeSentinel: the wire format carries the version marker and round-trips", () => {
+  const sentinel: Sentinel = { vaultId: "abc-123", createdAt: 1000 };
+
+  const raw = encodeSentinel(sentinel);
+
+  assert.equal((JSON.parse(raw) as { version: number }).version, 2);
+  assert.deepEqual(decodeSentinel(raw), { ok: true, sentinel });
+});
+
+test("decodeSentinel: version, shape, and field type are all validated", () => {
+  const cases: { name: string; raw: string; want: DecodedSentinel }[] = [
+    {
+      name: "a well formed sentinel",
+      raw: JSON.stringify({ version: 2, vaultId: "abc-123", createdAt: 1000 }),
+      want: { ok: true, sentinel: { vaultId: "abc-123", createdAt: 1000 } },
+    },
+    { name: "bytes that aren't JSON", raw: "not json", want: { ok: false, reason: "corrupt" } },
+    {
+      name: "no version field",
+      raw: JSON.stringify({ vaultId: "abc-123", createdAt: 1000 }),
+      want: { ok: false, reason: "unsupportedVersion" },
+    },
+    {
+      name: "a version from a newer build",
+      raw: JSON.stringify({ version: 3, vaultId: "abc-123", createdAt: 1000 }),
+      want: { ok: false, reason: "unsupportedVersion" },
+    },
+    {
+      name: "an empty vaultId",
+      raw: JSON.stringify({ version: 2, vaultId: "", createdAt: 1000 }),
+      want: { ok: false, reason: "corrupt" },
+    },
+    {
+      name: "a vaultId that isn't a string",
+      raw: JSON.stringify({ version: 2, vaultId: 42, createdAt: 1000 }),
+      want: { ok: false, reason: "corrupt" },
+    },
+    {
+      name: "a createdAt that isn't a number",
+      raw: JSON.stringify({ version: 2, vaultId: "abc-123", createdAt: "yesterday" }),
+      want: { ok: false, reason: "corrupt" },
+    },
+  ];
+
+  for (const { name, raw, want } of cases) {
+    assert.deepEqual(decodeSentinel(raw), want, name);
+  }
+});
+
+test("resolveVaultIdentity: a genuinely new bucket mints a fresh vaultId", () => {
+  const result = resolveVaultIdentity(true, null, undefined, () => "minted-id");
+
+  assert.deepEqual(result, { ok: true, vaultId: "minted-id" });
+});
+
+test("resolveVaultIdentity: a wiped looking bucket refuses a device with history (#183)", () => {
+  const result = resolveVaultIdentity(true, null, "known-id", () => "minted-id");
+
+  assert.equal(result.ok, false);
+});
+
+test("resolveVaultIdentity: a manifest without a sentinel self heals (#183)", () => {
+  const mintedForAnUpgrader = resolveVaultIdentity(false, null, undefined, () => "minted-id");
+  const adoptedForARetry = resolveVaultIdentity(false, null, "known-id", () => "minted-id");
+
+  assert.deepEqual(mintedForAnUpgrader, { ok: true, vaultId: "minted-id" });
+  assert.deepEqual(adoptedForARetry, { ok: true, vaultId: "known-id" });
+});
+
+test("resolveVaultIdentity: once a sentinel exists, a vaultId mismatch refuses (#109)", () => {
+  // A sentinel without a manifest is the #109 scenario (its manifest deleted, blobs surviving), and
+  // refusing it whenever the manifest is briefly missing, even for a device with no history to
+  // protect or one whose history genuinely agrees, would silently reinstate the exact permanent
+  // deadlock #109 fixed. So whether firstSync is true or false must never change the answer here,
+  // only whether localVaultId, if this device has one, actually disagrees with the sentinel's.
+  const sentinel: Sentinel = { vaultId: "known-id", createdAt: 1000 };
+
+  for (const firstSync of [true, false]) {
+    const freshDevice = resolveVaultIdentity(firstSync, sentinel, undefined, () => "minted-id");
+    const agreeingHistory = resolveVaultIdentity(
+      firstSync,
+      sentinel,
+      "known-id",
+      () => "minted-id",
+    );
+    const disagreeingHistory = resolveVaultIdentity(firstSync, sentinel, "other-id", () => "id");
+
+    assert.deepEqual(freshDevice, { ok: true, vaultId: "known-id" }, `firstSync=${firstSync}`);
+    assert.deepEqual(agreeingHistory, { ok: true, vaultId: "known-id" }, `firstSync=${firstSync}`);
+    assert.equal(disagreeingHistory.ok, false, `firstSync=${firstSync}`);
+  }
 });

--- a/src/sync/plan.ts
+++ b/src/sync/plan.ts
@@ -3,6 +3,7 @@ import {
   type Change,
   diffSnapshots,
   type FileState,
+  SNAPSHOT_VERSION,
   type Snapshot,
 } from "../vault/vault.ts";
 
@@ -26,6 +27,26 @@ export const MANIFEST_KEY = ".geode/manifest.json";
 // diff, on either side, even if a vault happens to hold a file at a colliding path.
 export const RESERVED_PREFIX = ".geode/";
 
+// SENTINEL_KEY is a small marker written once, on the pass that completes a bucket's very first
+// sync, and never rewritten after. Its only job is proving a bucket has been synced before,
+// independent of whether MANIFEST_KEY currently exists, so a manifest missing for a bad reason (a
+// lifecycle rule, a manual deletion, a typo in a configured prefix) can be told apart from a bucket
+// nobody has ever pointed geode at (#183). See resolveVaultIdentity.
+export const SENTINEL_KEY = ".geode/sentinel.json";
+
+// DecodedSentinel is the result of parsing a serialized sentinel: the sentinel itself, or why it
+// cannot be used.
+export type DecodedSentinel =
+  | { ok: true; sentinel: Sentinel }
+  | { ok: false; reason: "corrupt" | "unsupportedVersion" };
+
+// Sentinel is the durable marker written once at SENTINEL_KEY (#183). vaultId is a random
+// identifier minted the moment a bucket's first sync completes; createdAt is purely informational.
+export type Sentinel = {
+  vaultId: string;
+  createdAt: number;
+};
+
 // SyncAction is one thing a sync needs to do to bring local and remote back in step. A conflict
 // carries deletedSide so executeSyncPlan never has to guess, from a failed read, whether a deleted
 // side is why there's nothing there: "local" means there's no local content to preserve, "remote"
@@ -36,6 +57,10 @@ export type SyncAction =
   | { kind: "pull"; path: string }
   | { kind: "pullDelete"; path: string }
   | { kind: "conflict"; path: string; deletedSide: "local" | "remote" | "none" };
+
+// VaultIdentityCheck is the result of resolveVaultIdentity: either the vaultId to trust and, if
+// newly minted or newly adopted, persist locally, or why the pass must refuse rather than guess.
+export type VaultIdentityCheck = { ok: true; vaultId: string } | { ok: false; message: string };
 
 // blobKeyFor returns the reserved key content with the given hash lives at, the same key
 // regardless of which path, or how many paths, currently point at it.
@@ -54,6 +79,45 @@ export function conflictCopyPath(path: string, now: number): string {
     return `${path} (conflicted copy ${stamp})`;
   }
   return `${path.slice(0, lastDot)} (conflicted copy ${stamp})${path.slice(lastDot)}`;
+}
+
+// decodeSentinel parses a serialized sentinel and checks its format version, the same posture
+// decodeSnapshot takes for the manifest: an unrecognized version means "needs a different build",
+// never corrupt.
+export function decodeSentinel(raw: string): DecodedSentinel {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { ok: false, reason: "corrupt" };
+  }
+  if (typeof parsed !== "object" || parsed === null) {
+    return { ok: false, reason: "corrupt" };
+  }
+  const obj = parsed as { version?: unknown; vaultId?: unknown; createdAt?: unknown };
+  if (obj.version !== SNAPSHOT_VERSION) {
+    return { ok: false, reason: "unsupportedVersion" };
+  }
+  if (typeof obj.vaultId !== "string" || obj.vaultId === "") {
+    return { ok: false, reason: "corrupt" };
+  }
+  if (typeof obj.createdAt !== "number") {
+    return { ok: false, reason: "corrupt" };
+  }
+
+  return { ok: true, sentinel: { vaultId: obj.vaultId, createdAt: obj.createdAt } };
+}
+
+// encodeSentinel serializes a sentinel for persistence, stamping the same format version marker
+// every other geode bucket object carries.
+export function encodeSentinel(sentinel: Sentinel): string {
+  const result: { version: number; vaultId: string; createdAt: number } = {
+    version: SNAPSHOT_VERSION,
+    vaultId: sentinel.vaultId,
+    createdAt: sentinel.createdAt,
+  };
+
+  return JSON.stringify(result);
 }
 
 // manifestAfterSync returns the snapshot of what the bucket holds once the pass has run: remote
@@ -150,6 +214,63 @@ export function planSync(previous: Snapshot, local: Snapshot, remote: Snapshot):
   }
 
   return actions;
+}
+
+// resolveVaultIdentity decides whether this pass may proceed and, if so, which vaultId to trust
+// going forward, by comparing what the bucket says (firstSync, sentinel) against what this device
+// already believed (localVaultId).
+//
+// Once a sentinel exists, whether the manifest itself happens to be present or not never changes
+// the answer: what matters is only whether localVaultId, if this device has one, agrees with the
+// sentinel's. A sentinel without a manifest is the #109 scenario (a manifest deleted, lifecycle
+// rule or manual cleanup, while its blobs survive), which syncOnce's own unexplainedBlobs reporting
+// already exists to handle; refusing purely because the manifest is briefly missing, even when the
+// vaultId agrees or this device has no history to protect, would silently reinstate the exact
+// permanent deadlock #109 fixed. A genuine mismatch is refused regardless: this device previously
+// synced a different vault and is now pointed somewhere else, whether or not that other vault's
+// manifest happens to currently exist.
+//
+// Only when the sentinel is absent too does firstSync start to matter, because there is then
+// nothing to compare localVaultId against:
+//
+//   - Both missing, and this device has synced somewhere before: refused. Nothing here proves
+//     the bucket was ever this device's vault rather than an empty or wrong one (a typo in a
+//     configured prefix, wrong bucket, wrong credentials, or a full wipe).
+//   - Both missing, and this device has no history: a genuine first sync, minting a fresh vaultId.
+//   - The manifest exists but the sentinel does not: benign regardless of history, either an
+//     upgrade from before sentinels existed or a crash between the manifest and sentinel writes of
+//     an otherwise successful first sync. This self heals: adopt the local vaultId if there is one,
+//     mint a fresh one if not, and let the caller write the missing sentinel now.
+export function resolveVaultIdentity(
+  firstSync: boolean,
+  sentinel: Sentinel | null,
+  localVaultId: string | undefined,
+  newVaultId: () => string,
+): VaultIdentityCheck {
+  if (sentinel !== null) {
+    if (localVaultId !== undefined && localVaultId !== sentinel.vaultId) {
+      return {
+        ok: false,
+        message: "this bucket belongs to a different vault than the one last synced here",
+      };
+    }
+    return { ok: true, vaultId: sentinel.vaultId };
+  }
+
+  if (!firstSync) {
+    if (localVaultId !== undefined) {
+      return { ok: true, vaultId: localVaultId };
+    }
+    return { ok: true, vaultId: newVaultId() };
+  }
+  if (localVaultId !== undefined) {
+    return {
+      ok: false,
+      message: "the bucket looks empty but this device has synced here before",
+    };
+  }
+
+  return { ok: true, vaultId: newVaultId() };
 }
 
 // changesByPath builds a lookup from path to change, for matching a local change against a

--- a/src/sync/sync.test.ts
+++ b/src/sync/sync.test.ts
@@ -3,10 +3,17 @@ import { test } from "node:test";
 import { encodeSnapshot, hashBytes, type Snapshot } from "../vault/vault.ts";
 import type { LocalWriter } from "./execute.ts";
 import { empty, fakeLocalWriter, fakeReader, fakeStorage, file, snapshot } from "./fake.ts";
-import { blobKeyFor, conflictCopyPath, MANIFEST_KEY } from "./plan.ts";
+import {
+  blobKeyFor,
+  conflictCopyPath,
+  encodeSentinel,
+  MANIFEST_KEY,
+  SENTINEL_KEY,
+} from "./plan.ts";
 import {
   adoptLiveStats,
   readRemoteManifest,
+  readSentinel,
   revertFailedPaths,
   syncOnce,
   unexplainedBlobs,
@@ -151,6 +158,43 @@ test("readRemoteManifest: a non 404 failure is reported, never guessed at as emp
   assert.deepEqual(result, { ok: false, message: "Storage rejected the read (500)" });
 });
 
+test("readSentinel: a 404 is reported as sentinel: null, not a failure", async () => {
+  const { storage } = fakeStorage();
+
+  const result = await readSentinel(storage);
+
+  assert.deepEqual(result, { ok: true, sentinel: null });
+});
+
+test("readSentinel: valid JSON is parsed into a sentinel", async () => {
+  const sentinel = { vaultId: "abc-123", createdAt: 1000 };
+  const { storage } = fakeStorage({ [SENTINEL_KEY]: encodeSentinel(sentinel) });
+
+  const result = await readSentinel(storage);
+
+  assert.deepEqual(result, { ok: true, sentinel });
+});
+
+test("readSentinel: corrupt JSON is reported as a failure, not an absent sentinel", async () => {
+  const { storage } = fakeStorage({ [SENTINEL_KEY]: "not json" });
+
+  const result = await readSentinel(storage);
+
+  assert.deepEqual(result, { ok: false, message: "remote sentinel is corrupt" });
+});
+
+test("readSentinel: an unknown format version refuses the pass", async () => {
+  const raw = JSON.stringify({ version: 3, vaultId: "abc-123", createdAt: 1000 });
+  const { storage } = fakeStorage({ [SENTINEL_KEY]: raw });
+
+  const result = await readSentinel(storage);
+
+  assert.deepEqual(result, {
+    ok: false,
+    message: "remote sentinel is a format this version of geode can't read",
+  });
+});
+
 test("syncOnce: a manifest format this build doesn't know halts the pass before any sync work", async () => {
   const reader = fakeReader({ "local.md": "local" });
   reader.stat = async () => {
@@ -179,7 +223,10 @@ test("syncOnce: a manifest format this build doesn't know halts the pass before 
   });
   const getObject = storage.getObject;
   storage.getObject = async (key) => {
-    assert.equal(key, MANIFEST_KEY);
+    // syncOnce reads the sentinel alongside the manifest before deciding anything; only these two
+    // reserved keys are ever legitimate here, and nothing past them should be reached once the
+    // manifest itself refuses.
+    assert.ok(key === MANIFEST_KEY || key === SENTINEL_KEY, key);
     return getObject(key);
   };
   storage.headObject = async () => {
@@ -203,6 +250,76 @@ test("syncOnce: a manifest format this build doesn't know halts the pass before 
     failures: [],
     snapshot: null,
   });
+});
+
+test("syncOnce: a genuinely new bucket writes a sentinel too (#183)", async () => {
+  const reader = fakeReader({ "a.md": "alpha" });
+  const { writer } = fakeLocalWriter();
+  const { storage, objects } = fakeStorage();
+
+  const outcome = await syncOnce(empty, reader, writer, storage, 1, () => "minted-id");
+
+  assert.equal(outcome.ok, true);
+  assert.ok(outcome.ok && outcome.snapshot.vaultId === "minted-id");
+  assert.ok(objects.has(SENTINEL_KEY));
+  assert.ok(objects.has(MANIFEST_KEY));
+  // The sentinel's identity, not the manifest's content, is what a future pass checks the bucket
+  // against, so it must carry the same vaultId the pass just committed to.
+  const written = objects.get(SENTINEL_KEY);
+  assert.ok(written !== undefined);
+  assert.equal(JSON.parse(written as string).vaultId, "minted-id");
+});
+
+test("syncOnce: a device pointed at a different vault's sentinel refuses (#183)", async () => {
+  // This device already trusts a different vaultId (its state.json carries one from a prior
+  // successful sync), and the bucket it is pointed at now belongs to a genuinely different vault.
+  // Whether that other vault's manifest happens to exist is irrelevant here; the mismatch alone is
+  // the danger #183 exists to catch (a typo in a configured prefix, the wrong bucket entirely).
+  const reader = fakeReader({ "a.md": "alpha" });
+  reader.listFiles = async () => {
+    throw new Error("unexpected local listing");
+  };
+  const { writer } = fakeLocalWriter();
+  writer.stageFile = async () => {
+    throw new Error("unexpected local write");
+  };
+  const { storage } = fakeStorage({
+    [SENTINEL_KEY]: encodeSentinel({ vaultId: "known-id", createdAt: 1000 }),
+  });
+  storage.putObject = async () => {
+    throw new Error("unexpected remote write");
+  };
+  storage.listObjects = async () => {
+    throw new Error("unexpected remote listing");
+  };
+  const previous: Snapshot = { files: [], vaultId: "other-id" };
+
+  const outcome = await syncOnce(previous, reader, writer, storage, 1);
+
+  assert.deepEqual(outcome, {
+    ok: false,
+    message: "this bucket belongs to a different vault than the one last synced here",
+    failures: [],
+    snapshot: null,
+  });
+});
+
+test("syncOnce: a never-synced device proceeds without a manifest (#109)", async () => {
+  // The sentinel proves someone has used this bucket before, but this particular device has no
+  // history of its own to protect, so it must fall through to the ordinary first-sync path rather
+  // than refuse: exactly the #109 scenario a manifest deleted while its blob survives, which the
+  // existing unexplainedBlobs reporting already resolves. Refusing here for every device, not just
+  // ones with something to lose, would silently reinstate that permanent deadlock.
+  const reader = fakeReader({ "a.md": "alpha" });
+  const { writer } = fakeLocalWriter();
+  const { storage } = fakeStorage({
+    [SENTINEL_KEY]: encodeSentinel({ vaultId: "known-id", createdAt: 1000 }),
+  });
+
+  const outcome = await syncOnce(empty, reader, writer, storage, 1);
+
+  assert.equal(outcome.ok, true);
+  assert.ok(outcome.ok && outcome.snapshot.vaultId === "known-id");
 });
 
 test("syncOnce: a stale ancestor is ignored on a first sync, so a populated vault is pushed, not wiped", async () => {
@@ -408,8 +525,9 @@ test("syncOnce: retry adopts an identical orphaned upload with a HEAD, not anoth
   };
   const reader = fakeReader({ "a.md": "ours!" });
   const { writer } = fakeLocalWriter();
+  const newVaultId = () => "fixed-vault-id";
 
-  const first = await syncOnce(ancestor, reader, writer, storage, 1);
+  const first = await syncOnce(ancestor, reader, writer, storage, 1, newVaultId);
 
   assert.deepEqual(first, {
     ok: false,
@@ -422,18 +540,22 @@ test("syncOnce: retry adopts an identical orphaned upload with a HEAD, not anoth
 
   // The manifest is still at the ancestor while the blob already holds our bytes, so the retry's
   // HEAD must find it and skip the PUT entirely.
-  const retry = await syncOnce(ancestor, reader, writer, storage, 1);
+  const retry = await syncOnce(ancestor, reader, writer, storage, 1, newVaultId);
 
   assert.deepEqual(retry, {
     ok: true,
     snapshot: {
       files: [{ path: "a.md", size: 5, mtime: 1, hash: oursHash }],
+      vaultId: "fixed-vault-id",
     },
     changeCount: 1,
   });
   assert.equal(filePuts, 1, "retry replaced an identical orphaned upload with a HEAD, not a PUT");
   assert.ok(retry.ok);
-  assert.equal(objects.get(MANIFEST_KEY), encodeSnapshot(retry.snapshot));
+  // The stored manifest never carries vaultId, only the snapshot syncOnce hands back for local
+  // persistence does (#183), so the comparison strips it before checking the two agree.
+  const { vaultId: _vaultId, ...storedShape } = retry.snapshot;
+  assert.equal(objects.get(MANIFEST_KEY), encodeSnapshot(storedShape));
 });
 
 test("syncOnce: a file changed mid sync is not recorded in the manifest and is pushed next pass", async () => {

--- a/src/sync/sync.ts
+++ b/src/sync/sync.ts
@@ -9,7 +9,18 @@ import {
   takeSnapshot,
 } from "../vault/vault.ts";
 import { executeSyncPlan, type LocalWriter, type SyncFailure } from "./execute.ts";
-import { BLOB_PREFIX, MANIFEST_KEY, manifestAfterSync, planSync, type SyncAction } from "./plan.ts";
+import {
+  BLOB_PREFIX,
+  decodeSentinel,
+  encodeSentinel,
+  MANIFEST_KEY,
+  manifestAfterSync,
+  planSync,
+  resolveVaultIdentity,
+  SENTINEL_KEY,
+  type Sentinel,
+  type SyncAction,
+} from "./plan.ts";
 
 // SyncOutcome is the result of a single sync pass. On success it carries the new snapshot to
 // persist as the next sync's starting point and how many actions were applied; on failure it
@@ -110,6 +121,35 @@ export async function readRemoteManifest(
   return { ok: false, message: fetched.message };
 }
 
+// readSentinel fetches and parses the remote sentinel (#183). A confirmed 404 is reported as
+// `sentinel: null`, the same "definitely absent, not merely unreadable" distinction
+// readRemoteManifest already draws for the manifest, since resolveVaultIdentity needs to tell
+// "this bucket has never had one" from "something is wrong reading it" apart.
+export async function readSentinel(
+  storage: StorageClient,
+): Promise<{ ok: true; sentinel: Sentinel | null } | { ok: false; message: string }> {
+  const fetched = await storage.getObject(SENTINEL_KEY);
+
+  if (fetched.ok && fetched.body !== null) {
+    const decoded = decodeSentinel(new TextDecoder().decode(fetched.body));
+    if (!decoded.ok) {
+      if (decoded.reason === "unsupportedVersion") {
+        return {
+          ok: false,
+          message: "remote sentinel is a format this version of geode can't read",
+        };
+      }
+      return { ok: false, message: "remote sentinel is corrupt" };
+    }
+    return { ok: true, sentinel: decoded.sentinel };
+  }
+
+  if (fetched.status === "not_found") {
+    return { ok: true, sentinel: null };
+  }
+  return { ok: false, message: fetched.message };
+}
+
 // revertFailedPaths returns snapshot with every failed action's path restored to the ancestor's
 // view of it, so state.json never advances past an action that didn't complete: those paths diff
 // against the same ancestor next pass and are re-planned, while every completed path keeps its
@@ -142,17 +182,35 @@ export function revertFailedPaths(
 // reflecting what the bucket now actually holds. previous is passed in and the new
 // snapshot returned rather than read or written internally, so the caller owns persistence (the
 // plugin through state.json, tests through their own store) and this stays pure over its inputs.
-// now is injected so a conflict copy's name is deterministic under test.
+// now is injected so a conflict copy's name is deterministic under test. newVaultId mints the
+// identifier resolveVaultIdentity attaches to a bucket the first time this pass sees it, injected
+// for the same reason: real syncs use crypto.randomUUID(), tests want a fixed value.
 export async function syncOnce(
   previous: Snapshot,
   reader: Reader,
   localWriter: LocalWriter,
   storage: StorageClient,
   now: number,
+  newVaultId: () => string = () => crypto.randomUUID(),
 ): Promise<SyncOutcome> {
-  const remote = await readRemoteManifest(storage);
+  const [remote, sentinelResult] = await Promise.all([
+    readRemoteManifest(storage),
+    readSentinel(storage),
+  ]);
   if (!remote.ok) {
     return { ok: false, message: remote.message, failures: [], snapshot: null };
+  }
+  if (!sentinelResult.ok) {
+    return { ok: false, message: sentinelResult.message, failures: [], snapshot: null };
+  }
+  const identity = resolveVaultIdentity(
+    remote.firstSync,
+    sentinelResult.sentinel,
+    previous.vaultId,
+    newVaultId,
+  );
+  if (!identity.ok) {
+    return { ok: false, message: identity.message, failures: [], snapshot: null };
   }
 
   // No remote manifest means no prior sync ever completed against this bucket, so previous (the
@@ -264,6 +322,29 @@ export async function syncOnce(
     };
   }
 
+  // The manifest existing now is what every future pass uses to tell this bucket apart from one
+  // nobody has synced (see resolveVaultIdentity), so write the sentinel the moment that becomes
+  // true: on a genuine first sync, and on the self heal for one that has a manifest but lost its
+  // sentinel along the way. ifAbsent guards two devices racing to bootstrap the same bucket; the
+  // loser's pass fails here rather than overwriting a vaultId another device already committed to,
+  // and its retry adopts whichever one actually won.
+  if (sentinelResult.sentinel === null) {
+    const sentinelBody = new TextEncoder().encode(
+      encodeSentinel({ vaultId: identity.vaultId, createdAt: now }),
+    );
+    const sentinelUploaded = await storage.putObject(SENTINEL_KEY, sentinelBody, {
+      kind: "ifAbsent",
+    });
+    if (!sentinelUploaded.ok) {
+      return {
+        ok: false,
+        message: "could not write the vault sentinel; sync again",
+        failures: executed.failures,
+        snapshot: null,
+      };
+    }
+  }
+
   // The count comes from failed (one entry per planned path), not failures: a conflict can report
   // two operation failures (copy push and pull) for the same file, and the message counts files.
   // strandedFailures adds to it without adding to failed: there is no action, planned or
@@ -279,7 +360,13 @@ export async function syncOnce(
     };
   }
 
-  return { ok: true, snapshot: final, changeCount: actions.length };
+  // vaultId is attached only now, after manifestBody was already encoded from final: it belongs on
+  // the snapshot this pass hands back for local persistence, never inside the remote manifest.
+  return {
+    ok: true,
+    snapshot: { ...final, vaultId: identity.vaultId },
+    changeCount: actions.length,
+  };
 }
 
 // unexplainedBlobs returns the blob keys a first sync cannot account for: survivors whose content

--- a/src/vault/vault.ts
+++ b/src/vault/vault.ts
@@ -100,10 +100,17 @@ export type Reader = {
   stat: (path: string) => Promise<FileStat>;
 };
 
-// Snapshot is every file geode saw the last time it took a snapshot.
+// Snapshot is every file geode saw the last time it took a snapshot. vaultId, when present, is the
+// identifier of the bucket this snapshot was last synced against (see resolveVaultIdentity in
+// sync/plan.ts, #183): carried on the local state.json copy so a device can tell "I have never
+// synced" from "I have synced, and this bucket now looks wrong" the next time a manifest and
+// sentinel are both missing. Never populated on the remote manifest itself; syncOnce only ever
+// attaches it to the snapshot it hands back to the caller for persistence, after the manifest body
+// has already been encoded.
 export type Snapshot = {
   files: FileState[];
   settingsFingerprint?: string;
+  vaultId?: string;
 };
 
 // Store reads and writes the persisted snapshot. The real implementation stores it inside
@@ -194,9 +201,14 @@ export function decodeSnapshot(raw: string): DecodedSnapshot {
   }
   const settingsFingerprint = (parsed as { settingsFingerprint?: unknown }).settingsFingerprint;
   const fingerprintStr = typeof settingsFingerprint === "string" ? settingsFingerprint : undefined;
+  const vaultId = (parsed as { vaultId?: unknown }).vaultId;
+  const vaultIdStr = typeof vaultId === "string" ? vaultId : undefined;
   const snapshot: Snapshot = { files: parsed.files };
   if (fingerprintStr !== undefined) {
     snapshot.settingsFingerprint = fingerprintStr;
+  }
+  if (vaultIdStr !== undefined) {
+    snapshot.vaultId = vaultIdStr;
   }
 
   return { ok: true, snapshot };
@@ -231,12 +243,20 @@ export function diffSnapshots(previous: Snapshot, current: Snapshot): Change[] {
 // encodeSnapshot serializes a snapshot for persistence, stamping the format version so every
 // manifest and state.json written from here on carries the marker decodeSnapshot branches on.
 export function encodeSnapshot(snapshot: Snapshot): string {
-  const result: { version: number; files: FileState[]; settingsFingerprint?: string } = {
+  const result: {
+    version: number;
+    files: FileState[];
+    settingsFingerprint?: string;
+    vaultId?: string;
+  } = {
     version: SNAPSHOT_VERSION,
     files: snapshot.files,
   };
   if (snapshot.settingsFingerprint !== undefined) {
     result.settingsFingerprint = snapshot.settingsFingerprint;
+  }
+  if (snapshot.vaultId !== undefined) {
+    result.vaultId = snapshot.vaultId;
   }
 
   return JSON.stringify(result);


### PR DESCRIPTION
Resolves [#183](https://github.com/8thpark/geode/issues/183)

## Problem

A confirmed 404 on the remote manifest is treated as a genuinely new, empty bucket, but the same 404 is produced by a bucket that is not the one the user meant, a lifecycle rule, a manual deletion, a typo in a configured prefix, or credentials scoped somewhere else; nothing today can tell "nobody has ever synced here" from "someone has, and this now looks wrong"

## Why

- Silent misdirection here has real cost: notes pushed into the wrong bucket, or a wipe read as an empty vault ready to be refilled
- Whether the manifest itself happens to exist deliberately does not change the refusal: a manifest missing while its blobs survive is a scenario `syncOnce` already handles by reporting rather than blocking, and duplicating a second, stricter refusal on top of it would have quietly reintroduced a deadlock that fix already closed
- A device with nothing to lose, one that has never synced before, is treated differently from one already trusting a vault; only the latter has something a wrong bucket could actually take from it

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR distinguishes a genuinely unused bucket from a wiped or misdirected one by pairing a locally persisted vault identity with a remote sentinel.
- Adds versioned sentinel encoding, decoding, validation, and identity resolution.
- Reads and conditionally creates the sentinel during synchronization, refusing mismatched or suspicious empty targets.
- Persists the trusted vault ID locally and adds coverage for bootstrap, recovery, mismatch, and retry behavior.
- Documents the sentinel and local vault identity protocol for contributors.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/sync/plan.ts | Adds the versioned sentinel format and pure identity-resolution rules for new, upgraded, wiped, and mismatched vaults. |
| src/sync/sync.ts | Integrates sentinel reads, identity validation, conditional sentinel creation, and local vaultId persistence into syncOnce. |
| src/vault/vault.ts | Extends locally persisted snapshots with an optional vaultId and documents that the remote manifest excludes it. |
| src/sync/plan.test.ts | Covers sentinel serialization and each identity-resolution branch. |
| src/sync/sync.test.ts | Covers sentinel reads, first-sync creation, mismatch refusal, missing-manifest recovery, and stable retry identity. |
| CONTRIBUTING.md | Documents the remote sentinel and locally persisted vault identity, addressing the prior documentation concern. |

<sub>Reviews (2): Last reviewed commit: ["Address comment"](https://github.com/8thpark/geode/commit/58728f55dd5845b8cab7cdf49e1a2f752c35f181) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49515423)</sub>

<!-- /greptile_comment -->