### PR TITLE
[#103] Sync → Name the device that made a conflicted edit

### DIFF
--- a/src/device/device.test.ts
+++ b/src/device/device.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { conflictCopyPath } from "../sync/plan.ts";
+import { isSafePath } from "../vault/vault.ts";
+import { DEVICE_ID_KEY, deviceIdFrom, deviceSuffixFrom } from "./device.ts";
+
+test("deviceSuffixFrom: five bytes encode to eight base32 characters (#103)", () => {
+  // 40 bits split into eight 5-bit groups holding 0 through 7 in order, so the expected output
+  // reads straight off the front of the alphabet.
+  const suffix = deviceSuffixFrom(new Uint8Array([0x00, 0x44, 0x32, 0x14, 0xc7]));
+
+  assert.equal(suffix, "01234567");
+});
+
+test("deviceSuffixFrom: the alphabet is lowercase and skips the ambiguous letters (#103)", () => {
+  // One case throughout is what makes two device IDs unable to collide by case alone, which
+  // decodeSnapshot refuses outright (#94); lowercase specifically because the whole suffix a
+  // conflict copy carries is lowercase. i, l, o and u are absent so a suffix read off a filename
+  // can't be transcribed back wrong.
+  const every = deviceSuffixFrom(new Uint8Array([255, 255, 255, 255, 255]));
+
+  assert.equal(every, "zzzzzzzz");
+  for (const byte of [0, 64, 128, 192, 255]) {
+    const suffix = deviceSuffixFrom(new Uint8Array([byte, byte, byte, byte, byte]));
+
+    assert.match(suffix, /^[0-9a-hjkmnp-tv-z]{8}$/, `byte ${byte}`);
+    assert.equal(suffix, suffix.toLowerCase(), `byte ${byte}`);
+  }
+});
+
+test("deviceSuffixFrom: distinct randomness gives distinct suffixes", () => {
+  // The suffix is the only thing separating two devices carrying the same platform label, so two
+  // different draws must not land on the same eight characters.
+  const a = deviceSuffixFrom(new Uint8Array([1, 2, 3, 4, 5]));
+  const b = deviceSuffixFrom(new Uint8Array([1, 2, 3, 4, 6]));
+
+  assert.notEqual(a, b);
+});
+
+test("deviceIdFrom: a label and suffix join with a hyphen", () => {
+  assert.equal(deviceIdFrom("mac", "k3pl7qna"), "mac-k3pl7qna");
+});
+
+test("deviceIdFrom: an empty half degrades to the other rather than leaving a stray hyphen", () => {
+  assert.equal(deviceIdFrom("", "k3pl7qna"), "k3pl7qna");
+  assert.equal(deviceIdFrom("mac", ""), "mac");
+});
+
+test("deviceIdFrom: every generated ID is safe in a conflict copy path (#103)", () => {
+  // The ID lands in a filename written to disk, so it has to clear the same rules a pulled
+  // manifest entry does (#132) and must never introduce uppercase that could let two devices
+  // collide by case alone (#94).
+  const labels = ["mac", "ios", "android", "windows", "linux", "device"];
+  const suffixes = ["01234567", "zzzzzzzz", "k3pl7qna", "00000000"];
+
+  for (const label of labels) {
+    for (const suffix of suffixes) {
+      const deviceId = deviceIdFrom(label, suffix);
+      const copy = conflictCopyPath(
+        "notes/todo.md",
+        Date.parse("2026-07-14T14:37:22.123Z"),
+        deviceId,
+      );
+
+      assert.equal(deviceId, deviceId.toLowerCase(), deviceId);
+      assert.equal(isSafePath(copy), true, copy);
+      assert.equal(copy.includes(" "), false, copy);
+    }
+  }
+});
+
+test("DEVICE_ID_KEY: is a stable, namespaced localStorage key", () => {
+  // Vault scoped localStorage is shared with Obsidian and every other plugin, so the key has to
+  // stay namespaced, and it has to stay stable: changing it silently remints every device's
+  // identity and renames every conflict copy written from then on.
+  assert.equal(DEVICE_ID_KEY, "geode-device-id");
+});

--- a/src/device/device.ts
+++ b/src/device/device.ts
@@ -1,0 +1,57 @@
+// DEVICE_ID_KEY is where this device's identity is kept: Obsidian's vault scoped localStorage,
+// deliberately not data.json or state.json (#103). Both of those live under
+// .obsidian/plugins/geode/, and plenty of people sync .obsidian/ through iCloud, Dropbox, git or
+// another plugin, which would hand one device's identity to every other device that reads the
+// synced copy. Devices sharing an ID is worse than having none: conflict copies get attributed to
+// the wrong machine, and two machines can then generate the identical conflict path for one note.
+// localStorage never travels with the vault, so an identity stored here stays local by
+// construction rather than by asking users not to sync a file.
+//
+// The cost is that clearing app data mints a fresh ID for that device. That is a cosmetic reset,
+// conflict copies already written keep the name they were given, and it is the right trade against
+// two devices silently answering to the same name.
+export const DEVICE_ID_KEY = "geode-device-id";
+
+// DEVICE_SUFFIX_ALPHABET is Crockford's base32 alphabet, lowercased, and missing i, l, o and u so
+// a suffix read off a filename can't be transcribed wrong. One case throughout, here and in the
+// platform label, is what stops two generated device IDs differing only by case, which would be a
+// path collision decodeSnapshot refuses outright (#94). Lowercase specifically because a conflict
+// copy's whole added suffix is lowercase (see conflictCopyPath).
+const DEVICE_SUFFIX_ALPHABET = "0123456789abcdefghjkmnpqrstvwxyz";
+
+// deviceIdFrom returns the identifier naming this device in conflict copies and logs: a platform
+// label a human can recognise, and a random suffix that separates two devices of the same kind.
+// Both halves are generated rather than typed, so the result is always safe as a path segment
+// (#132) and can never collide with another device's only by case (#94), neither of which holds
+// for a name a user could set.
+export function deviceIdFrom(label: string, suffix: string): string {
+  if (label === "") {
+    return suffix;
+  }
+  if (suffix === "") {
+    return label;
+  }
+
+  return `${label}-${suffix}`;
+}
+
+// deviceSuffixFrom encodes bytes as Crockford base32, five bits per character, for the random half
+// of a device ID. Five bytes in gives exactly eight characters out with no padding or remainder.
+export function deviceSuffixFrom(bytes: Uint8Array): string {
+  let bits = 0;
+  let value = 0;
+  let out = "";
+  for (const byte of bytes) {
+    value = (value << 8) | byte;
+    bits += 8;
+    while (bits >= 5) {
+      out += DEVICE_SUFFIX_ALPHABET[(value >>> (bits - 5)) & 31];
+      bits -= 5;
+    }
+  }
+  if (bits > 0) {
+    out += DEVICE_SUFFIX_ALPHABET[(value << (5 - bits)) & 31];
+  }
+
+  return out;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,12 @@
 import type { App } from "obsidian";
-import { Plugin, setIcon, setTooltip } from "obsidian";
+import { Platform, Plugin, setIcon, setTooltip } from "obsidian";
 import { createLogSink } from "./log/adapter";
 import { createLogBus, createLogger, type LogBus, type Logger, type LogSink } from "./log/log";
 import { GeodeLogView, LOG_VIEW_TYPE } from "./log/view";
 import {
   DEFAULT_SETTINGS,
+  deviceIdFrom,
+  deviceSuffixFrom,
   type GeodeSettings,
   hasConnectionConfig,
   normalizeSettings,
@@ -33,6 +35,10 @@ const MAX_LOG_LINES = 500;
 // edits (autosave, bulk rename, etc.) collapses into one snapshot instead of one per file.
 const VAULT_STATE_DEBOUNCE_MS = 2000;
 
+// DEVICE_SUFFIX_BYTES is how much randomness separates two devices carrying the same platform
+// label. Five bytes encode to exactly eight base32 characters with nothing left over.
+const DEVICE_SUFFIX_BYTES = 5;
+
 // AppWithSetting adds Obsidian's internal, undocumented settings-window API (there is no public
 // equivalent) so the Settings command can jump straight to Geode's tab, and opening the log view
 // can close the settings modal out from under itself.
@@ -46,6 +52,30 @@ type AppWithSetting = App & {
 
 // SyncStatus is the state the status bar item reflects.
 type SyncStatus = "idle" | "syncing" | "error";
+
+// deviceLabel returns the human recognisable half of this device's ID, lowercase to match the rest
+// of the suffix a conflict copy carries. The mobile checks come first: an iPad reports itself as
+// macOS on some builds, so asking "is this a phone or tablet" before "which desktop OS" is what
+// keeps an iPad from being labelled mac.
+function deviceLabel(): string {
+  if (Platform.isIosApp) {
+    return "ios";
+  }
+  if (Platform.isAndroidApp) {
+    return "android";
+  }
+  if (Platform.isMacOS) {
+    return "mac";
+  }
+  if (Platform.isWin) {
+    return "windows";
+  }
+  if (Platform.isLinux) {
+    return "linux";
+  }
+
+  return "device";
+}
 
 // iconFor returns the status bar icon for status.
 function iconFor(status: SyncStatus): string {
@@ -119,7 +149,9 @@ export default class GeodePlugin extends Plugin {
     this.setSyncStatus("idle", "");
 
     this.addSettingTab(new GeodeSettingTab(this.app, this));
-    this.logger.info(`loaded (provider=${this.settings.provider})`);
+    this.logger.info(
+      `loaded (provider=${this.settings.provider}, device=${this.settings.deviceId})`,
+    );
 
     // onLayoutReady, not onload directly: the vault isn't guaranteed fully indexed yet at
     // onload time, and a snapshot taken too early would see an incomplete file list.
@@ -246,7 +278,15 @@ export default class GeodePlugin extends Plugin {
     await flushOpenEditors(this.app.workspace);
 
     const previous = await stateStore.read();
-    const outcome = await syncOnce(previous, reader, localWriter, storage, Date.now());
+    const outcome = await syncOnce(
+      previous,
+      reader,
+      localWriter,
+      storage,
+      Date.now(),
+      () => crypto.randomUUID(),
+      this.settings.deviceId,
+    );
     if (!outcome.ok) {
       // A failed pass can still have made progress worth keeping (#87): the snapshot records what
       // completed so it is never re-planned, while each failed file stays pending for next pass.
@@ -266,8 +306,17 @@ export default class GeodePlugin extends Plugin {
     this.setSyncStatus("idle", "");
   }
 
+  // loadSettings mints this device's ID on the first load that finds none, which covers both a
+  // fresh install and an upgrade from a build that predates #103. It persists through saveData
+  // rather than saveSettings: this runs before the logger exists, and saveSettings logs.
   async loadSettings() {
     this.settings = normalizeSettings(await this.loadData());
+    if (this.settings.deviceId !== "") {
+      return;
+    }
+    const suffix = deviceSuffixFrom(crypto.getRandomValues(new Uint8Array(DEVICE_SUFFIX_BYTES)));
+    this.settings.deviceId = deviceIdFrom(deviceLabel(), suffix);
+    await this.saveData(this.settings);
   }
 
   async saveSettings() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,12 +1,11 @@
 import type { App } from "obsidian";
 import { Platform, Plugin, setIcon, setTooltip } from "obsidian";
+import { DEVICE_ID_KEY, deviceIdFrom, deviceSuffixFrom } from "./device/device";
 import { createLogSink } from "./log/adapter";
 import { createLogBus, createLogger, type LogBus, type Logger, type LogSink } from "./log/log";
 import { GeodeLogView, LOG_VIEW_TYPE } from "./log/view";
 import {
   DEFAULT_SETTINGS,
-  deviceIdFrom,
-  deviceSuffixFrom,
   type GeodeSettings,
   hasConnectionConfig,
   normalizeSettings,
@@ -102,6 +101,10 @@ function tooltipFor(status: SyncStatus, detail: string): string {
 // GeodePlugin is the Obsidian plugin entry point that owns settings load and save.
 export default class GeodePlugin extends Plugin {
   settings: GeodeSettings = DEFAULT_SETTINGS;
+  // deviceId names this machine in conflict copies and logs (#103). Read from, and when absent
+  // minted into, vault scoped localStorage rather than settings: see DEVICE_ID_KEY for why it must
+  // never be able to travel to another device.
+  deviceId = "";
   // Assigned in onload, which Obsidian always runs before any other plugin method.
   logger!: Logger;
   private logBus!: LogBus;
@@ -120,6 +123,7 @@ export default class GeodePlugin extends Plugin {
 
   async onload() {
     await this.loadSettings();
+    this.deviceId = this.loadDeviceId();
 
     this.logSink = createLogSink(this.app.vault.adapter, this.manifest.dir, MAX_LOG_LINES);
     this.logBus = createLogBus();
@@ -149,9 +153,7 @@ export default class GeodePlugin extends Plugin {
     this.setSyncStatus("idle", "");
 
     this.addSettingTab(new GeodeSettingTab(this.app, this));
-    this.logger.info(
-      `loaded (provider=${this.settings.provider}, device=${this.settings.deviceId})`,
-    );
+    this.logger.info(`loaded (provider=${this.settings.provider}, device=${this.deviceId})`);
 
     // onLayoutReady, not onload directly: the vault isn't guaranteed fully indexed yet at
     // onload time, and a snapshot taken too early would see an incomplete file list.
@@ -285,7 +287,7 @@ export default class GeodePlugin extends Plugin {
       storage,
       Date.now(),
       () => crypto.randomUUID(),
-      this.settings.deviceId,
+      this.deviceId,
     );
     if (!outcome.ok) {
       // A failed pass can still have made progress worth keeping (#87): the snapshot records what
@@ -306,17 +308,24 @@ export default class GeodePlugin extends Plugin {
     this.setSyncStatus("idle", "");
   }
 
-  // loadSettings mints this device's ID on the first load that finds none, which covers both a
-  // fresh install and an upgrade from a build that predates #103. It persists through saveData
-  // rather than saveSettings: this runs before the logger exists, and saveSettings logs.
-  async loadSettings() {
-    this.settings = normalizeSettings(await this.loadData());
-    if (this.settings.deviceId !== "") {
-      return;
+  // loadDeviceId returns this device's identity, minting and storing one the first time it runs on
+  // a given device. Vault scoped localStorage, never data.json or state.json, so a synced
+  // .obsidian/ folder can't hand this identity to another machine (see DEVICE_ID_KEY). A stored
+  // value that isn't a usable string is treated as absent and replaced rather than trusted.
+  loadDeviceId(): string {
+    const stored: unknown = this.app.loadLocalStorage(DEVICE_ID_KEY);
+    if (typeof stored === "string" && stored !== "") {
+      return stored;
     }
     const suffix = deviceSuffixFrom(crypto.getRandomValues(new Uint8Array(DEVICE_SUFFIX_BYTES)));
-    this.settings.deviceId = deviceIdFrom(deviceLabel(), suffix);
-    await this.saveData(this.settings);
+    const minted = deviceIdFrom(deviceLabel(), suffix);
+    this.app.saveLocalStorage(DEVICE_ID_KEY, minted);
+
+    return minted;
+  }
+
+  async loadSettings() {
+    this.settings = normalizeSettings(await this.loadData());
   }
 
   async saveSettings() {

--- a/src/settings/settings.test.ts
+++ b/src/settings/settings.test.ts
@@ -4,6 +4,8 @@ import {
   type ConnectionStatus,
   canSave,
   DEFAULT_SETTINGS,
+  deviceIdFrom,
+  deviceSuffixFrom,
   draftForDisplay,
   endpointFor,
   type GeodeSettings,
@@ -425,4 +427,60 @@ test("draftForDisplay: internal re-render returns the same draft reference", () 
   const draft = { ...DEFAULT_SETTINGS, bucket: "in-progress" };
   const got = draftForDisplay(false, draft, DEFAULT_SETTINGS);
   assert.strictEqual(got, draft);
+});
+
+test("deviceSuffixFrom: five bytes encode to eight base32 characters (#103)", () => {
+  // 40 bits split into eight 5-bit groups holding 0 through 7 in order, so the expected output
+  // reads straight off the front of the alphabet.
+  const suffix = deviceSuffixFrom(new Uint8Array([0x00, 0x44, 0x32, 0x14, 0xc7]));
+
+  assert.equal(suffix, "01234567");
+});
+
+test("deviceSuffixFrom: the alphabet is lowercase and skips the ambiguous letters (#103)", () => {
+  // One case throughout is what makes two device IDs unable to collide by case alone, which
+  // decodeSnapshot refuses outright (#94); lowercase specifically because the whole suffix a
+  // conflict copy carries is lowercase. i, l, o and u are absent so a suffix read off a filename
+  // can't be transcribed back wrong.
+  const every = deviceSuffixFrom(new Uint8Array([255, 255, 255, 255, 255]));
+
+  assert.equal(every, "zzzzzzzz");
+  for (const byte of [0, 64, 128, 192, 255]) {
+    const suffix = deviceSuffixFrom(new Uint8Array([byte, byte, byte, byte, byte]));
+
+    assert.match(suffix, /^[0-9a-hjkmnp-tv-z]{8}$/, `byte ${byte}`);
+    assert.equal(suffix, suffix.toLowerCase(), `byte ${byte}`);
+  }
+});
+
+test("deviceIdFrom: a label and suffix join with a hyphen", () => {
+  assert.equal(deviceIdFrom("mac", "k3pl7qna"), "mac-k3pl7qna");
+});
+
+test("deviceIdFrom: an empty half degrades to the other rather than leaving a stray hyphen", () => {
+  assert.equal(deviceIdFrom("", "k3pl7qna"), "k3pl7qna");
+  assert.equal(deviceIdFrom("mac", ""), "mac");
+});
+
+test("normalizeSettings: an upgrader with no deviceId reads back empty, ready to be minted", () => {
+  // Minting needs randomness, which normalizeSettings deliberately has none of; the plugin fills
+  // this in on load (#103). What matters here is that an absent field doesn't become undefined.
+  const settings = normalizeSettings({ bucket: "b" });
+
+  assert.equal(settings.deviceId, "");
+});
+
+test("normalizeSettings: an existing deviceId survives a reload untouched", () => {
+  const settings = normalizeSettings({ bucket: "b", deviceId: "mac-k3pl7qna" });
+
+  assert.equal(settings.deviceId, "mac-k3pl7qna");
+});
+
+test("settingsEqual: a differing deviceId is not an unsaved change (#103)", () => {
+  // deviceId is not user editable and a draft always carries the saved one forward, so counting it
+  // toward dirtiness could only ever produce a phantom "Unsaved changes".
+  const a: GeodeSettings = { ...DEFAULT_SETTINGS, deviceId: "mac-aaaaaaaa" };
+  const b: GeodeSettings = { ...DEFAULT_SETTINGS, deviceId: "ios-bbbbbbbb" };
+
+  assert.equal(settingsEqual(a, b), true);
 });

--- a/src/settings/settings.test.ts
+++ b/src/settings/settings.test.ts
@@ -4,8 +4,6 @@ import {
   type ConnectionStatus,
   canSave,
   DEFAULT_SETTINGS,
-  deviceIdFrom,
-  deviceSuffixFrom,
   draftForDisplay,
   endpointFor,
   type GeodeSettings,
@@ -427,60 +425,4 @@ test("draftForDisplay: internal re-render returns the same draft reference", () 
   const draft = { ...DEFAULT_SETTINGS, bucket: "in-progress" };
   const got = draftForDisplay(false, draft, DEFAULT_SETTINGS);
   assert.strictEqual(got, draft);
-});
-
-test("deviceSuffixFrom: five bytes encode to eight base32 characters (#103)", () => {
-  // 40 bits split into eight 5-bit groups holding 0 through 7 in order, so the expected output
-  // reads straight off the front of the alphabet.
-  const suffix = deviceSuffixFrom(new Uint8Array([0x00, 0x44, 0x32, 0x14, 0xc7]));
-
-  assert.equal(suffix, "01234567");
-});
-
-test("deviceSuffixFrom: the alphabet is lowercase and skips the ambiguous letters (#103)", () => {
-  // One case throughout is what makes two device IDs unable to collide by case alone, which
-  // decodeSnapshot refuses outright (#94); lowercase specifically because the whole suffix a
-  // conflict copy carries is lowercase. i, l, o and u are absent so a suffix read off a filename
-  // can't be transcribed back wrong.
-  const every = deviceSuffixFrom(new Uint8Array([255, 255, 255, 255, 255]));
-
-  assert.equal(every, "zzzzzzzz");
-  for (const byte of [0, 64, 128, 192, 255]) {
-    const suffix = deviceSuffixFrom(new Uint8Array([byte, byte, byte, byte, byte]));
-
-    assert.match(suffix, /^[0-9a-hjkmnp-tv-z]{8}$/, `byte ${byte}`);
-    assert.equal(suffix, suffix.toLowerCase(), `byte ${byte}`);
-  }
-});
-
-test("deviceIdFrom: a label and suffix join with a hyphen", () => {
-  assert.equal(deviceIdFrom("mac", "k3pl7qna"), "mac-k3pl7qna");
-});
-
-test("deviceIdFrom: an empty half degrades to the other rather than leaving a stray hyphen", () => {
-  assert.equal(deviceIdFrom("", "k3pl7qna"), "k3pl7qna");
-  assert.equal(deviceIdFrom("mac", ""), "mac");
-});
-
-test("normalizeSettings: an upgrader with no deviceId reads back empty, ready to be minted", () => {
-  // Minting needs randomness, which normalizeSettings deliberately has none of; the plugin fills
-  // this in on load (#103). What matters here is that an absent field doesn't become undefined.
-  const settings = normalizeSettings({ bucket: "b" });
-
-  assert.equal(settings.deviceId, "");
-});
-
-test("normalizeSettings: an existing deviceId survives a reload untouched", () => {
-  const settings = normalizeSettings({ bucket: "b", deviceId: "mac-k3pl7qna" });
-
-  assert.equal(settings.deviceId, "mac-k3pl7qna");
-});
-
-test("settingsEqual: a differing deviceId is not an unsaved change (#103)", () => {
-  // deviceId is not user editable and a draft always carries the saved one forward, so counting it
-  // toward dirtiness could only ever produce a phantom "Unsaved changes".
-  const a: GeodeSettings = { ...DEFAULT_SETTINGS, deviceId: "mac-aaaaaaaa" };
-  const b: GeodeSettings = { ...DEFAULT_SETTINGS, deviceId: "ios-bbbbbbbb" };
-
-  assert.equal(settingsEqual(a, b), true);
 });

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -1,4 +1,6 @@
 // DEFAULT_SETTINGS is the complete zero value used before any user configuration is loaded.
+// deviceId is empty here and minted on first load rather than defaulted, since a real one needs
+// randomness this module deliberately doesn't reach for.
 export const DEFAULT_SETTINGS: GeodeSettings = {
   version: 1,
   provider: "r2",
@@ -8,7 +10,15 @@ export const DEFAULT_SETTINGS: GeodeSettings = {
   bucket: "",
   accessKeyId: "",
   secretId: "",
+  deviceId: "",
 };
+
+// DEVICE_SUFFIX_ALPHABET is Crockford's base32 alphabet, lowercased, and missing i, l, o and u so
+// a suffix read off a filename can't be transcribed wrong. One case throughout, here and in the
+// platform label, is what stops two generated device IDs differing only by case, which would be a
+// path collision decodeSnapshot refuses outright (#94). Lowercase specifically because a conflict
+// copy's whole added suffix is lowercase (see conflictCopyPath).
+const DEVICE_SUFFIX_ALPHABET = "0123456789abcdefghjkmnpqrstvwxyz";
 
 // ConnectionStatus is the current in-memory state of a Test Connection check.
 export type ConnectionStatus = "unknown" | "checking" | "ok" | "error";
@@ -23,10 +33,17 @@ export type GeodeSettings = {
   bucket: string;
   accessKeyId: string;
   // secretId is a SecretStorage reference name, not the secret value itself. Obsidian's
-  // SecretComponent picker lets a user pick or create a secret under any name of their choosing;
+  // SecretComponent picker lets a user pick or create a secret name of their choosing;
   // it does not support forcing new entries onto a fixed ID, so we have to remember whichever
   // one they picked.
   secretId: string;
+  // deviceId names this device in conflict copy filenames and log lines (#103), so a three device
+  // vault says which machine an edit came from rather than leaving it to be guessed from a
+  // timestamp. Minted once on first load and never rewritten. It lives here, in data.json,
+  // deliberately rather than in state.json: state.json resets on a settings fingerprint change and
+  // on corruption, and unlike vaultId there is no remote copy to re-derive a device's identity
+  // from, so a reset would silently rename every conflict copy this device writes from then on.
+  deviceId: string;
 };
 
 // SaveTarget is the narrow persistence surface needed to save a settings draft.
@@ -45,6 +62,43 @@ export function canSave(dirty: boolean, connectionStatus: ConnectionStatus): boo
   }
 
   return connectionStatus === "unknown" || connectionStatus === "ok";
+}
+
+// deviceIdFrom returns the identifier naming this device in conflict copies and logs: a platform
+// label a human can recognise, and a random suffix that separates two devices of the same kind.
+// Both halves are generated rather than typed, so the result is always safe as a path segment
+// (#132) and can never collide with another device's only by case (#94), neither of which holds
+// for a name a user could set.
+export function deviceIdFrom(label: string, suffix: string): string {
+  if (label === "") {
+    return suffix;
+  }
+  if (suffix === "") {
+    return label;
+  }
+
+  return `${label}-${suffix}`;
+}
+
+// deviceSuffixFrom encodes bytes as Crockford base32, five bits per character, for the random half
+// of a device ID. Five bytes in gives exactly eight characters out with no padding or remainder.
+export function deviceSuffixFrom(bytes: Uint8Array): string {
+  let bits = 0;
+  let value = 0;
+  let out = "";
+  for (const byte of bytes) {
+    value = (value << 8) | byte;
+    bits += 8;
+    while (bits >= 5) {
+      out += DEVICE_SUFFIX_ALPHABET[(value >>> (bits - 5)) & 31];
+      bits -= 5;
+    }
+  }
+  if (bits > 0) {
+    out += DEVICE_SUFFIX_ALPHABET[(value << (5 - bits)) & 31];
+  }
+
+  return out;
 }
 
 // draftForDisplay returns the draft a settings tab should show for a given render.
@@ -115,6 +169,9 @@ export function normalizeSettings(raw: unknown): GeodeSettings {
     bucket: stringOr(source.bucket, DEFAULT_SETTINGS.bucket),
     accessKeyId: stringOr(source.accessKeyId, DEFAULT_SETTINGS.accessKeyId),
     secretId: stringOr(source.secretId, DEFAULT_SETTINGS.secretId),
+    // Left empty when absent rather than minted here: this is pure, and an upgrader's existing
+    // data.json has no deviceId. The plugin mints one on load and persists it (see main.ts).
+    deviceId: stringOr(source.deviceId, DEFAULT_SETTINGS.deviceId),
   };
 }
 
@@ -151,9 +208,11 @@ export async function saveDraft(
   await target.saveSettings();
 }
 
-// settingsEqual reports whether two settings values are identical field for field. Used to
-// derive whether a draft has unsaved changes by comparing it to the last saved settings, rather
-// than tracking a dirty flag that can't self-correct when an edit is reverted by hand.
+// settingsEqual reports whether two settings values match across every field a user can edit. Used
+// to derive whether a draft has unsaved changes by comparing it to the last saved settings, rather
+// than tracking a dirty flag that can't self-correct when an edit is reverted by hand. deviceId is
+// excluded deliberately: nothing in the tab can change it, a draft always carries the saved one
+// forward, and counting it would only ever be a comparison that cannot fail.
 export function settingsEqual(a: GeodeSettings, b: GeodeSettings): boolean {
   return (
     a.provider === b.provider &&

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -1,6 +1,4 @@
 // DEFAULT_SETTINGS is the complete zero value used before any user configuration is loaded.
-// deviceId is empty here and minted on first load rather than defaulted, since a real one needs
-// randomness this module deliberately doesn't reach for.
 export const DEFAULT_SETTINGS: GeodeSettings = {
   version: 1,
   provider: "r2",
@@ -10,15 +8,7 @@ export const DEFAULT_SETTINGS: GeodeSettings = {
   bucket: "",
   accessKeyId: "",
   secretId: "",
-  deviceId: "",
 };
-
-// DEVICE_SUFFIX_ALPHABET is Crockford's base32 alphabet, lowercased, and missing i, l, o and u so
-// a suffix read off a filename can't be transcribed wrong. One case throughout, here and in the
-// platform label, is what stops two generated device IDs differing only by case, which would be a
-// path collision decodeSnapshot refuses outright (#94). Lowercase specifically because a conflict
-// copy's whole added suffix is lowercase (see conflictCopyPath).
-const DEVICE_SUFFIX_ALPHABET = "0123456789abcdefghjkmnpqrstvwxyz";
 
 // ConnectionStatus is the current in-memory state of a Test Connection check.
 export type ConnectionStatus = "unknown" | "checking" | "ok" | "error";
@@ -37,13 +27,6 @@ export type GeodeSettings = {
   // it does not support forcing new entries onto a fixed ID, so we have to remember whichever
   // one they picked.
   secretId: string;
-  // deviceId names this device in conflict copy filenames and log lines (#103), so a three device
-  // vault says which machine an edit came from rather than leaving it to be guessed from a
-  // timestamp. Minted once on first load and never rewritten. It lives here, in data.json,
-  // deliberately rather than in state.json: state.json resets on a settings fingerprint change and
-  // on corruption, and unlike vaultId there is no remote copy to re-derive a device's identity
-  // from, so a reset would silently rename every conflict copy this device writes from then on.
-  deviceId: string;
 };
 
 // SaveTarget is the narrow persistence surface needed to save a settings draft.
@@ -62,43 +45,6 @@ export function canSave(dirty: boolean, connectionStatus: ConnectionStatus): boo
   }
 
   return connectionStatus === "unknown" || connectionStatus === "ok";
-}
-
-// deviceIdFrom returns the identifier naming this device in conflict copies and logs: a platform
-// label a human can recognise, and a random suffix that separates two devices of the same kind.
-// Both halves are generated rather than typed, so the result is always safe as a path segment
-// (#132) and can never collide with another device's only by case (#94), neither of which holds
-// for a name a user could set.
-export function deviceIdFrom(label: string, suffix: string): string {
-  if (label === "") {
-    return suffix;
-  }
-  if (suffix === "") {
-    return label;
-  }
-
-  return `${label}-${suffix}`;
-}
-
-// deviceSuffixFrom encodes bytes as Crockford base32, five bits per character, for the random half
-// of a device ID. Five bytes in gives exactly eight characters out with no padding or remainder.
-export function deviceSuffixFrom(bytes: Uint8Array): string {
-  let bits = 0;
-  let value = 0;
-  let out = "";
-  for (const byte of bytes) {
-    value = (value << 8) | byte;
-    bits += 8;
-    while (bits >= 5) {
-      out += DEVICE_SUFFIX_ALPHABET[(value >>> (bits - 5)) & 31];
-      bits -= 5;
-    }
-  }
-  if (bits > 0) {
-    out += DEVICE_SUFFIX_ALPHABET[(value << (5 - bits)) & 31];
-  }
-
-  return out;
 }
 
 // draftForDisplay returns the draft a settings tab should show for a given render.
@@ -169,9 +115,6 @@ export function normalizeSettings(raw: unknown): GeodeSettings {
     bucket: stringOr(source.bucket, DEFAULT_SETTINGS.bucket),
     accessKeyId: stringOr(source.accessKeyId, DEFAULT_SETTINGS.accessKeyId),
     secretId: stringOr(source.secretId, DEFAULT_SETTINGS.secretId),
-    // Left empty when absent rather than minted here: this is pure, and an upgrader's existing
-    // data.json has no deviceId. The plugin mints one on load and persists it (see main.ts).
-    deviceId: stringOr(source.deviceId, DEFAULT_SETTINGS.deviceId),
   };
 }
 
@@ -208,11 +151,9 @@ export async function saveDraft(
   await target.saveSettings();
 }
 
-// settingsEqual reports whether two settings values match across every field a user can edit. Used
-// to derive whether a draft has unsaved changes by comparing it to the last saved settings, rather
-// than tracking a dirty flag that can't self-correct when an edit is reverted by hand. deviceId is
-// excluded deliberately: nothing in the tab can change it, a draft always carries the saved one
-// forward, and counting it would only ever be a comparison that cannot fail.
+// settingsEqual reports whether two settings values are identical field for field. Used to
+// derive whether a draft has unsaved changes by comparing it to the last saved settings, rather
+// than tracking a dirty flag that can't self-correct when an edit is reverted by hand.
 export function settingsEqual(a: GeodeSettings, b: GeodeSettings): boolean {
   return (
     a.provider === b.provider &&

--- a/src/sync/execute.ts
+++ b/src/sync/execute.ts
@@ -118,6 +118,7 @@ export async function executeSyncPlan(
   now: number,
   remote: Snapshot = { files: [] },
   manifestEtag: string | null = null,
+  deviceId = "",
 ): Promise<ExecuteResult> {
   const completed: SyncAction[] = [];
   const failed: SyncAction[] = [];
@@ -136,6 +137,7 @@ export async function executeSyncPlan(
       storage,
       now,
       manifestEtag,
+      deviceId,
     );
     // A conflict's copy push can succeed even when the rest of the action later fails (the pull,
     // its integrity check, or the local write), so pushed is gathered regardless of outcome: it
@@ -347,6 +349,7 @@ async function executeAction(
   storage: StorageClient,
   now: number,
   manifestEtag: string | null,
+  deviceId: string,
 ): Promise<ActionResult> {
   if (action.kind === "push") {
     let bytes: Uint8Array;
@@ -463,7 +466,7 @@ async function executeAction(
   // push that copy to storage too, so the diverged edit lands on every device and the manifest
   // we later upload isn't claiming a remote object that doesn't exist. Neither side's edit is
   // ever silently discarded.
-  const copyPath = conflictCopyPath(action.path, now);
+  const copyPath = conflictCopyPath(action.path, now, deviceId);
   let localBytes: Uint8Array;
   try {
     localBytes = await reader.readFile(action.path);

--- a/src/sync/plan.test.ts
+++ b/src/sync/plan.test.ts
@@ -240,49 +240,49 @@ test("manifestAfterSync: a local deletion conflict pushes nothing, the remote en
 test("conflictCopyPath: keeps the extension", () => {
   assert.equal(
     conflictCopyPath("notes/todo.md", Date.parse("2026-07-14T14:37:22.123Z")),
-    "notes/todo_conflict_20260714-143722.md",
+    "notes/todo_conflict_20260714-143722-123.md",
   );
 });
 
 test("conflictCopyPath: a file with no extension", () => {
   assert.equal(
     conflictCopyPath("notes/todo", Date.parse("2026-07-14T14:37:22.123Z")),
-    "notes/todo_conflict_20260714-143722",
+    "notes/todo_conflict_20260714-143722-123",
   );
 });
 
 test("conflictCopyPath: a dot in a folder name isn't mistaken for an extension", () => {
   assert.equal(
     conflictCopyPath("my.notes/todo", Date.parse("2026-07-14T14:37:22.123Z")),
-    "my.notes/todo_conflict_20260714-143722",
+    "my.notes/todo_conflict_20260714-143722-123",
   );
 });
 
 test("conflictCopyPath: a leading dot in the filename isn't mistaken for an extension", () => {
   assert.equal(
     conflictCopyPath("notes/.gitignore", Date.parse("2026-07-14T14:37:22.123Z")),
-    "notes/.gitignore_conflict_20260714-143722",
+    "notes/.gitignore_conflict_20260714-143722-123",
   );
 });
 
 test("conflictCopyPath: a dotfile at the vault root isn't mistaken for an extension", () => {
   assert.equal(
     conflictCopyPath(".editorconfig", Date.parse("2026-07-14T14:37:22.123Z")),
-    ".editorconfig_conflict_20260714-143722",
+    ".editorconfig_conflict_20260714-143722-123",
   );
 });
 
 test("conflictCopyPath: the device sits before the timestamp, extension kept (#103)", () => {
   assert.equal(
     conflictCopyPath("notes/todo.md", Date.parse("2026-07-14T14:37:22.123Z"), "mac-k3pl7qna"),
-    "notes/todo_conflict_mac-k3pl7qna_20260714-143722.md",
+    "notes/todo_conflict_mac-k3pl7qna_20260714-143722-123.md",
   );
 });
 
 test("conflictCopyPath: the device also lands on a name with no extension (#103)", () => {
   assert.equal(
     conflictCopyPath("notes/todo", Date.parse("2026-07-14T14:37:22.123Z"), "ios-bbbbbbbb"),
-    "notes/todo_conflict_ios-bbbbbbbb_20260714-143722",
+    "notes/todo_conflict_ios-bbbbbbbb_20260714-143722-123",
   );
 });
 
@@ -290,7 +290,7 @@ test("conflictCopyPath: an empty device is omitted, never left as a stray delimi
   // A pass can run before a device ID has been minted; the name it produces must still be clean.
   assert.equal(
     conflictCopyPath("notes/todo.md", Date.parse("2026-07-14T14:37:22.123Z"), ""),
-    "notes/todo_conflict_20260714-143722.md",
+    "notes/todo_conflict_20260714-143722-123.md",
   );
 });
 
@@ -300,9 +300,30 @@ test("conflictCopyPath: the name carries no spaces and no uppercase it added its
   // shell and clean in a URL. Only the note's own name may contribute uppercase.
   const copy = conflictCopyPath("notes/Todo.md", Date.parse("2026-07-14T14:37:22.123Z"), "mac-abc");
 
-  assert.equal(copy, "notes/Todo_conflict_mac-abc_20260714-143722.md");
+  assert.equal(copy, "notes/Todo_conflict_mac-abc_20260714-143722-123.md");
   assert.equal(copy.includes(" "), false);
-  assert.equal(copy.slice("notes/Todo".length), "_conflict_mac-abc_20260714-143722.md");
+  assert.equal(copy.slice("notes/Todo".length), "_conflict_mac-abc_20260714-143722-123.md");
+});
+
+test("conflictCopyPath: two passes in the same second get different copies (#103)", () => {
+  // A plan carries at most one action per path, so two conflicts for one path can only come from
+  // two passes; nothing stops a failed pass being retried immediately, and automatic sync makes
+  // back to back passes ordinary. At second precision both would name the same copy and the second
+  // rename would overwrite or strand the edit the first preserved. Milliseconds are what stop the
+  // one function whose job is preserving edits from silently destroying one.
+  const first = conflictCopyPath("a.md", Date.parse("2026-07-14T14:37:22.123Z"), "mac-abc");
+  const second = conflictCopyPath("a.md", Date.parse("2026-07-14T14:37:22.456Z"), "mac-abc");
+
+  assert.equal(first, "a_conflict_mac-abc_20260714-143722-123.md");
+  assert.equal(second, "a_conflict_mac-abc_20260714-143722-456.md");
+  assert.notEqual(first, second);
+});
+
+test("conflictCopyPath: two devices never name the same copy at the same instant (#103)", () => {
+  const mine = conflictCopyPath("a.md", Date.parse("2026-07-14T14:37:22.123Z"), "mac-abc");
+  const theirs = conflictCopyPath("a.md", Date.parse("2026-07-14T14:37:22.123Z"), "ios-xyz");
+
+  assert.notEqual(mine, theirs);
 });
 
 test("conflictCopyPath: the suffix parses back from the right (#103)", () => {
@@ -314,9 +335,9 @@ test("conflictCopyPath: the suffix parses back from the right (#103)", () => {
     "mac-abc",
   );
 
-  assert.equal(copy, "my_notes/my_todo_conflict_mac-abc_20260714-143722.md");
+  assert.equal(copy, "my_notes/my_todo_conflict_mac-abc_20260714-143722-123.md");
   const fields = copy.slice(0, copy.lastIndexOf(".")).split("_");
-  assert.deepEqual(fields.slice(-3), ["conflict", "mac-abc", "20260714-143722"]);
+  assert.deepEqual(fields.slice(-3), ["conflict", "mac-abc", "20260714-143722-123"]);
 });
 
 test("conflictCopyPath: a generated device ID survives the path safety rules (#103)", () => {

--- a/src/sync/plan.test.ts
+++ b/src/sync/plan.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
+import { isSafePath } from "../vault/vault.ts";
 import { empty, file, snapshot } from "./fake.ts";
 import {
   blobKeyFor,
@@ -238,37 +239,100 @@ test("manifestAfterSync: a local deletion conflict pushes nothing, the remote en
 
 test("conflictCopyPath: keeps the extension", () => {
   assert.equal(
-    conflictCopyPath("notes/todo.md", Date.parse("2026-07-14T10:00:00.000Z")),
-    "notes/todo (conflicted copy 2026-07-14T10-00-00-000Z).md",
+    conflictCopyPath("notes/todo.md", Date.parse("2026-07-14T14:37:22.123Z")),
+    "notes/todo_conflict_20260714-143722.md",
   );
 });
 
 test("conflictCopyPath: a file with no extension", () => {
   assert.equal(
-    conflictCopyPath("notes/todo", Date.parse("2026-07-14T10:00:00.000Z")),
-    "notes/todo (conflicted copy 2026-07-14T10-00-00-000Z)",
+    conflictCopyPath("notes/todo", Date.parse("2026-07-14T14:37:22.123Z")),
+    "notes/todo_conflict_20260714-143722",
   );
 });
 
 test("conflictCopyPath: a dot in a folder name isn't mistaken for an extension", () => {
   assert.equal(
-    conflictCopyPath("my.notes/todo", Date.parse("2026-07-14T10:00:00.000Z")),
-    "my.notes/todo (conflicted copy 2026-07-14T10-00-00-000Z)",
+    conflictCopyPath("my.notes/todo", Date.parse("2026-07-14T14:37:22.123Z")),
+    "my.notes/todo_conflict_20260714-143722",
   );
 });
 
 test("conflictCopyPath: a leading dot in the filename isn't mistaken for an extension", () => {
   assert.equal(
-    conflictCopyPath("notes/.gitignore", Date.parse("2026-07-14T10:00:00.000Z")),
-    "notes/.gitignore (conflicted copy 2026-07-14T10-00-00-000Z)",
+    conflictCopyPath("notes/.gitignore", Date.parse("2026-07-14T14:37:22.123Z")),
+    "notes/.gitignore_conflict_20260714-143722",
   );
 });
 
 test("conflictCopyPath: a dotfile at the vault root isn't mistaken for an extension", () => {
   assert.equal(
-    conflictCopyPath(".editorconfig", Date.parse("2026-07-14T10:00:00.000Z")),
-    ".editorconfig (conflicted copy 2026-07-14T10-00-00-000Z)",
+    conflictCopyPath(".editorconfig", Date.parse("2026-07-14T14:37:22.123Z")),
+    ".editorconfig_conflict_20260714-143722",
   );
+});
+
+test("conflictCopyPath: the device sits before the timestamp, extension kept (#103)", () => {
+  assert.equal(
+    conflictCopyPath("notes/todo.md", Date.parse("2026-07-14T14:37:22.123Z"), "mac-k3pl7qna"),
+    "notes/todo_conflict_mac-k3pl7qna_20260714-143722.md",
+  );
+});
+
+test("conflictCopyPath: the device also lands on a name with no extension (#103)", () => {
+  assert.equal(
+    conflictCopyPath("notes/todo", Date.parse("2026-07-14T14:37:22.123Z"), "ios-bbbbbbbb"),
+    "notes/todo_conflict_ios-bbbbbbbb_20260714-143722",
+  );
+});
+
+test("conflictCopyPath: an empty device is omitted, never left as a stray delimiter (#103)", () => {
+  // A pass can run before a device ID has been minted; the name it produces must still be clean.
+  assert.equal(
+    conflictCopyPath("notes/todo.md", Date.parse("2026-07-14T14:37:22.123Z"), ""),
+    "notes/todo_conflict_20260714-143722.md",
+  );
+});
+
+test("conflictCopyPath: the name carries no spaces and no uppercase it added itself (#103)", () => {
+  // The whole added suffix is lowercase and space free by construction: lowercase is what stops
+  // two devices colliding by case alone (#94), and no spaces is what keeps the name quotable in a
+  // shell and clean in a URL. Only the note's own name may contribute uppercase.
+  const copy = conflictCopyPath("notes/Todo.md", Date.parse("2026-07-14T14:37:22.123Z"), "mac-abc");
+
+  assert.equal(copy, "notes/Todo_conflict_mac-abc_20260714-143722.md");
+  assert.equal(copy.includes(" "), false);
+  assert.equal(copy.slice("notes/Todo".length), "_conflict_mac-abc_20260714-143722.md");
+});
+
+test("conflictCopyPath: the suffix parses back from the right (#103)", () => {
+  // Underscore separates fields and hyphen lives inside them, so a note whose own name contains
+  // underscores still leaves exactly three fields on the end to recover device and time from.
+  const copy = conflictCopyPath(
+    "my_notes/my_todo.md",
+    Date.parse("2026-07-14T14:37:22.123Z"),
+    "mac-abc",
+  );
+
+  assert.equal(copy, "my_notes/my_todo_conflict_mac-abc_20260714-143722.md");
+  const fields = copy.slice(0, copy.lastIndexOf(".")).split("_");
+  assert.deepEqual(fields.slice(-3), ["conflict", "mac-abc", "20260714-143722"]);
+});
+
+test("conflictCopyPath: a generated device ID survives the path safety rules (#103)", () => {
+  // The copy is written to disk, so its name has to clear the same checks a pulled manifest entry
+  // does (#132) and must not be able to collide with another device's only by case (#94).
+  const generated = ["mac-k3pl7qna", "ios-bbbbbbbb", "windows-0123456z", "device-zzzzzzzz"];
+
+  for (const deviceId of generated) {
+    const copy = conflictCopyPath(
+      "notes/todo.md",
+      Date.parse("2026-07-14T10:00:00.000Z"),
+      deviceId,
+    );
+
+    assert.equal(isSafePath(copy), true, deviceId);
+  }
 });
 
 test("encodeSentinel: the wire format carries the version marker and round-trips", () => {

--- a/src/sync/plan.ts
+++ b/src/sync/plan.ts
@@ -86,17 +86,21 @@ export function blobKeyFor(hash: string): string {
 // (#94), and the absence of spaces keeps the name quotable in a shell and clean in a URL, which the
 // CLI and API on the roadmap both eventually want.
 //
-// Second precision, rather than the milliseconds an ISO string carries: two conflicts on one file,
-// from one device, inside the same second needs two passes in that second where the first left the
-// path still conflicting. The cross device version of that collision is gone entirely now the
-// device is in the name.
+// The timestamp keeps milliseconds. Two conflicts for one path can only come from two separate
+// passes, since a plan carries at most one action per path, but nothing stops a failed pass being
+// retried immediately, and automatic sync (#93) makes back to back passes ordinary rather than
+// exceptional. At second precision those two would name the same copy, and the second rename would
+// overwrite or strand the edit the first one preserved: silent loss, in the one function whose
+// entire job is that no edit is ever silently discarded. Milliseconds put a bound on that which no
+// realistic pair of network bound passes can cross.
 export function conflictCopyPath(path: string, now: number, deviceId = ""): string {
   const iso = new Date(now).toISOString();
   const date = `${iso.slice(0, 4)}${iso.slice(5, 7)}${iso.slice(8, 10)}`;
   const time = `${iso.slice(11, 13)}${iso.slice(14, 16)}${iso.slice(17, 19)}`;
-  let marker = `conflict_${date}-${time}`;
+  const millis = iso.slice(20, 23);
+  let marker = `conflict_${date}-${time}-${millis}`;
   if (deviceId !== "") {
-    marker = `conflict_${deviceId}_${date}-${time}`;
+    marker = `conflict_${deviceId}_${date}-${time}-${millis}`;
   }
   const lastSlash = path.lastIndexOf("/");
   const lastDot = path.lastIndexOf(".");

--- a/src/sync/plan.ts
+++ b/src/sync/plan.ts
@@ -71,14 +71,39 @@ export function blobKeyFor(hash: string): string {
 // conflictCopyPath returns the name a locally diverged file is renamed to before the remote
 // version claims the original path, so neither edit is ever silently discarded. The extension,
 // if any, is preserved so the renamed copy still opens in whatever app handles that file type.
-export function conflictCopyPath(path: string, now: number): string {
-  const stamp = new Date(now).toISOString().replace(/[:.]/g, "-");
+//
+// deviceId names the machine the preserved edit came from (#103). A timestamp alone answers "when"
+// but not "whose", and on a three device vault "whose" is the question actually being asked. An
+// empty deviceId is omitted rather than left as a gap, so a pass running before one has been minted
+// still produces a clean name.
+//
+// The name carries no spaces, and every token it adds is lowercase. Underscore separates fields and
+// hyphen lives inside them, so `mac-k3pl7qna` and `20260714-143722` are each exactly one field and
+// the suffix stays unambiguous to parse from the right even when the note's own name contains
+// underscores. That is what lets a future "unresolved conflicts" view recover the device and the
+// time from a filename alone, with no index to keep in step. Lowercase throughout also means two
+// devices can never produce paths differing only by case, which decodeSnapshot refuses outright
+// (#94), and the absence of spaces keeps the name quotable in a shell and clean in a URL, which the
+// CLI and API on the roadmap both eventually want.
+//
+// Second precision, rather than the milliseconds an ISO string carries: two conflicts on one file,
+// from one device, inside the same second needs two passes in that second where the first left the
+// path still conflicting. The cross device version of that collision is gone entirely now the
+// device is in the name.
+export function conflictCopyPath(path: string, now: number, deviceId = ""): string {
+  const iso = new Date(now).toISOString();
+  const date = `${iso.slice(0, 4)}${iso.slice(5, 7)}${iso.slice(8, 10)}`;
+  const time = `${iso.slice(11, 13)}${iso.slice(14, 16)}${iso.slice(17, 19)}`;
+  let marker = `conflict_${date}-${time}`;
+  if (deviceId !== "") {
+    marker = `conflict_${deviceId}_${date}-${time}`;
+  }
   const lastSlash = path.lastIndexOf("/");
   const lastDot = path.lastIndexOf(".");
   if (lastDot === -1 || lastDot <= lastSlash + 1) {
-    return `${path} (conflicted copy ${stamp})`;
+    return `${path}_${marker}`;
   }
-  return `${path.slice(0, lastDot)} (conflicted copy ${stamp})${path.slice(lastDot)}`;
+  return `${path.slice(0, lastDot)}_${marker}${path.slice(lastDot)}`;
 }
 
 // decodeSentinel parses a serialized sentinel and checks its format version, the same posture

--- a/src/sync/sync.test.ts
+++ b/src/sync/sync.test.ts
@@ -692,6 +692,41 @@ test("syncOnce: a file edited mid sync is never overwritten by a pull, and the r
   assert.equal(files.get("b.md"), "b v2");
 });
 
+test("syncOnce: a conflict copy carries the device that made the edit (#103)", async () => {
+  // Both sides changed relative to the ancestor, so the local edit is preserved under a conflict
+  // copy. On a three device vault a timestamp alone leaves whose edit it holds to be guessed, so
+  // the device this pass ran on has to be in the name, on disk and in the uploaded manifest.
+  const remoteHash = await hashOf("from another device");
+  const ancestor = snapshot({ path: "a.md", size: 4, mtime: 1, hash: await hashOf("shared base") });
+  const remoteManifest = encodeSnapshot(
+    snapshot({ path: "a.md", size: 19, mtime: 1, hash: remoteHash }),
+  );
+  const { storage, objects } = fakeStorage({
+    [MANIFEST_KEY]: remoteManifest,
+    [blobKeyFor(remoteHash)]: "from another device",
+  });
+  const reader = fakeReader({ "a.md": "my own edit" });
+  const { writer, files } = fakeLocalWriter();
+  files.set("a.md", "my own edit");
+  const now = Date.parse("2026-07-14T14:37:22.123Z");
+
+  const outcome = await syncOnce(ancestor, reader, writer, storage, now, undefined, "mac-k3pl7qna");
+
+  assert.equal(outcome.ok, true);
+  const copyPath = conflictCopyPath("a.md", now, "mac-k3pl7qna");
+  assert.equal(copyPath, "a_conflict_mac-k3pl7qna_20260714-143722.md");
+  // The preserved edit sits under the device named copy, and the remote version claimed the path.
+  assert.equal(files.get(copyPath), "my own edit");
+  assert.equal(files.get("a.md"), "from another device");
+  // Other devices see it too: the copy reached the bucket and the manifest names it.
+  assert.equal(objects.get(blobKeyFor(await hashOf("my own edit"))), "my own edit");
+  const manifestBody = objects.get(MANIFEST_KEY);
+  assert.ok(manifestBody !== undefined);
+  const manifest = JSON.parse(manifestBody) as Snapshot;
+  const paths = manifest.files.map((f) => f.path);
+  assert.ok(paths.includes(copyPath), paths.join(", "));
+});
+
 test("syncOnce: a manifest that moves on mid pull is caught before stale content lands on disk", async () => {
   // A blob fetched by its own hash always reads back exactly that content, so unlike the plaintext
   // path keyed layout this replaced, a pull can never notice on its own that a newer manifest has

--- a/src/sync/sync.test.ts
+++ b/src/sync/sync.test.ts
@@ -714,7 +714,7 @@ test("syncOnce: a conflict copy carries the device that made the edit (#103)", a
 
   assert.equal(outcome.ok, true);
   const copyPath = conflictCopyPath("a.md", now, "mac-k3pl7qna");
-  assert.equal(copyPath, "a_conflict_mac-k3pl7qna_20260714-143722.md");
+  assert.equal(copyPath, "a_conflict_mac-k3pl7qna_20260714-143722-123.md");
   // The preserved edit sits under the device named copy, and the remote version claimed the path.
   assert.equal(files.get(copyPath), "my own edit");
   assert.equal(files.get("a.md"), "from another device");

--- a/src/sync/sync.ts
+++ b/src/sync/sync.ts
@@ -184,7 +184,8 @@ export function revertFailedPaths(
 // plugin through state.json, tests through their own store) and this stays pure over its inputs.
 // now is injected so a conflict copy's name is deterministic under test. newVaultId mints the
 // identifier resolveVaultIdentity attaches to a bucket the first time this pass sees it, injected
-// for the same reason: real syncs use crypto.randomUUID(), tests want a fixed value.
+// for the same reason: real syncs use crypto.randomUUID(), tests want a fixed value. deviceId names
+// this machine in any conflict copy the pass writes (#103).
 export async function syncOnce(
   previous: Snapshot,
   reader: Reader,
@@ -192,6 +193,7 @@ export async function syncOnce(
   storage: StorageClient,
   now: number,
   newVaultId: () => string = () => crypto.randomUUID(),
+  deviceId = "",
 ): Promise<SyncOutcome> {
   const [remote, sentinelResult] = await Promise.all([
     readRemoteManifest(storage),
@@ -275,6 +277,7 @@ export async function syncOnce(
     now,
     remoteView,
     manifestEtag,
+    deviceId,
   );
 
   // The manifest is derived from what the plan just did to the bucket, never from a fresh disk


### PR DESCRIPTION
Resolves [#103](https://github.com/8thpark/geode/issues/103)

## Problem

Conflict copies are named with a timestamp alone, so on a vault with more than two devices working out whose edit a copy actually holds is guesswork; Geode also had no stable notion of device identity for logs or anything else to draw on

## Changes

- Mint a device identifier once per device, a platform label plus a random suffix, for example `mac-k3pl7qna`
- Keep it in Obsidian's vault scoped `localStorage`, not `data.json` or `state.json`, so a synced `.obsidian/` folder can never hand one device's identity to another
- Rename conflict copies to `todo_conflict_mac-k3pl7qna_20260714-143722-123.md`, replacing the previous parenthetical prose form
- Include the device in the plugin's load log line

## Why

- A timestamp answers when an edit happened but not which machine made it, and the second question is the one people actually have when they find a conflict copy
- Two devices answering to one identity is worse than having none, since it both misattributes copies and lets two machines generate the same conflict path, and plenty of people sync `.obsidian/` through iCloud, git or another plugin
- Generating both halves rather than letting a user type a name is what keeps the result safe as a path segment and unable to collide with another device's only by case, either of which would otherwise refuse a whole sync pass
- Underscore between fields and hyphen inside them keeps the suffix parseable from the right even when a note's own name contains underscores, so a future unresolved conflicts view can recover device and time from the filename with no index to keep in step
- Dropping spaces keeps the name quotable in a shell and clean in a URL, which the CLI and API both eventually want, and matches what ownCloud, Syncthing and rclone all settled on
- The timestamp keeps milliseconds because a retried pass can produce a second conflict for the same path within one second, and at second precision that would overwrite the edit the first copy preserved

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a stable, device-local identifier and incorporates it into conflict-copy filenames and plugin startup logs.
- Stores generated device identity in vault-specific local storage so synchronized plugin settings cannot propagate it between devices.
- Threads the identifier through the sync execution path and names conflict copies with device identity and millisecond-resolution timestamps.
- Adds coverage for identifier generation, safe filename construction, and conflict naming behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the synchronized-identity issue is fixed by device-local persistence, and the prior same-second conflict collision is addressed by millisecond-resolution naming.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/device/device.ts | Adds lowercase, path-safe device identifier generation using a platform label and random Crockford-base32 suffix. |
| src/main.ts | Loads or mints device identity in device-local storage and passes it into sync while including it in startup logs. |
| src/sync/plan.ts | Updates conflict-copy naming to include device identity and millisecond-resolution timestamps. |
| src/sync/execute.ts | Threads device identity into conflict execution so local edits are renamed using the new conflict-copy format. |
| src/sync/sync.ts | Propagates device identity through sync orchestration without changing manifest identity generation. |

<sub>Reviews (2): Last reviewed commit: ["Add new package"](https://github.com/8thpark/geode/commit/efe1d1ffc80241fb868ed538b2e46ad4761abb33) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49519807)</sub>

**Context used:**

- Knowledge Base — [Plugin entrypoint (src/main.ts)](https://app.greptile.com/8thpark/-/custom-context/knowledge-base/8thpark/geode/-/docs/plugin-entrypoint.md)
- Knowledge Base — [Sync flow](https://app.greptile.com/8thpark/-/custom-context/knowledge-base/8thpark/geode/-/docs/sync-flow.md)

<!-- /greptile_comment -->