### PR TITLE
[#154] Sync → Support syncing to a folder inside the bucket

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,14 @@ With `npm run dev` running:
    proving it has been synced before independent of whether the manifest itself currently exists
    (see `resolveVaultIdentity` in `src/sync/plan.ts`).
 
+   Setting the optional Prefix moves all three under that folder
+   (`vaults/personal/.geode/manifest.json`), so several vaults can share one bucket without seeing
+   each other. Only `createS3Client` knows about it: every key above this line is relative to the
+   configured prefix, and every listed key comes back relative to it too, so nothing in `src/sync`
+   ever has to ask where the vault sits. A prefix is part of what `fingerprintSettings` identifies,
+   so changing it invalidates `state.json` the same way changing the bucket does, and the next sync
+   starts clean against the new folder rather than diffing your vault against a stranger's.
+
 Obsidian's plugin data file (`data.json`), geode's own vault state file (`state.json`), and its
 log file (`geode.log`), all of which land at the repo root because the dev vault symlinks the
 whole repo in as the plugin folder, are gitignored and should never be committed. `state.json`

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import {
   type GeodeSettings,
   hasConnectionConfig,
   normalizeSettings,
+  prefixError,
 } from "./settings/settings";
 import { GeodeSettingTab } from "./settings/tab";
 import { obsidianTransport } from "./storage/obsidian";
@@ -219,6 +220,16 @@ export default class GeodePlugin extends Plugin {
     if (!hasConnectionConfig(this.settings)) {
       this.logger.warn("sync: storage isn't configured yet");
       this.setSyncStatus("error", "storage isn't configured yet");
+      return;
+    }
+    // createS3Client refuses an unusable prefix on its own, so this is not what makes sync safe
+    // (#154); it is what makes the refusal legible. Without it the first operation to run is the
+    // conditional write probe, and a user would be told their provider failed a write check when
+    // the real answer is one bad character in a setting they can fix.
+    const badPrefix = prefixError(this.settings.prefix);
+    if (badPrefix !== "") {
+      this.logger.warn(`sync: ${badPrefix}`);
+      this.setSyncStatus("error", badPrefix);
       return;
     }
     const dir = this.manifest.dir;

--- a/src/settings/settings.test.ts
+++ b/src/settings/settings.test.ts
@@ -9,7 +9,9 @@ import {
   type GeodeSettings,
   hasConnectionConfig,
   isCurrentConnectionResult,
+  normalizePrefix,
   normalizeSettings,
+  prefixError,
   regionFor,
   saveDraft,
   settingsEqual,
@@ -230,6 +232,21 @@ const normalizeCases: { name: string; input: unknown; want: GeodeSettings }[] = 
     input: { secretId: "foo" },
     want: { ...DEFAULT_SETTINGS, secretId: "foo" },
   },
+  {
+    name: "prefix missing defaults to the bucket root",
+    input: {},
+    want: DEFAULT_SETTINGS,
+  },
+  {
+    name: "prefix non-string coerced to the bucket root",
+    input: { prefix: 42 },
+    want: DEFAULT_SETTINGS,
+  },
+  {
+    name: "prefix is stored exactly as typed, not canonicalized",
+    input: { prefix: "/vaults/personal/" },
+    want: { ...DEFAULT_SETTINGS, prefix: "/vaults/personal/" },
+  },
 ];
 
 for (const { name, input, want } of normalizeCases) {
@@ -281,6 +298,80 @@ for (const { name, input, want } of regionCases) {
   });
 }
 
+const normalizePrefixCases: { name: string; input: string; want: string }[] = [
+  { name: "empty is the bucket root", input: "", want: "" },
+  { name: "whitespace only is the bucket root", input: "   ", want: "" },
+  { name: "a plain path is left alone", input: "vaults/personal", want: "vaults/personal" },
+  { name: "a leading slash is dropped", input: "/vaults/personal", want: "vaults/personal" },
+  { name: "a trailing slash is dropped", input: "vaults/personal/", want: "vaults/personal" },
+  { name: "surrounding whitespace is dropped", input: "  vaults  ", want: "vaults" },
+  { name: "repeated slashes collapse", input: "vaults//personal", want: "vaults/personal" },
+  { name: "slashes alone are the bucket root", input: "///", want: "" },
+  { name: "a single segment survives", input: "vaults", want: "vaults" },
+  { name: "interior spaces are content, not padding", input: "my vaults", want: "my vaults" },
+];
+
+for (const { name, input, want } of normalizePrefixCases) {
+  test(`normalizePrefix: ${name}`, () => {
+    assert.strictEqual(normalizePrefix(input), want);
+  });
+}
+
+test("normalizePrefix: canonicalizing an already canonical prefix changes nothing", () => {
+  // The prefix is canonicalized at every point of use rather than on save, so it runs over its own
+  // output constantly; a second pass that moved it would make the key an object lives at depend on
+  // how many times the value had been round tripped.
+  for (const { input } of normalizePrefixCases) {
+    const once = normalizePrefix(input);
+
+    assert.strictEqual(normalizePrefix(once), once, input);
+  }
+});
+
+const prefixErrorCases: { name: string; input: string; want: string }[] = [
+  { name: "empty is fine", input: "", want: "" },
+  { name: "a plain path is fine", input: "vaults/personal", want: "" },
+  { name: "slashes normalizePrefix absorbs are fine", input: "//vaults//", want: "" },
+  { name: "a dot inside a name is fine", input: "vaults/v1.2", want: "" },
+  { name: "a leading dot is fine", input: ".vaults", want: "" },
+  {
+    name: "a backslash is refused",
+    input: "vaults\\personal",
+    want: "Prefix separates folders with /, not \\",
+  },
+  {
+    name: "a newline is refused",
+    input: "vaults\npersonal",
+    want: "Prefix can't contain control characters",
+  },
+  {
+    name: "a tab is refused",
+    input: "vaults\tpersonal",
+    want: "Prefix can't contain control characters",
+  },
+  {
+    name: "a relative parent segment is refused",
+    input: "vaults/../personal",
+    want: "Prefix can't use . or .. as a folder",
+  },
+  {
+    name: "a relative current segment is refused",
+    input: "vaults/./personal",
+    want: "Prefix can't use . or .. as a folder",
+  },
+  {
+    name: "a lone parent segment is refused",
+    input: "..",
+    want: "Prefix can't use . or .. as a folder",
+  },
+];
+
+for (const { name, input, want } of prefixErrorCases) {
+  test(`prefixError: ${name}`, () => {
+    assert.strictEqual(prefixError(input), want);
+  });
+}
+
 const settingsEqualCases: { name: string; a: GeodeSettings; b: GeodeSettings; want: boolean }[] = [
   {
     name: "identical values are equal",
@@ -298,6 +389,12 @@ const settingsEqualCases: { name: string; a: GeodeSettings; b: GeodeSettings; wa
     name: "different provider is not equal",
     a: DEFAULT_SETTINGS,
     b: { ...DEFAULT_SETTINGS, provider: "custom" },
+    want: false,
+  },
+  {
+    name: "different prefix is not equal",
+    a: DEFAULT_SETTINGS,
+    b: { ...DEFAULT_SETTINGS, prefix: "vaults/personal" },
     want: false,
   },
   {

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -6,6 +6,7 @@ export const DEFAULT_SETTINGS: GeodeSettings = {
   endpoint: "",
   region: "",
   bucket: "",
+  prefix: "",
   accessKeyId: "",
   secretId: "",
 };
@@ -21,6 +22,10 @@ export type GeodeSettings = {
   endpoint: string;
   region: string;
   bucket: string;
+  // prefix is the folder inside the bucket the vault lives under, empty for the bucket root
+  // (#154). Stored exactly as typed and canonicalized at the point of use by normalizePrefix, the
+  // same way endpoint and region are, so a trailing slash never reads back as an unsaved change.
+  prefix: string;
   accessKeyId: string;
   // secretId is a SecretStorage reference name, not the secret value itself. Obsidian's
   // SecretComponent picker lets a user pick or create a secret name of their choosing;
@@ -97,6 +102,22 @@ export function isCurrentConnectionResult(
   return settingsEqual(testedSettings, currentSettings);
 }
 
+// normalizePrefix returns the canonical bucket key prefix for a raw settings value: surrounding
+// whitespace gone, and empty segments dropped, so "/vaults/personal/", "vaults//personal" and
+// "vaults/personal" all address the same place. Forgiving about slashes on purpose; what it cannot
+// make sense of is left for prefixError to refuse rather than quietly reinterpreted.
+export function normalizePrefix(raw: string): string {
+  const segments: string[] = [];
+  for (const segment of raw.trim().split("/")) {
+    if (segment === "") {
+      continue;
+    }
+    segments.push(segment);
+  }
+
+  return segments.join("/");
+}
+
 // normalizeSettings returns a complete GeodeSettings from whatever loadData produced,
 // filling gaps with defaults.
 export function normalizeSettings(raw: unknown): GeodeSettings {
@@ -113,9 +134,38 @@ export function normalizeSettings(raw: unknown): GeodeSettings {
     endpoint: stringOr(source.endpoint, DEFAULT_SETTINGS.endpoint),
     region: stringOr(source.region, DEFAULT_SETTINGS.region),
     bucket: stringOr(source.bucket, DEFAULT_SETTINGS.bucket),
+    prefix: stringOr(source.prefix, DEFAULT_SETTINGS.prefix),
     accessKeyId: stringOr(source.accessKeyId, DEFAULT_SETTINGS.accessKeyId),
     secretId: stringOr(source.secretId, DEFAULT_SETTINGS.secretId),
   };
+}
+
+// prefixError returns a short message describing why raw cannot be used as a bucket prefix, or ""
+// when it can, so an unusable value is caught while a user is typing it rather than as a baffling
+// provider error on the next sync. Only what normalizePrefix cannot canonicalize is refused: it
+// already absorbs surrounding and repeated slashes, so what reaches here is a typo rather than a
+// formatting preference. Relative segments are refused instead of resolved because the URL a
+// request is signed against collapses them itself, so "notes/../vault" would sync somewhere other
+// than what was typed, and control characters because they cannot survive a URL intact.
+export function prefixError(raw: string): string {
+  const prefix = normalizePrefix(raw);
+  if (prefix === "") {
+    return "";
+  }
+  if (prefix.includes("\\")) {
+    return "Prefix separates folders with /, not \\";
+  }
+  if (hasControlCharacter(prefix)) {
+    return "Prefix can't contain control characters";
+  }
+
+  for (const segment of prefix.split("/")) {
+    if (segment === "." || segment === "..") {
+      return "Prefix can't use . or .. as a folder";
+    }
+  }
+
+  return "";
 }
 
 // providerOr returns "custom" if v is "custom", otherwise "r2".
@@ -161,9 +211,26 @@ export function settingsEqual(a: GeodeSettings, b: GeodeSettings): boolean {
     a.endpoint === b.endpoint &&
     a.region === b.region &&
     a.bucket === b.bucket &&
+    a.prefix === b.prefix &&
     a.accessKeyId === b.accessKeyId &&
     a.secretId === b.secretId
   );
+}
+
+// hasControlCharacter reports whether value holds any C0 or DEL character, none of which can be
+// carried through a request URL as itself.
+function hasControlCharacter(value: string): boolean {
+  for (const char of value) {
+    const code = char.codePointAt(0);
+    if (code === undefined) {
+      continue;
+    }
+    if (code < 0x20 || code === 0x7f) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 // stringOr returns v if it is a string, otherwise fallback.

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -25,6 +25,11 @@ export type GeodeSettings = {
   // prefix is the folder inside the bucket the vault lives under, empty for the bucket root
   // (#154). Stored exactly as typed and canonicalized at the point of use by normalizePrefix, the
   // same way endpoint and region are, so a trailing slash never reads back as an unsaved change.
+  //
+  // A value normalizeSettings loads is never checked against prefixError, and is deliberately kept
+  // even when unusable: blanking it would silently repoint a vault at the bucket root, and showing
+  // an empty field gives a user nothing to correct. createS3Client is what refuses to act on one,
+  // so an unusable prefix always fails loudly and always survives long enough to be fixed.
   prefix: string;
   accessKeyId: string;
   // secretId is a SecretStorage reference name, not the secret value itself. Obsidian's

--- a/src/settings/tab.ts
+++ b/src/settings/tab.ts
@@ -17,6 +17,7 @@ import {
   type GeodeSettings,
   hasConnectionConfig,
   isCurrentConnectionResult,
+  prefixError,
   providerOr,
   saveDraft,
   settingsEqual,
@@ -83,9 +84,21 @@ function flashButtonText(button: ButtonComponent, original: string, feedback: st
 // onFieldChanged clears any stale connection status and updates the actions row without
 // redrawing the whole tab, so text inputs never lose focus mid keystroke. Whether the draft
 // counts as dirty is derived by comparing it to saved settings, not tracked here.
+//
+// A value the storage layer would refuse outright (a malformed prefix) is reported as a connection
+// error rather than through a field of its own: that reuses the one status line and the Save
+// gating already keyed to it, so an unusable draft can't be saved and left to fail at sync time
+// instead, and no new UI has to exist to say so.
 function onFieldChanged(tab: GeodeSettingTab): void {
   tab.connectionStatus = "unknown";
   tab.connectionMessage = "";
+
+  const badPrefix = prefixError(tab.draft.prefix);
+  if (badPrefix !== "") {
+    tab.connectionStatus = "error";
+    tab.connectionMessage = badPrefix;
+  }
+
   tab.refreshActionsUI();
 }
 
@@ -282,6 +295,19 @@ function renderStorageSection(tab: GeodeSettingTab, containerEl: HTMLElement): v
         .setValue(tab.draft.bucket)
         .onChange((value) => {
           tab.draft.bucket = value;
+          onFieldChanged(tab);
+        }),
+    );
+
+  new Setting(card)
+    .setName("Prefix")
+    .setDesc("Optional folder inside the bucket to sync into. Empty syncs to the bucket root.")
+    .addText((text) =>
+      text
+        .setPlaceholder("vaults/personal")
+        .setValue(tab.draft.prefix)
+        .onChange((value) => {
+          tab.draft.prefix = value;
           onFieldChanged(tab);
         }),
     );

--- a/src/storage/storage.itest.ts
+++ b/src/storage/storage.itest.ts
@@ -261,3 +261,71 @@ test("putObject/getObject round-trips a key containing a hash and percent", asyn
   assert.equal(getResult.ok, true);
   assert.deepEqual(getResult.body, body);
 });
+
+// prefixedSettings point a client at a folder inside the same shared bucket, written the untidy way
+// a user would type it so the round trip proves canonicalization happens at the point of use.
+const prefixedSettings: GeodeSettings = {
+  ...liveSettings,
+  prefix: "/vaults/personal/",
+};
+
+test("a prefixed client round-trips against a real server and hides the prefix", async () => {
+  const client = createS3Client(prefixedSettings, SECRET_ACCESS_KEY, fetchTransport);
+  const root = createS3Client(liveSettings, SECRET_ACCESS_KEY, fetchTransport);
+  const key = "prefix-test/note.md";
+  const body = new TextEncoder().encode("inside a folder");
+
+  try {
+    assert.equal((await client.putObject(key, body)).ok, true);
+    assert.deepEqual((await client.getObject(key)).body, body);
+    assert.equal((await client.headObject(key)).ok, true);
+
+    // What the bucket really holds: the object sits under the prefix and nothing lands beside it
+    // at the root, so two vaults can share one bucket without ever seeing each other.
+    assert.equal((await root.getObject(`vaults/personal/${key}`)).ok, true);
+    assert.equal((await root.getObject(key)).status, "not_found");
+  } finally {
+    await client.deleteObject(key);
+  }
+});
+
+test("a prefixed client lists keys relative to its own root", async () => {
+  const client = createS3Client(prefixedSettings, SECRET_ACCESS_KEY, fetchTransport);
+  const body = new TextEncoder().encode("x");
+
+  try {
+    await client.putObject("prefix-list/a.md", body);
+    await client.putObject("prefix-list/b.md", body);
+
+    const result = await client.listObjects("prefix-list/");
+    assert.equal(result.ok, true);
+    const keys: string[] = [];
+    for (const object of result.objects) {
+      keys.push(object.key);
+    }
+    keys.sort();
+    assert.deepEqual(keys, ["prefix-list/a.md", "prefix-list/b.md"]);
+  } finally {
+    await client.deleteObject("prefix-list/a.md");
+    await client.deleteObject("prefix-list/b.md");
+  }
+});
+
+test("a prefixed client cannot see an object sitting at the bucket root", async () => {
+  // The isolation sync depends on when two vaults share a bucket: a listing that leaked a
+  // neighbour's key would be read as content this vault cannot explain and fail its first sync.
+  const client = createS3Client(prefixedSettings, SECRET_ACCESS_KEY, fetchTransport);
+  const root = createS3Client(liveSettings, SECRET_ACCESS_KEY, fetchTransport);
+  const key = "prefix-isolation/neighbour.md";
+
+  try {
+    await root.putObject(key, new TextEncoder().encode("not mine"));
+
+    assert.equal((await client.getObject(key)).status, "not_found");
+    const result = await client.listObjects("prefix-isolation/");
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.objects, []);
+  } finally {
+    await root.deleteObject(key);
+  }
+});

--- a/src/storage/storage.test.ts
+++ b/src/storage/storage.test.ts
@@ -403,6 +403,62 @@ test("listObjects: a key outside the prefix fails the listing, it is never mis-s
   assert.match(result.message, /outside the configured prefix/);
 });
 
+test("createS3Client: an unusable prefix refuses every operation (#154)", async () => {
+  // Settings reach createS3Client straight from data.json, so the settings tab's own validation is
+  // not on this path at all: a hand edit, an older build, or a synced .obsidian/ folder can all
+  // deliver a prefix no user ever typed. stubTransport throws, so any operation that reached the
+  // network would fail this test rather than return a refusal.
+  const client = createS3Client(
+    { ...rootedSettings, prefix: "../elsewhere" },
+    "shh",
+    stubTransport,
+  );
+  const want = "Prefix can't use . or .. as a folder";
+
+  assert.deepEqual(await client.putObject("k", new Uint8Array([1])), {
+    ok: false,
+    status: "client",
+    message: want,
+  });
+  assert.deepEqual(await client.getObject("k"), {
+    ok: false,
+    status: "client",
+    message: want,
+    body: null,
+    etag: null,
+  });
+  assert.deepEqual(await client.headObject("k"), {
+    ok: false,
+    status: "client",
+    message: want,
+    etag: null,
+  });
+  assert.deepEqual(await client.deleteObject("k"), {
+    ok: false,
+    status: "client",
+    message: want,
+  });
+  assert.deepEqual(await client.listObjects(), {
+    ok: false,
+    status: "client",
+    message: want,
+    objects: [],
+  });
+});
+
+test("createS3Client: a leading .. can never address a different bucket (#154)", async () => {
+  // The concrete danger, and why an unusable prefix cannot simply be dropped: signing normalizes
+  // the URL, so "https://host/vault/../evil/x" resolves to bucket "evil". A client that built this
+  // request at all would read and write someone else's bucket while reporting success.
+  const { transport, urls } = recordingTransport();
+  const client = createS3Client({ ...rootedSettings, prefix: "../evil" }, "shh", transport);
+
+  const result = await client.putObject(".geode/manifest.json", new Uint8Array([1]));
+
+  assert.equal(result.ok, false);
+  assert.deepEqual(urls, []);
+});
+
 test("testConnection: an unusable prefix is refused before any request is signed", async () => {
   const settings: GeodeSettings = { ...rootedSettings, prefix: "vaults/../escape" };
 

--- a/src/storage/storage.test.ts
+++ b/src/storage/storage.test.ts
@@ -293,6 +293,125 @@ test("getObject: a read with no known size falls back to the base budget", async
   assert.match(result.message, /timed out/);
 });
 
+// rootedSettings point a client at a folder inside the bucket. The prefix is deliberately written
+// the sloppy way a user would type it, so these also prove the client canonicalizes at the point of
+// use rather than trusting what was stored.
+const rootedSettings: GeodeSettings = {
+  ...deadlineSettings,
+  prefix: "/vaults/personal/",
+};
+
+// recordingTransport captures the URL of every request dispatched through it and answers each with
+// body, so a test can assert on the key a client actually addressed without touching a network.
+function recordingTransport(body = ""): { transport: Transport; urls: string[] } {
+  const urls: string[] = [];
+  const transport: Transport = async (request) => {
+    urls.push(request.url);
+    return {
+      ok: true,
+      status: 200,
+      body: new TextEncoder().encode(body),
+      header: () => '"etag"',
+    };
+  };
+
+  return { transport, urls };
+}
+
+// listingXml renders a ListObjectsV2 response holding exactly keys, for the prefix stripping tests.
+function listingXml(keys: string[]): string {
+  let contents = "";
+  for (const key of keys) {
+    contents += `<Contents><Key>${key}</Key>`;
+    contents += "<LastModified>2026-07-13T00:00:00.000Z</LastModified><Size>3</Size></Contents>";
+  }
+
+  return `<?xml version="1.0" encoding="UTF-8"?><ListBucketResult>${contents}</ListBucketResult>`;
+}
+
+test("createS3Client: every key is addressed under the configured prefix (#154)", async () => {
+  const { transport, urls } = recordingTransport();
+  const client = createS3Client(rootedSettings, "shh", transport);
+
+  await client.putObject(".geode/manifest.json", new Uint8Array([1]));
+  await client.getObject(".geode/manifest.json");
+  await client.headObject(".geode/blobs/abc");
+  await client.deleteObject(".geode/blobs/abc");
+
+  assert.deepEqual(urls, [
+    "https://s3.example.com/vault/vaults/personal/.geode/manifest.json",
+    "https://s3.example.com/vault/vaults/personal/.geode/manifest.json",
+    "https://s3.example.com/vault/vaults/personal/.geode/blobs/abc",
+    "https://s3.example.com/vault/vaults/personal/.geode/blobs/abc",
+  ]);
+});
+
+test("createS3Client: no prefix leaves every key at the bucket root", async () => {
+  // The default, and what every bucket synced before #154 already holds, so this is the case that
+  // must not move: rooting a client at "" has to produce byte for byte the URL it always did.
+  const { transport, urls } = recordingTransport();
+  const client = createS3Client(deadlineSettings, "shh", transport);
+
+  await client.getObject(".geode/manifest.json");
+
+  assert.deepEqual(urls, ["https://s3.example.com/vault/.geode/manifest.json"]);
+});
+
+test("listObjects: lists under the prefix and hands keys back relative to it (#154)", async () => {
+  // The round trip that matters: sync reads a blob's hash by slicing BLOB_PREFIX off a listed key,
+  // so a key still carrying the bucket prefix would parse as a hash that matches nothing local and
+  // be reported as content the vault can't explain (#109).
+  const listed = listingXml(["vaults/personal/.geode/blobs/aaa"]);
+  const { transport, urls } = recordingTransport(listed);
+  const client = createS3Client(rootedSettings, "shh", transport);
+
+  const result = await client.listObjects(".geode/blobs/");
+
+  assert.ok(result.ok);
+  assert.deepEqual(
+    result.objects.map((object) => object.key),
+    [".geode/blobs/aaa"],
+  );
+  assert.match(urls[0], /prefix=vaults%2Fpersonal%2F\.geode%2Fblobs%2F/);
+});
+
+test("listObjects: no prefix argument still lists only under the client's root", async () => {
+  const { transport, urls } = recordingTransport(listingXml(["vaults/personal/note"]));
+  const client = createS3Client(rootedSettings, "shh", transport);
+
+  const result = await client.listObjects();
+
+  assert.ok(result.ok);
+  assert.deepEqual(
+    result.objects.map((object) => object.key),
+    ["note"],
+  );
+  assert.match(urls[0], /prefix=vaults%2Fpersonal%2F/);
+});
+
+test("listObjects: a key outside the prefix fails the listing, it is never mis-sliced", async () => {
+  // Every key was asked for under the prefix, so one that arrives outside it means the provider
+  // answered a different question. Slicing it anyway would invent a plausible looking key, and a
+  // listing that quietly disagrees with the bucket is what sync reads as remote deletions (#180).
+  const { transport } = recordingTransport(listingXml(["someone-elses/note"]));
+  const client = createS3Client(rootedSettings, "shh", transport);
+
+  const result = await client.listObjects();
+
+  assert.equal(result.ok, false);
+  assert.equal(result.status, "server");
+  assert.match(result.message, /outside the configured prefix/);
+});
+
+test("testConnection: an unusable prefix is refused before any request is signed", async () => {
+  const settings: GeodeSettings = { ...rootedSettings, prefix: "vaults/../escape" };
+
+  const result = await testConnection(settings, "shh", stubTransport);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.message, "Prefix can't use . or .. as a folder");
+});
+
 test("parseListObjectsXml decodes XML entities in object keys", () => {
   const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <ListBucketResult>

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -1,5 +1,11 @@
 import { AwsClient } from "aws4fetch";
-import { endpointFor, type GeodeSettings, regionFor } from "../settings/settings.ts";
+import {
+  endpointFor,
+  type GeodeSettings,
+  normalizePrefix,
+  prefixError,
+  regionFor,
+} from "../settings/settings.ts";
 import { timeoutFor, withDeadline } from "./deadline.ts";
 import { encodeComponent, encodeKey } from "./encode.ts";
 import { messageFor, statusForHttp } from "./errors.ts";
@@ -102,6 +108,11 @@ export type ResultStatus =
 // StorageClient reads, writes, deletes, and lists objects in a bucket. Every method takes and
 // returns plain data, never provider credentials or settings, so a future WebDAV or Dropbox
 // client can satisfy this same shape without changing anything that depends on it.
+//
+// Every key is relative to the client's own root, the configured bucket prefix (#154), and every
+// listed key comes back relative to it too. So nothing above this type knows or cares whether the
+// vault sits at the bucket root or three folders down: sync's key constants stay fixed strings,
+// and a blob's hash reads off a listed key the same way either way.
 export type StorageClient = {
   putObject: (key: string, body: Uint8Array, condition?: PutCondition) => Promise<PutResult>;
   getObject: (key: string, expectedBytes?: number) => Promise<GetResult>;
@@ -132,14 +143,16 @@ export function createS3Client(
     service: "s3",
   });
   const baseUrl = `${endpointFor(settings)}/${settings.bucket}`;
+  const root = normalizePrefix(settings.prefix);
 
   return {
     putObject: (key, body, condition) =>
-      s3PutObject(client, transport, baseUrl, key, body, condition),
-    getObject: (key, expectedBytes) => s3GetObject(client, transport, baseUrl, key, expectedBytes),
-    headObject: (key) => s3HeadObject(client, transport, baseUrl, key),
-    deleteObject: (key) => s3DeleteObject(client, transport, baseUrl, key),
-    listObjects: (prefix) => s3ListObjects(client, transport, baseUrl, prefix),
+      s3PutObject(client, transport, baseUrl, rootedKey(root, key), body, condition),
+    getObject: (key, expectedBytes) =>
+      s3GetObject(client, transport, baseUrl, rootedKey(root, key), expectedBytes),
+    headObject: (key) => s3HeadObject(client, transport, baseUrl, rootedKey(root, key)),
+    deleteObject: (key) => s3DeleteObject(client, transport, baseUrl, rootedKey(root, key)),
+    listObjects: (prefix) => rootedList(client, transport, baseUrl, root, prefix),
   };
 }
 
@@ -223,6 +236,10 @@ export async function testConnection(
   if (missing !== "") {
     return { ok: false, status: "auth", message: `Fill in ${missing} first` };
   }
+  const badPrefix = prefixError(settings.prefix);
+  if (badPrefix !== "") {
+    return { ok: false, status: "client", message: badPrefix };
+  }
 
   const client = new AwsClient({
     accessKeyId: settings.accessKeyId,
@@ -302,6 +319,59 @@ function missingFieldFor(settings: GeodeSettings, secretAccessKey: string): stri
   }
 
   return "";
+}
+
+// rootedKey returns the bucket key an object actually lives at for a client rooted at root. Doing
+// this here, rather than threading a prefix through sync's key constants, is what keeps the whole
+// layer above unaware a prefix exists at all.
+function rootedKey(root: string, key: string): string {
+  if (root === "") {
+    return key;
+  }
+
+  return `${root}/${key}`;
+}
+
+// rootedList lists under the client's root and hands the keys back relative to it, the mirror of
+// rootedKey, so a caller reading a blob's hash off a listed key gets the same string whether or
+// not a prefix is configured. Every key is asked for under the root, so one that comes back
+// outside it is a provider answering a question it wasn't asked; that fails the listing rather
+// than being mis-sliced into a plausible looking key (#180), since a listing silently short of
+// the truth is what sync reads as remote deletions.
+async function rootedList(
+  client: AwsClient,
+  transport: Transport,
+  baseUrl: string,
+  root: string,
+  prefix: string | undefined,
+): Promise<ListResult> {
+  if (root === "") {
+    return s3ListObjects(client, transport, baseUrl, prefix);
+  }
+
+  let under = `${root}/`;
+  if (prefix !== undefined) {
+    under += prefix;
+  }
+  const listed = await s3ListObjects(client, transport, baseUrl, under);
+  if (!listed.ok) {
+    return listed;
+  }
+
+  const objects: ObjectMeta[] = [];
+  for (const object of listed.objects) {
+    if (!object.key.startsWith(`${root}/`)) {
+      return {
+        ok: false,
+        status: "server",
+        message: `Storage listed "${object.key}", which is outside the configured prefix`,
+        objects: [],
+      };
+    }
+    objects.push({ ...object, key: object.key.slice(root.length + 1) });
+  }
+
+  return { ok: true, status: "ok", message: "", objects };
 }
 
 // s3DeleteObject removes key from the bucket.

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -130,12 +130,26 @@ export type StorageClient = {
 export type Transport = (request: Request) => Promise<HttpResponse>;
 
 // createS3Client returns a StorageClient backed by the S3 compatible endpoint in settings, sending
-// every request through the given transport.
+// every request through the given transport. A prefix the client cannot address safely is refused
+// here rather than anywhere above, since this is the one place every request to a provider is built
+// and so the only guard no future caller (the CLI, the API, MCP) can be written without.
 export function createS3Client(
   settings: GeodeSettings,
   secretAccessKey: string,
   transport: Transport,
 ): StorageClient {
+  // Settings arrive here straight from data.json, which a hand edit, an older build, or a synced
+  // .obsidian/ folder can all put an unusable prefix into without the settings tab ever seeing it,
+  // so validating only where a user types is validating nothing. Dropping a bad prefix would sync
+  // the vault to the bucket root, and honouring one is worse still: the URL a request is signed
+  // against collapses relative segments itself, so a leading ".." leaves the bucket entirely and
+  // addresses a different one. Refusing every operation is the only outcome that cannot quietly
+  // read or write a vault somewhere it was never meant to go.
+  const badPrefix = prefixError(settings.prefix);
+  if (badPrefix !== "") {
+    return refusingClient(badPrefix);
+  }
+
   const client = new AwsClient({
     accessKeyId: settings.accessKeyId,
     secretAccessKey,
@@ -319,6 +333,20 @@ function missingFieldFor(settings: GeodeSettings, secretAccessKey: string): stri
   }
 
   return "";
+}
+
+// refusingClient returns a StorageClient that fails every operation with the same message, for a
+// configuration no request built from it could be trusted to address. The status is "client"
+// because nothing about the request was ever valid, so a retry cannot help and only correcting the
+// setting can; sync surfaces the message as-is, naming the setting at fault.
+function refusingClient(message: string): StorageClient {
+  return {
+    putObject: async () => ({ ok: false, status: "client", message }),
+    getObject: async () => ({ ok: false, status: "client", message, body: null, etag: null }),
+    headObject: async () => ({ ok: false, status: "client", message, etag: null }),
+    deleteObject: async () => ({ ok: false, status: "client", message }),
+    listObjects: async () => ({ ok: false, status: "client", message, objects: [] }),
+  };
 }
 
 // rootedKey returns the bucket key an object actually lives at for a client rooted at root. Doing

--- a/src/sync/sync.itest.ts
+++ b/src/sync/sync.itest.ts
@@ -54,8 +54,10 @@ type Device = {
 };
 
 // newDevice creates a fresh temp vault with the plugin data folder pre-created (as Obsidian would
-// have), wired to the real vault/obsidian.ts code over a node:fs backed vault.
-function newDevice(): Device {
+// have), wired to the real vault/obsidian.ts code over a node:fs backed vault. settings only ever
+// differs for the prefix scenario, which needs a state store fingerprinted against the same target
+// its sync actually writes to.
+function newDevice(settings: GeodeSettings = liveSettings): Device {
   const root = mkdtempSync(join(tmpdir(), "geode-device-"));
   mkdirSync(join(root, ".obsidian", "plugins", "geode"), { recursive: true });
   const { vault, adapter } = nodeVault(root);
@@ -63,7 +65,7 @@ function newDevice(): Device {
     root,
     reader: createObsidianReader(vault),
     writer: createObsidianLocalWriter(adapter),
-    stateStore: createObsidianStore(adapter, STATE_PATH, liveSettings),
+    stateStore: createObsidianStore(adapter, STATE_PATH, settings),
   };
 }
 
@@ -99,10 +101,11 @@ async function deleteLocal(d: Device, path: string): Promise<void> {
 
 // sync runs one pass for a device, mirroring the plugin's runSync spine: read previous state, run
 // syncOnce, persist the new snapshot whenever one comes back (a full success, or a failed pass
-// that still made progress).
-async function sync(d: Device, now = Date.now()): Promise<SyncOutcome> {
+// that still made progress). client only ever differs for the prefix scenario, which drives the
+// same code against a client rooted inside the bucket rather than at it.
+async function sync(d: Device, now = Date.now(), client = storage): Promise<SyncOutcome> {
   const previous = await d.stateStore.read();
-  const outcome = await syncOnce(previous, d.reader, d.writer, storage, now);
+  const outcome = await syncOnce(previous, d.reader, d.writer, client, now);
   if (outcome.ok) {
     await d.stateStore.write(outcome.snapshot);
     return outcome;
@@ -491,6 +494,40 @@ test("sync: an edit on one device and a delete on another preserves the edit as 
 
     assert.equal((await sync(b)).ok, true);
     assert.equal(await readLocal(b, copyPath), "A kept editing");
+  } finally {
+    cleanup(a, b);
+  }
+});
+
+test("sync: two devices converge inside a bucket prefix (#154)", async () => {
+  // The whole spine driven against a client rooted inside the bucket: manifest, sentinel and blobs
+  // all land under the prefix, the bucket root stays empty, and the devices converge exactly as
+  // they do at the root. Nothing above the storage client knows the prefix exists, so this is what
+  // proves that indifference is real rather than merely intended.
+  await resetRemote();
+  const prefixed: GeodeSettings = { ...liveSettings, prefix: "vaults/personal" };
+  const prefixedStorage = createS3Client(prefixed, SECRET, fetchTransport);
+  const a = newDevice(prefixed);
+  const b = newDevice(prefixed);
+  const now = Date.now();
+
+  try {
+    await writeLocal(a, "prefixed/a.md", "from A");
+    assert.equal((await sync(a, now, prefixedStorage)).ok, true);
+
+    assert.equal((await sync(b, now, prefixedStorage)).ok, true);
+    assert.equal(await readLocal(b, "prefixed/a.md"), "from A");
+
+    await writeLocal(b, "prefixed/b.md", "from B side");
+    assert.equal((await sync(b, now, prefixedStorage)).ok, true);
+    assert.equal((await sync(a, now, prefixedStorage)).ok, true);
+    assert.equal(await readLocal(a, "prefixed/b.md"), "from B side");
+
+    // Read through the unprefixed client to see where the bytes really are.
+    assert.equal((await storage.getObject(`vaults/personal/${MANIFEST_KEY}`)).ok, true);
+    assert.equal((await storage.getObject(MANIFEST_KEY)).status, "not_found");
+    const hash = await hashOf("from A");
+    assert.equal((await storage.getObject(`vaults/personal/${blobKeyFor(hash)}`)).ok, true);
   } finally {
     cleanup(a, b);
   }

--- a/src/vault/obsidian.test.ts
+++ b/src/vault/obsidian.test.ts
@@ -430,6 +430,32 @@ test("createObsidianStore: a fingerprint mismatch reads back as empty", async ()
   assert.deepEqual(await store2.read(), { files: [] });
 });
 
+test("createObsidianStore: repointing at a bucket prefix reads back as empty (#154)", async () => {
+  // A prefix is where the vault lives, so moving it lands on a folder with its own manifest and its
+  // own sentinel. Carrying the old ancestor across would diff this vault against a stranger's.
+  const adapter = fakeAdapter();
+  const store1 = createObsidianStore(adapter, STATE_PATH, DEFAULT_SETTINGS);
+  const snapshot: Snapshot = { files: [{ path: "a.md", size: 1, mtime: 2, hash: "h" }] };
+
+  await store1.write(snapshot);
+
+  const prefixed = { ...DEFAULT_SETTINGS, prefix: "vaults/personal" };
+  const store2 = createObsidianStore(adapter, STATE_PATH, prefixed);
+
+  assert.deepEqual(await store2.read(), { files: [] });
+});
+
+test("fingerprintSettings: a prefix only written differently is the same target (#154)", () => {
+  // The prefix is stored exactly as typed, so the same folder can be spelled several ways. Treating
+  // those as different targets would throw away a good ancestor and force a full re-hash over a
+  // trailing slash.
+  const typed = { ...DEFAULT_SETTINGS, prefix: "/vaults//personal/" };
+  const tidy = { ...DEFAULT_SETTINGS, prefix: "vaults/personal" };
+
+  assert.equal(fingerprintSettings(typed), fingerprintSettings(tidy));
+  assert.notEqual(fingerprintSettings(tidy), fingerprintSettings(DEFAULT_SETTINGS));
+});
+
 test("createObsidianStore: rotating credentials keeps state, it does not change the target", async () => {
   const adapter = fakeAdapter();
   const store1 = createObsidianStore(adapter, STATE_PATH, DEFAULT_SETTINGS);

--- a/src/vault/vault.ts
+++ b/src/vault/vault.ts
@@ -1,4 +1,9 @@
-import { endpointFor, type GeodeSettings, regionFor } from "../settings/settings.ts";
+import {
+  endpointFor,
+  type GeodeSettings,
+  normalizePrefix,
+  regionFor,
+} from "../settings/settings.ts";
 
 // SNAPSHOT_VERSION is the format version stamped into every serialized snapshot, remote manifest
 // and local state.json alike, so a future format change (encryption, chunked upload) has
@@ -264,10 +269,12 @@ export function encodeSnapshot(snapshot: Snapshot): string {
 
 // fingerprintSettings returns a stable string identifying the sync target, so we can detect when
 // that target changes and invalidate old state (#89). It covers only where the vault lives, the
-// fields normalized through endpointFor/regionFor to match what a connection actually uses.
-// Credentials (accessKeyId, secretId) are deliberately excluded: they authorize access to a
-// target, they do not identify one, so rotating a key must not invalidate state and force a full
-// re-hash. A genuine target change always moves one of the fields below.
+// fields normalized through endpointFor/regionFor/normalizePrefix to match what a connection
+// actually uses. Credentials (accessKeyId, secretId) are deliberately excluded: they authorize
+// access to a target, they do not identify one, so rotating a key must not invalidate state and
+// force a full re-hash. A genuine target change always moves one of the fields below, and a prefix
+// is one: repointing at another folder in the same bucket lands somewhere with its own manifest and
+// its own sentinel, so carrying the old state across would diff the vault against a stranger.
 export function fingerprintSettings(settings: GeodeSettings): string {
   return JSON.stringify({
     provider: settings.provider,
@@ -275,6 +282,7 @@ export function fingerprintSettings(settings: GeodeSettings): string {
     endpoint: endpointFor(settings),
     region: regionFor(settings),
     bucket: settings.bucket,
+    prefix: normalizePrefix(settings.prefix),
   });
 }
 


### PR DESCRIPTION
Resolves [#154](https://github.com/8thpark/geode/issues/154)

## Problem

Geode always synced to the root of the configured bucket, so a bucket could only ever hold one vault and had to be dedicated to Geode entirely; anyone with an existing bucket, or more than one vault, had nowhere to put them

## Why

- One bucket per vault is a real cost and a real annoyance for anyone self hosting, and every comparable tool lets you name a folder
- Applying the prefix in the storage client alone keeps the entire sync layer unaware it exists, so no future key has to remember to be prefixed and no test above that line changed
- Listing has to strip the prefix back off, or a blob's hash read from a listed key matches nothing local and a first sync reports the whole bucket as content it cannot explain
- A listed key arriving outside the prefix fails the listing rather than being trimmed into a plausible looking one, since a listing that quietly disagrees with the bucket is what sync reads as remote deletions
- Treating the prefix as part of the target is what stops a moved prefix diffing your vault against whatever already lives in the new folder
- Relative segments are refused rather than resolved because the URL a request is signed against collapses them itself, so a leading `..` leaves the bucket entirely and addresses a different one
- Validating only where a user types validates nothing, since settings reach the client straight from `data.json` where a hand edit, an older build, or a synced `.obsidian/` folder can all put a value no user ever entered

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an optional bucket prefix so multiple vaults can sync into isolated folders within one S3 bucket.
- Adds prefix configuration, normalization, validation, and settings UI support.
- Roots all storage operations beneath the configured prefix while returning listed keys relative to that root.
- Includes the prefix in sync-target fingerprints so changing folders invalidates stale local state.
- Adds unit and integration coverage for prefix isolation, malformed-prefix refusal, and prefixed synchronization.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The previously reported malformed-prefix path is now guarded before request construction in both production client creation and connection testing, and no blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/storage/storage.ts | Adds prefix validation at the storage boundary, roots object operations and listings, and safely refuses malformed persisted prefixes before request construction. |
| src/settings/settings.ts | Adds the prefix setting with canonicalization and validation helpers while preserving invalid loaded values for explicit correction rather than silently changing targets. |
| src/settings/tab.ts | Adds the Prefix field and blocks saving malformed values through the existing connection-status workflow. |
| src/main.ts | Adds an early malformed-prefix check that surfaces a specific sync error before storage probing. |
| src/vault/vault.ts | Incorporates the canonical prefix into target fingerprinting so moving a vault to another folder discards incompatible prior state. |
| src/storage/storage.test.ts | Covers rooted operations, relative listing results, isolation enforcement, and refusal of malformed prefixes before transport dispatch. |
| src/storage/storage.itest.ts | Verifies prefixed object operations and isolation against a real S3-compatible service. |
| src/sync/sync.itest.ts | Verifies end-to-end convergence within a bucket prefix without placing sync metadata at the bucket root. |

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into revett/fix/154"](https://github.com/8thpark/geode/commit/99f67be6b870527868c2385cab3f3ae3c53e41d2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49838091)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Settings module](https://app.greptile.com/8thpark/-/custom-context/knowledge-base/8thpark/geode/-/docs/settings-module.md)
- Knowledge Base — [Storage module](https://app.greptile.com/8thpark/-/custom-context/knowledge-base/8thpark/geode/-/docs/storage-module.md)
- Knowledge Base — [Plugin entrypoint (src/main.ts)](https://app.greptile.com/8thpark/-/custom-context/knowledge-base/8thpark/geode/-/docs/plugin-entrypoint.md)
- Knowledge Base — [Vault module](https://app.greptile.com/8thpark/-/custom-context/knowledge-base/8thpark/geode/-/docs/vault-module.md)
</details>

<!-- /greptile_comment -->