### PR TITLE
Security → Clear the fast-uri host advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,12 +13,12 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.5",
-        "@secretlint/secretlint-rule-preset-recommend": "^13.0.4",
+        "@secretlint/secretlint-rule-preset-recommend": "13.x.x",
         "@types/node": "24.x.x",
         "concurrently": "10.x.x",
         "esbuild": "0.x.x",
         "obsidian": "1.x.x",
-        "secretlint": "^13.0.4",
+        "secretlint": "13.x.x",
         "typescript": "7.x.x"
       }
     },
@@ -1701,9 +1701,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Resolves [GHSA-7p8r-x3mc-p8w7](https://github.com/8thpark/geode/security/code-scanning/21)

## Problem

Scorecard's supply chain check reports one open advisory against `fast-uri`, holding the OpenSSF score the README links to at 9

## Changes

- Upgrade `fast-uri` from `3.1.4` to `3.1.5`, the first release carrying the fix
- Correct two stale dependency range strings the lockfile had recorded for `secretlint`, which `npm update` reconciled against what `package.json` already said

## Why

- `fast-uri` reads a backslash authority introducer as part of the path where Node's own URL parser reads it as a host, so anything checking a URL's host through one and then fetching it through the other can be sent somewhere it never approved
- The advisory offers no workaround, only the upgrade, and `ajv` accepts the patched release within its existing range, so nothing above it had to move
- Worth being clear that this is hygiene rather than exposure: the package is a development dependency four levels beneath `secretlint`, is absent from the built plugin, and is used by `ajv` to resolve schema identifiers rather than to make any network decision

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR updates the development-only fast-uri lockfile resolution from 3.1.4 to 3.1.5 to address the host-parsing advisory.
- Synchronizes the lockfile’s root secretlint ranges with package.json.
- Leaves the surrounding dependency graph and resolved secretlint versions unchanged.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable issues identified.

The patched fast-uri release remains within ajv’s accepted range, and the updated secretlint metadata matches package.json, preserving clean-install compatibility.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| package-lock.json | Updates fast-uri to the patched compatible release and reconciles root secretlint range metadata without introducing a lockfile inconsistency. |

<sub>Reviews (1): Last reviewed commit: ["Upgrade dep"](https://github.com/8thpark/geode/commit/2eb080ab17562e81f6fe1aa2d0348042d3698155) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49984656)</sub>

<!-- /greptile_comment -->