### PR TITLE
[#184] Storage → Reserve an encryption envelope in the object format

### DIFF
--- a/docs/object-format.md
+++ b/docs/object-format.md
@@ -1,0 +1,148 @@
+<!-- omit in toc -->
+# Object Format
+
+How **Geode** lays out a vault in your bucket, and which parts of that layout are fixed now so
+encryption can arrive later without moving anyone's data.
+
+- [Bucket Layout](#bucket-layout)
+- [The Envelope](#the-envelope)
+- [Suites](#suites)
+- [Versions and Refusal](#versions-and-refusal)
+- [The Manifest](#the-manifest)
+- [What Encryption Changes](#what-encryption-changes)
+- [What Is Deliberately Not Reserved](#what-is-deliberately-not-reserved)
+
+## Bucket Layout
+
+Everything Geode writes lives under a single reserved prefix, so nothing it owns can ever be
+mistaken for a vault file, even if your vault happens to contain a note at a colliding path. If you
+configure a bucket prefix, all of this sits underneath it.
+
+| Key                      | What it holds                                                     |
+| ------------------------ | ----------------------------------------------------------------- |
+| `.geode/manifest.json`   | The last synced snapshot: every path, and what it points at       |
+| `.geode/sentinel.json`   | A marker written once, proving this bucket has been synced before |
+| `.geode/blobs/<address>` | One file's content, addressed by its content rather than its path |
+
+One other key can appear under the prefix: `.geode/connection-probe-<uuid>`, written and deleted by
+the settings tab's connection test to prove the provider honours conditional writes. It holds no
+vault data, is never read back as vault data, and is not part of the format below.
+
+A blob is keyed by an address derived from its own bytes, not by the vault path it belongs to. That
+is what makes a rename free (the manifest points the new path at the same key), a duplicate
+attachment cost one copy, and a delete non destructive: the manifest simply stops naming the
+address, and the bytes stay recoverable for as long as any retained manifest still names it.
+
+## The Envelope
+
+Every object above is stored inside the same six byte envelope. The bucket is uniformly self
+describing: a reader can tell what an object is, and whether it can read it at all, before it parses
+a single byte of the payload.
+
+| Offset | Bytes | Field   | Value today                    |
+| ------ | ----- | ------- | ------------------------------ |
+| 0      | 4     | Magic   | `GEOD` (`0x47 0x45 0x4F 0x44`) |
+| 4      | 1     | Version | `0x01`                         |
+| 5      | 1     | Suite   | `0x00`, plaintext              |
+| 6      | rest  | Payload | The object's own bytes         |
+
+The payload runs to the end of the object; S3 already reports where that is, so there is no length
+field to keep in step with it.
+
+Version and suite are separate bytes because they change for different reasons. Version describes
+the header layout itself. Suite describes what was done to the payload. A new cipher must not have
+to burn an envelope version, and a new header field must not invalidate every blob in the bucket.
+
+The envelope is also why the bytes of an object are never read leniently. A body without a valid
+header is refused rather than treated as a bare payload, because the moment a version 2 exists, an
+unversioned object and a version 1 object would be indistinguishable.
+
+## Suites
+
+| Suite  | Meaning                                              | Status                 |
+| ------ | ---------------------------------------------------- | ---------------------- |
+| `0x00` | Plaintext, the payload exactly as it was handed over | Written and read today |
+| Others | Reserved                                             | Encryption, 0.3.0      |
+
+The sentinel is expected to stay plaintext permanently. It is the bootstrap record, read before a
+device knows anything else about the bucket, and it holds no vault content: an identifier and a
+timestamp. When encryption lands it is also the natural home for the key derivation salt and a key
+check value, both of which have to be readable before any key exists to read them with.
+
+## Versions and Refusal
+
+Two version markers exist, and both take the same posture: a version this build does not recognise
+is refused outright, reported as needing a different build of Geode, never read as far as possible
+and never quietly repaired.
+
+- The **envelope version**, in the header of every object, covering the framing.
+- The **snapshot version**, inside the manifest's JSON, covering the shape of the manifest itself.
+  The sentinel carries the same marker.
+
+**From `0.1.0` onwards, a bucket is migrated forward, never abandoned.** Any format change after
+that release reads what is already there and upgrades it in place; asking a user to start a fresh
+bucket is not an option once real vaults are in the field. A newer format is still refused rather
+than guessed at, since a build cannot migrate forward from a version that did not exist when it
+shipped, and the fix there is updating the plugin.
+
+The versions before `0.1.0` are the exception, and this is the last of them. Versions 1, 2, and 3
+were all settled while the only vaults in a bucket were the project's own, so each asked for a fresh
+bucket rather than carrying migration code for data nobody had. That window closes at `0.1.0`.
+
+## The Manifest
+
+Each entry in the manifest names one vault path and four things about it:
+
+| Field   | Meaning                                                 |
+| ------- | ------------------------------------------------------- |
+| `size`  | The file's size in bytes, as last seen                  |
+| `mtime` | The file's modification time, as last seen              |
+| `hash`  | The SHA-256 of the file's own bytes                     |
+| `blob`  | The address its content lives at, under `.geode/blobs/` |
+
+`hash` and `blob` hold the same string in an unencrypted vault, and they are still separate fields,
+because they answer different questions. `hash` is what the content **is**: how a diff notices an
+edit, and what a pulled body is checked against before it lands on disk. `blob` is **where** those
+bytes are: an address, not a claim about content.
+
+They stop being the same string at `0.3.0`, which is why the manifest records the address per entry
+rather than leaving every reader to derive it. A device pulling a file it has never seen has no
+plaintext to derive an address from, and, once addressing is keyed, no way to compute one without
+the vault key. So the address has to be written down next to the digest rather than instead of it.
+
+An address is validated as a single safe key segment when a manifest is read, since a manifest is
+untrusted input: anyone who can write to the bucket can shape it, and an address becomes the last
+segment of a bucket key.
+
+## What Encryption Changes
+
+`0.3.0` turns encryption on. The format decisions it depends on are already made, and the shape of
+the bucket does not move:
+
+1. **Blobs and the manifest gain a new suite.** The payload becomes ciphertext; the envelope around
+   it is unchanged, so a mixed bucket stays readable object by object rather than all or nothing.
+2. **Blob addressing becomes a keyed hash.** An address becomes an HMAC of the plaintext under a
+   subkey derived from the vault key, rather than the plaintext's bare SHA-256.
+3. **Nothing else has to move.** Keys stay fixed length, the manifest already has a field to record
+   an address in, and every object already says which suite it is.
+
+The keyed hash is the decision most worth stating plainly. Addressing a blob by the plain SHA-256 of
+its plaintext would leak a hash of that plaintext to anyone who can list the bucket, letting them
+test whether a file they already hold is in your vault. That is a real weakness for a project whose
+whole premise is storage you do not have to fully trust. A keyed hash preserves deduplication within
+a vault, keeps addresses fixed length, and removes the confirmation attack, at the cost of no longer
+deduplicating across separate vaults, which was never a property worth having anyway.
+
+Turning encryption on for a vault that already synced in plaintext re-uploads its content, since
+plaintext blobs cannot become ciphertext in place. That is unavoidable, and it is a one time cost
+paid by choice. What the envelope buys is everything else: no discriminator bolted onto a format
+with no room for one, and no forced re-upload for a vault that starts out encrypted.
+
+## What Is Deliberately Not Reserved
+
+Content addressing removed the hard half of encrypted storage before it was ever built. There are no
+plaintext paths in the bucket to hide, and every key is the same length, so directory identifier
+machinery of the kind Cryptomator needs is unnecessary here.
+
+Nothing is reserved for chunking, compression, or per file keys. Each of those would change the
+payload rather than the framing, which is exactly what a suite byte is for.

--- a/src/storage/envelope.test.ts
+++ b/src/storage/envelope.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { type DecodedObject, ENVELOPE_VERSION, unwrapObject, wrapObject } from "./envelope.ts";
+
+// bodyOf builds a raw bucket body from a header and a payload, for the cases a well formed
+// wrapObject call cannot produce: a foreign object, a version this build doesn't write, a suite it
+// doesn't know.
+function bodyOf(header: number[], payload: string): Uint8Array {
+  const bytes = new TextEncoder().encode(payload);
+  const body = new Uint8Array(header.length + bytes.length);
+  body.set(header, 0);
+  body.set(bytes, header.length);
+
+  return body;
+}
+
+test("wrapObject: the header is the magic, the version, and the suite, then the payload", () => {
+  const body = wrapObject(new TextEncoder().encode("hello"));
+
+  assert.deepEqual([...body.slice(0, 4)], [0x47, 0x45, 0x4f, 0x44]);
+  assert.equal(body[4], ENVELOPE_VERSION);
+  assert.equal(body[5], 0x00);
+  assert.equal(new TextDecoder().decode(body.slice(6)), "hello");
+});
+
+test("wrapObject: round-trips through unwrapObject, payload byte for byte", () => {
+  const cases: string[] = ["", "hello", '{"version":3,"files":[]}', "café 😀", "a".repeat(10_000)];
+
+  for (const payload of cases) {
+    const bytes = new TextEncoder().encode(payload);
+
+    const opened = unwrapObject(wrapObject(bytes));
+
+    assert.ok(opened.ok, payload.slice(0, 20));
+    assert.deepEqual(opened.ok && [...opened.payload], [...bytes], payload.slice(0, 20));
+  }
+});
+
+test("unwrapObject: an unknown version or suite needs a newer build, anything else is corrupt", () => {
+  const cases: { name: string; body: Uint8Array; want: DecodedObject }[] = [
+    {
+      // The bytes a build before the envelope existed would have written, and the bytes any other
+      // tool would: read leniently as a bare payload, they would be indistinguishable from a
+      // version 1 object the moment a version 2 exists.
+      name: "a payload with no envelope at all",
+      body: new TextEncoder().encode("just some bytes"),
+      want: { ok: false, reason: "corrupt" },
+    },
+    {
+      name: "a body too short to hold a header",
+      body: bodyOf([0x47, 0x45, 0x4f], ""),
+      want: { ok: false, reason: "corrupt" },
+    },
+    {
+      name: "a body whose magic doesn't match",
+      body: bodyOf([0x47, 0x45, 0x4f, 0x45, 0x01, 0x00], "hello"),
+      want: { ok: false, reason: "corrupt" },
+    },
+    {
+      // A newer geode wrote this bucket. The fix is updating the plugin, never starting over, so
+      // the reason must be distinguishable from damage.
+      name: "an envelope version from a newer build",
+      body: bodyOf([0x47, 0x45, 0x4f, 0x44, 0x02, 0x00], "hello"),
+      want: { ok: false, reason: "unsupportedVersion" },
+    },
+    {
+      // The reservation this whole envelope exists for (#184): the vault is encrypted and this
+      // build has no idea how to read it, which it must say rather than hand ciphertext on as
+      // though it were content.
+      name: "a suite this build does not know",
+      body: bodyOf([0x47, 0x45, 0x4f, 0x44, 0x01, 0x01], "ciphertext"),
+      want: { ok: false, reason: "unsupportedSuite" },
+    },
+    {
+      name: "an empty body",
+      body: new Uint8Array(0),
+      want: { ok: false, reason: "corrupt" },
+    },
+    {
+      name: "a header with nothing after it",
+      body: bodyOf([0x47, 0x45, 0x4f, 0x44, 0x01, 0x00], ""),
+      want: { ok: true, payload: new Uint8Array(0) },
+    },
+  ];
+
+  for (const { name, body, want } of cases) {
+    assert.deepEqual(unwrapObject(body), want, name);
+  }
+});

--- a/src/storage/envelope.ts
+++ b/src/storage/envelope.ts
@@ -1,0 +1,82 @@
+// ENVELOPE_VERSION is the version stamped into the header of every object geode writes to the
+// bucket, and the only version this build will read back (#184). It describes the header layout
+// itself, not what the payload is: a new field, a different header size, or a different way of
+// framing the payload moves this number, while a new way of protecting the payload moves the suite
+// byte instead. The two change for different reasons and at different times, so they are separate
+// bytes rather than one number that has to mean both.
+//
+// It is deliberately not SNAPSHOT_VERSION. That version describes the shape of the JSON inside the
+// manifest, which is a different question from how the bytes around it are framed: a manifest that
+// gains a field must not invalidate every blob in the bucket, and a change to the framing must not
+// pretend the manifest's shape moved. The posture is the same though, and that is what #184 asked
+// to reuse: a version this build does not know is refused as "needs a different build of geode",
+// never read as far as possible, never silently repaired.
+export const ENVELOPE_VERSION = 1;
+
+// HEADER_BYTES is the fixed width of the header wrapObject writes: four magic bytes, one version
+// byte, one suite byte. Fixed rather than length prefixed on purpose; the payload runs to the end
+// of the object, and S3 already tells us where that is.
+const HEADER_BYTES = 6;
+
+// MAGIC is the four byte tag ("GEOD") every geode object starts with, so a body that is not one is
+// recognised as foreign rather than parsed as whatever the caller was hoping for. It costs four
+// bytes per object and buys the difference between "this bucket holds something we did not write"
+// and a confusing failure three layers up.
+const MAGIC = [0x47, 0x45, 0x4f, 0x44];
+
+// SUITE_PLAINTEXT is the suite byte for a payload stored exactly as it was handed over: no
+// encryption, no compression, no framing of its own. It is the only suite this build writes or
+// reads, and reserving the byte now is the whole point of the envelope. Encryption arrives at
+// 0.3.0 as a second suite value, met by objects that already say which one they are, rather than
+// as a discriminator bolted onto a format that never had room for one; see docs/object-format.md.
+const SUITE_PLAINTEXT = 0x00;
+
+// DecodedObject is the result of opening an object's envelope: the payload inside it, or why this
+// build cannot read it. "corrupt" means the bytes are not a geode object at all (truncated, or
+// never had a header); the two unsupported reasons mean they are, and a newer build would know
+// what to do with them.
+export type DecodedObject =
+  | { ok: true; payload: Uint8Array }
+  | { ok: false; reason: "corrupt" | "unsupportedSuite" | "unsupportedVersion" };
+
+// unwrapObject reads the envelope off a bucket object and returns the payload inside it. Every
+// object geode writes carries one, so a body without a valid header is never unwrapped "leniently"
+// as a bare payload: doing so would make an unversioned object indistinguishable from a version 1
+// one the moment a version 2 exists, which is exactly the ambiguity the header removes.
+//
+// The payload is a view over the caller's bytes rather than a copy. A blob can be a whole
+// attachment, and copying every one of them to strip six bytes would double the peak memory of
+// every pull for nothing; the body is read once and dropped, so nothing later mutates what the
+// view sees.
+export function unwrapObject(body: Uint8Array): DecodedObject {
+  if (body.length < HEADER_BYTES) {
+    return { ok: false, reason: "corrupt" };
+  }
+  for (let i = 0; i < MAGIC.length; i++) {
+    if (body[i] !== MAGIC[i]) {
+      return { ok: false, reason: "corrupt" };
+    }
+  }
+  if (body[MAGIC.length] !== ENVELOPE_VERSION) {
+    return { ok: false, reason: "unsupportedVersion" };
+  }
+  if (body[MAGIC.length + 1] !== SUITE_PLAINTEXT) {
+    return { ok: false, reason: "unsupportedSuite" };
+  }
+
+  return { ok: true, payload: body.subarray(HEADER_BYTES) };
+}
+
+// wrapObject returns the bytes to store for payload: the envelope header followed by the payload
+// itself. Every object geode owns goes through here, blobs and the manifest and the sentinel
+// alike, so the bucket is uniformly self describing and a reader never has to know which kind of
+// object it is holding before it can tell whether it can read it at all.
+export function wrapObject(payload: Uint8Array): Uint8Array {
+  const body = new Uint8Array(HEADER_BYTES + payload.length);
+  body.set(MAGIC, 0);
+  body[MAGIC.length] = ENVELOPE_VERSION;
+  body[MAGIC.length + 1] = SUITE_PLAINTEXT;
+  body.set(payload, HEADER_BYTES);
+
+  return body;
+}

--- a/src/sync/execute.test.ts
+++ b/src/sync/execute.test.ts
@@ -2,7 +2,15 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import { hashBytes, type Reader } from "../vault/vault.ts";
 import { executeSyncPlan } from "./execute.ts";
-import { empty, fakeLocalWriter, fakeReader, fakeStorage, file, snapshot } from "./fake.ts";
+import {
+  empty,
+  fakeLocalWriter,
+  fakeReader,
+  fakeStorage,
+  file,
+  snapshot,
+  wrapped,
+} from "./fake.ts";
 import { blobKeyFor, conflictCopyPath, MANIFEST_KEY, type SyncAction } from "./plan.ts";
 
 // hashOf returns the real content hash of text, for building local snapshots whose entries
@@ -28,9 +36,9 @@ test("executeSyncPlan: push reads the local file and puts its blob remotely", as
 
   const hash = await hashOf("hello");
   assert.deepEqual(failures, []);
-  assert.equal(objects.get(blobKeyFor(hash)), "hello");
+  assert.equal(objects.get(blobKeyFor(hash)), wrapped("hello"));
   assert.equal(files.size, 0);
-  assert.deepEqual(pushedFiles, [{ path: "a.md", size: 5, mtime: 1, hash }]);
+  assert.deepEqual(pushedFiles, [{ path: "a.md", size: 5, mtime: 1, hash, blob: hash }]);
 });
 
 test("executeSyncPlan: a push records the bytes it actually uploaded, not the pre push snapshot's hash", async () => {
@@ -54,9 +62,9 @@ test("executeSyncPlan: a push records the bytes it actually uploaded, not the pr
 
   const hash = await hashOf("edited after snapshot");
   assert.deepEqual(failures, []);
-  assert.equal(objects.get(blobKeyFor(hash)), "edited after snapshot");
+  assert.equal(objects.get(blobKeyFor(hash)), wrapped("edited after snapshot"));
   assert.deepEqual(pushedFiles, [
-    { path: "a.md", size: "edited after snapshot".length, mtime: 1, hash },
+    { path: "a.md", size: "edited after snapshot".length, mtime: 1, hash, blob: hash },
   ]);
 });
 
@@ -66,7 +74,7 @@ test("executeSyncPlan: pushing content already stored under another path costs a
   const reader = fakeReader({ "b.md": "hello" });
   const { writer } = fakeLocalWriter();
   const hash = await hashOf("hello");
-  const { storage, objects } = fakeStorage({ [blobKeyFor(hash)]: "hello" });
+  const { storage, objects } = fakeStorage({ [blobKeyFor(hash)]: wrapped("hello") });
   let puts = 0;
   storage.putObject = async () => {
     puts++;
@@ -85,14 +93,14 @@ test("executeSyncPlan: pushing content already stored under another path costs a
   assert.deepEqual(failures, []);
   assert.equal(puts, 0);
   assert.equal(objects.size, 1);
-  assert.deepEqual(pushedFiles, [{ path: "b.md", size: 5, mtime: 1, hash }]);
+  assert.deepEqual(pushedFiles, [{ path: "b.md", size: 5, mtime: 1, hash, blob: hash }]);
 });
 
 test("executeSyncPlan: pushDelete completes without touching the bucket, and the blob survives", async () => {
   const reader = fakeReader({});
   const { writer } = fakeLocalWriter();
   const hash = await hashOf("hello");
-  const { storage, objects } = fakeStorage({ [blobKeyFor(hash)]: "hello" });
+  const { storage, objects } = fakeStorage({ [blobKeyFor(hash)]: wrapped("hello") });
   const remote = snapshot(file("a.md", hash));
 
   const { completed, failures } = await executeSyncPlan(
@@ -109,7 +117,7 @@ test("executeSyncPlan: pushDelete completes without touching the bucket, and the
   assert.deepEqual(completed, [{ kind: "pushDelete", path: "a.md" }]);
   // Deletion is a manifest change, never a bucket write: the blob is never destroyed, so it stays
   // reachable at its hash for as long as any retained manifest, past or present, still names it.
-  assert.equal(objects.get(blobKeyFor(hash)), "hello");
+  assert.equal(objects.get(blobKeyFor(hash)), wrapped("hello"));
 });
 
 test("executeSyncPlan: pushDelete succeeds even when the bucket never held a blob for the path", async () => {
@@ -135,7 +143,7 @@ test("executeSyncPlan: pull fetches the remote blob and writes it locally", asyn
   const reader = fakeReader({});
   const { writer, files } = fakeLocalWriter();
   const hash = await hashOf("hello");
-  const { storage } = fakeStorage({ [blobKeyFor(hash)]: "hello" });
+  const { storage } = fakeStorage({ [blobKeyFor(hash)]: wrapped("hello") });
   const remote = snapshot(file("a.md", hash));
 
   const { failures } = await executeSyncPlan(
@@ -158,7 +166,7 @@ test("executeSyncPlan: pull overwrites a local file that still matches the snaps
   files.set("a.md", "unchanged");
   const local = snapshot(file("a.md", await hashOf("unchanged")));
   const remoteHash = await hashOf("remote edit");
-  const { storage } = fakeStorage({ [blobKeyFor(remoteHash)]: "remote edit" });
+  const { storage } = fakeStorage({ [blobKeyFor(remoteHash)]: wrapped("remote edit") });
   const remote = snapshot(file("a.md", remoteHash));
 
   const { failures } = await executeSyncPlan(
@@ -187,8 +195,8 @@ test("executeSyncPlan: pull onto a file edited after the snapshot is refused and
   const aHash = await hashOf("remote edit");
   const bHash = await hashOf("remote b");
   const { storage } = fakeStorage({
-    [blobKeyFor(aHash)]: "remote edit",
-    [blobKeyFor(bHash)]: "remote b",
+    [blobKeyFor(aHash)]: wrapped("remote edit"),
+    [blobKeyFor(bHash)]: wrapped("remote b"),
   });
   const remote = snapshot(file("a.md", aHash), file("b.md", bHash));
 
@@ -214,7 +222,7 @@ test("executeSyncPlan: pull onto a file created after the snapshot is refused", 
   const { writer, files } = fakeLocalWriter();
   files.set("a.md", "created after snapshot");
   const hash = await hashOf("remote edit");
-  const { storage } = fakeStorage({ [blobKeyFor(hash)]: "remote edit" });
+  const { storage } = fakeStorage({ [blobKeyFor(hash)]: wrapped("remote edit") });
   const remote = snapshot(file("a.md", hash));
 
   const { failures } = await executeSyncPlan(
@@ -350,7 +358,7 @@ test("executeSyncPlan: a conflict renames the local copy, pushes its blob to sto
   const { writer, files } = fakeLocalWriter();
   files.set("a.md", "local edit");
   const remoteHash = await hashOf("remote edit");
-  const { storage, objects } = fakeStorage({ [blobKeyFor(remoteHash)]: "remote edit" });
+  const { storage, objects } = fakeStorage({ [blobKeyFor(remoteHash)]: wrapped("remote edit") });
   const remote = snapshot(file("a.md", remoteHash));
   const now = Date.parse("2026-07-14T10:00:00.000Z");
 
@@ -371,7 +379,7 @@ test("executeSyncPlan: a conflict renames the local copy, pushes its blob to sto
   // The conflict copy's blob must also reach storage: otherwise the manifest uploaded after this
   // sync claims a path pointing at a blob that doesn't exist, and every other device fails
   // forever trying to pull it.
-  assert.equal(objects.get(blobKeyFor(copyHash)), "local edit");
+  assert.equal(objects.get(blobKeyFor(copyHash)), wrapped("local edit"));
   // Recorded at the hash of the copy's own bytes, the same race a push closes: the conflict copy
   // is read fresh at execution time, never assumed from a pre-sync snapshot.
   assert.deepEqual(pushedFiles, [
@@ -380,6 +388,7 @@ test("executeSyncPlan: a conflict renames the local copy, pushes its blob to sto
       size: "local edit".length,
       mtime: now,
       hash: copyHash,
+      blob: copyHash,
     },
   ]);
 });
@@ -388,7 +397,7 @@ test("executeSyncPlan: a conflict with nothing local to preserve just pulls the 
   const reader = fakeReader({});
   const { writer, files } = fakeLocalWriter();
   const hash = await hashOf("remote edit");
-  const { storage } = fakeStorage({ [blobKeyFor(hash)]: "remote edit" });
+  const { storage } = fakeStorage({ [blobKeyFor(hash)]: wrapped("remote edit") });
   const remote = snapshot(file("a.md", hash));
   const now = Date.parse("2026-07-14T10:00:00.000Z");
 
@@ -442,7 +451,7 @@ test("executeSyncPlan: a conflict restore onto a path recreated after the snapsh
   const { writer, files } = fakeLocalWriter();
   files.set("a.md", "recreated after snapshot");
   const hash = await hashOf("remote edit");
-  const { storage } = fakeStorage({ [blobKeyFor(hash)]: "remote edit" });
+  const { storage } = fakeStorage({ [blobKeyFor(hash)]: wrapped("remote edit") });
   const remote = snapshot(file("a.md", hash));
   const now = Date.parse("2026-07-14T10:00:00.000Z");
 
@@ -477,7 +486,7 @@ test("executeSyncPlan: a conflict restore onto a path recreated after its own re
     files.set(path, "recreated mid sync");
   };
   const remoteHash = await hashOf("remote edit");
-  const { storage, objects } = fakeStorage({ [blobKeyFor(remoteHash)]: "remote edit" });
+  const { storage, objects } = fakeStorage({ [blobKeyFor(remoteHash)]: wrapped("remote edit") });
   const remote = snapshot(file("a.md", remoteHash));
   const now = Date.parse("2026-07-14T10:00:00.000Z");
 
@@ -501,13 +510,14 @@ test("executeSyncPlan: a conflict restore onto a path recreated after its own re
   // sync sees the recreated file as a local change and replans the path as an ordinary conflict.
   const copyHash = await hashOf("local edit");
   assert.equal(files.get(conflictCopyPath("a.md", now)), "local edit");
-  assert.equal(objects.get(blobKeyFor(copyHash)), "local edit");
+  assert.equal(objects.get(blobKeyFor(copyHash)), wrapped("local edit"));
   assert.deepEqual(pushedFiles, [
     {
       path: conflictCopyPath("a.md", now),
       size: "local edit".length,
       mtime: now,
       hash: copyHash,
+      blob: copyHash,
     },
   ]);
 });
@@ -521,7 +531,7 @@ test("executeSyncPlan: a conflict restore is refused by its commit even when the
   const { writer, files } = fakeLocalWriter();
   files.set("a.md", "created but not yet indexed");
   const hash = await hashOf("remote edit");
-  const { storage } = fakeStorage({ [blobKeyFor(hash)]: "remote edit" });
+  const { storage } = fakeStorage({ [blobKeyFor(hash)]: wrapped("remote edit") });
   const remote = snapshot(file("a.md", hash));
   const now = Date.parse("2026-07-14T10:00:00.000Z");
 
@@ -550,7 +560,7 @@ test("executeSyncPlan: an ordinary pull still replaces the file its plan decided
   const { writer, files } = fakeLocalWriter();
   files.set("a.md", "as snapshotted");
   const hash = await hashOf("remote edit");
-  const { storage } = fakeStorage({ [blobKeyFor(hash)]: "remote edit" });
+  const { storage } = fakeStorage({ [blobKeyFor(hash)]: wrapped("remote edit") });
   const remote = snapshot(file("a.md", hash));
 
   const { failures } = await executeSyncPlan(
@@ -587,7 +597,7 @@ test("executeSyncPlan: a conflict with nothing remote to pull preserves the loca
   assert.deepEqual(failures, []);
   assert.equal(files.has("a.md"), false);
   assert.equal(files.get(conflictCopyPath("a.md", now)), "local edit");
-  assert.equal(objects.get(blobKeyFor(copyHash)), "local edit");
+  assert.equal(objects.get(blobKeyFor(copyHash)), wrapped("local edit"));
 });
 
 test("executeSyncPlan: a push whose local file vanished is reported and doesn't stop the rest of the plan", async () => {
@@ -606,7 +616,7 @@ test("executeSyncPlan: a push whose local file vanished is reported and doesn't 
 
   const worldHash = await hashOf("world");
   assert.deepEqual(failures, [{ path: "a.md", message: "no such file: a.md" }]);
-  assert.equal(objects.get(blobKeyFor(worldHash)), "world");
+  assert.equal(objects.get(blobKeyFor(worldHash)), wrapped("world"));
 });
 
 test("executeSyncPlan: a conflict whose local file vanished is reported, nothing is renamed or pushed, and the plan continues", async () => {
@@ -629,7 +639,7 @@ test("executeSyncPlan: a conflict whose local file vanished is reported, nothing
   // No conflict copy was created locally or remotely from a file that wasn't there to preserve.
   assert.equal(files.has(conflictCopyPath("a.md", now)), false);
   // The following action still ran.
-  assert.equal(objects.get(blobKeyFor(worldHash)), "world");
+  assert.equal(objects.get(blobKeyFor(worldHash)), wrapped("world"));
 });
 
 test("executeSyncPlan: a failed push is reported and doesn't stop the rest of the plan", async () => {
@@ -660,7 +670,7 @@ test("executeSyncPlan: a failed push is reported and doesn't stop the rest of th
 
   const worldHash = await hashOf("world");
   assert.deepEqual(failures, [{ path: "a.md", message: "Storage rejected the write (500)" }]);
-  assert.equal(objects.get(blobKeyFor(worldHash)), "world");
+  assert.equal(objects.get(blobKeyFor(worldHash)), wrapped("world"));
   assert.equal(files.size, 0);
   // The pass reports exactly which actions completed and which didn't, so syncOnce can record
   // b.md's progress in the manifest while leaving a.md pending for the next pass (#87).
@@ -676,7 +686,7 @@ test("executeSyncPlan: a conflict whose copy push fails is a failed action, even
   const { writer, files } = fakeLocalWriter();
   files.set("a.md", "local edit");
   const remoteHash = await hashOf("remote edit");
-  const { storage, objects } = fakeStorage({ [blobKeyFor(remoteHash)]: "remote edit" });
+  const { storage, objects } = fakeStorage({ [blobKeyFor(remoteHash)]: wrapped("remote edit") });
   const remote = snapshot(file("a.md", remoteHash));
   storage.putObject = async () => ({
     ok: false,
@@ -728,8 +738,8 @@ test("executeSyncPlan: a pull whose local write throws is reported and doesn't s
   const aHash = await hashOf("remote a");
   const bHash = await hashOf("remote b");
   const { storage } = fakeStorage({
-    [blobKeyFor(aHash)]: "remote a",
-    [blobKeyFor(bHash)]: "remote b",
+    [blobKeyFor(aHash)]: wrapped("remote a"),
+    [blobKeyFor(bHash)]: wrapped("remote b"),
   });
   const remote = snapshot(file("a.md", aHash), file("b.md", bHash));
 
@@ -754,7 +764,7 @@ test("executeSyncPlan: a conflict whose rename throws is reported and the local 
     throw new Error("EACCES: permission denied");
   };
   const hash = await hashOf("remote edit");
-  const { storage, objects } = fakeStorage({ [blobKeyFor(hash)]: "remote edit" });
+  const { storage, objects } = fakeStorage({ [blobKeyFor(hash)]: wrapped("remote edit") });
   const remote = snapshot(file("a.md", hash));
   const now = Date.parse("2026-07-14T10:00:00.000Z");
 
@@ -779,7 +789,7 @@ test("executeSyncPlan: pull with matching hash writes the file to disk", async (
   const reader = fakeReader({});
   const { writer, files } = fakeLocalWriter();
   const hash = await hashOf("hello");
-  const { storage } = fakeStorage({ [blobKeyFor(hash)]: "hello" });
+  const { storage } = fakeStorage({ [blobKeyFor(hash)]: wrapped("hello") });
   const remote = snapshot(file("a.md", hash));
 
   const { failures } = await executeSyncPlan(
@@ -803,7 +813,7 @@ test("executeSyncPlan: pull with hash mismatch is refused and nothing is written
   const reader = fakeReader({});
   const { writer, files } = fakeLocalWriter();
   const correctHash = await hashOf("correct content");
-  const { storage } = fakeStorage({ [blobKeyFor(correctHash)]: "wrong content" });
+  const { storage } = fakeStorage({ [blobKeyFor(correctHash)]: wrapped("wrong content") });
   const remote = snapshot(file("a.md", correctHash));
 
   const { failures } = await executeSyncPlan(
@@ -825,11 +835,64 @@ test("executeSyncPlan: pull with hash mismatch is refused and nothing is written
   assert.equal(files.has("a.md"), false);
 });
 
+test("executeSyncPlan: pull of a blob that isn't a geode object is refused, never written as content", async () => {
+  // Whatever is at this key, it did not come from a geode that wrote an envelope (#184): another
+  // tool's object, or a truncated one. Handing its bytes on as the file's content would write
+  // whatever it happens to be straight into the vault.
+  const reader = fakeReader({});
+  const { writer, files } = fakeLocalWriter();
+  const hash = await hashOf("hello");
+  const { storage } = fakeStorage({ [blobKeyFor(hash)]: "hello" });
+  const remote = snapshot(file("a.md", hash));
+
+  const { failures } = await executeSyncPlan(
+    [{ kind: "pull", path: "a.md" }],
+    empty,
+    reader,
+    writer,
+    storage,
+    1,
+    remote,
+  );
+
+  assert.deepEqual(failures, [
+    { path: "a.md", message: "stored blob is not in geode's object format" },
+  ]);
+  assert.equal(files.has("a.md"), false);
+});
+
+test("executeSyncPlan: pull of a blob a newer build wrote reports needing an update, not damage", async () => {
+  // An envelope this build can read the header of but not the payload of: the bucket was written
+  // by a geode that knows a suite this one doesn't, which at 0.3.0 is an encrypted vault. The fix
+  // is updating the plugin, so it must not be reported as corruption.
+  const reader = fakeReader({});
+  const { writer, files } = fakeLocalWriter();
+  const hash = await hashOf("hello");
+  const newerSuite = new Uint8Array([0x47, 0x45, 0x4f, 0x44, 0x01, 0x09, 0x68, 0x69]);
+  const { storage } = fakeStorage({ [blobKeyFor(hash)]: new TextDecoder().decode(newerSuite) });
+  const remote = snapshot(file("a.md", hash));
+
+  const { failures } = await executeSyncPlan(
+    [{ kind: "pull", path: "a.md" }],
+    empty,
+    reader,
+    writer,
+    storage,
+    1,
+    remote,
+  );
+
+  assert.deepEqual(failures, [
+    { path: "a.md", message: "stored blob is a format this version of geode can't read" },
+  ]);
+  assert.equal(files.has("a.md"), false);
+});
+
 test("executeSyncPlan: pull with truncated body is refused and nothing is written to disk", async () => {
   const reader = fakeReader({});
   const { writer, files } = fakeLocalWriter();
   const hash = await hashOf("hello");
-  const { storage } = fakeStorage({ [blobKeyFor(hash)]: "hel" });
+  const { storage } = fakeStorage({ [blobKeyFor(hash)]: wrapped("hel") });
   const remote = snapshot(file("a.md", hash));
 
   const { failures } = await executeSyncPlan(
@@ -860,7 +923,10 @@ test("executeSyncPlan: pull refuses when the manifest has moved on, rather than 
   const reader = fakeReader({});
   const { writer, files } = fakeLocalWriter();
   const hash = await hashOf("hello");
-  const { storage } = fakeStorage({ [blobKeyFor(hash)]: "hello", [MANIFEST_KEY]: "irrelevant" });
+  const { storage } = fakeStorage({
+    [blobKeyFor(hash)]: wrapped("hello"),
+    [MANIFEST_KEY]: "irrelevant",
+  });
   const remote = snapshot(file("a.md", hash));
 
   const { failures } = await executeSyncPlan(
@@ -884,7 +950,10 @@ test("executeSyncPlan: pull proceeds when the manifest etag still matches what t
   const reader = fakeReader({});
   const { writer, files } = fakeLocalWriter();
   const hash = await hashOf("hello");
-  const { storage } = fakeStorage({ [blobKeyFor(hash)]: "hello", [MANIFEST_KEY]: "current" });
+  const { storage } = fakeStorage({
+    [blobKeyFor(hash)]: wrapped("hello"),
+    [MANIFEST_KEY]: "current",
+  });
   const remote = snapshot(file("a.md", hash));
   const manifestHead = await storage.headObject(MANIFEST_KEY);
 
@@ -929,7 +998,7 @@ test("executeSyncPlan: a pull whose local file is edited while its payload stage
     };
   };
   const hash = await hashOf("remote a");
-  const { storage } = fakeStorage({ [blobKeyFor(hash)]: "remote a" });
+  const { storage } = fakeStorage({ [blobKeyFor(hash)]: wrapped("remote a") });
   const remote = snapshot(file("a.md", hash));
 
   const { failures, completed } = await executeSyncPlan(
@@ -987,7 +1056,10 @@ test("executeSyncPlan: a pull stages its payload, then checks cheapest-last, and
     };
   };
   const hash = await hashOf("hello");
-  const { storage } = fakeStorage({ [blobKeyFor(hash)]: "hello", [MANIFEST_KEY]: "current" });
+  const { storage } = fakeStorage({
+    [blobKeyFor(hash)]: wrapped("hello"),
+    [MANIFEST_KEY]: "current",
+  });
   const innerHead = storage.headObject;
   storage.headObject = async (key) => {
     if (key === MANIFEST_KEY) {
@@ -1003,6 +1075,7 @@ test("executeSyncPlan: a pull stages its payload, then checks cheapest-last, and
     size: "as snapshotted".length,
     mtime: 1,
     hash: await hashOf("as snapshotted"),
+    blob: await hashOf("as snapshotted"),
   });
 
   const { failures } = await executeSyncPlan(
@@ -1044,11 +1117,15 @@ test("executeSyncPlan: a pull whose local file is edited while the manifest chec
     size: "as snapshotted".length,
     mtime: 1,
     hash: await hashOf("as snapshotted"),
+    blob: await hashOf("as snapshotted"),
   });
   const { writer, files } = fakeLocalWriter();
   files.set("a.md", "as snapshotted");
   const hash = await hashOf("remote a");
-  const { storage } = fakeStorage({ [blobKeyFor(hash)]: "remote a", [MANIFEST_KEY]: "current" });
+  const { storage } = fakeStorage({
+    [blobKeyFor(hash)]: wrapped("remote a"),
+    [MANIFEST_KEY]: "current",
+  });
   const head = await storage.headObject(MANIFEST_KEY);
   const innerHead = storage.headObject;
   storage.headObject = async (key) => {
@@ -1091,11 +1168,15 @@ test("executeSyncPlan: a pull refused when the edit landing during the manifest 
     size: "hello world".length,
     mtime: 1,
     hash: await hashOf("hello world"),
+    blob: await hashOf("hello world"),
   });
   const { writer, files } = fakeLocalWriter();
   files.set("a.md", "hello world");
   const hash = await hashOf("remote a");
-  const { storage } = fakeStorage({ [blobKeyFor(hash)]: "remote a", [MANIFEST_KEY]: "current" });
+  const { storage } = fakeStorage({
+    [blobKeyFor(hash)]: wrapped("remote a"),
+    [MANIFEST_KEY]: "current",
+  });
   const head = await storage.headObject(MANIFEST_KEY);
   const innerHead = storage.headObject;
   storage.headObject = async (key) => {
@@ -1137,6 +1218,7 @@ test("executeSyncPlan: a pullDelete refused when the edit landing during the man
     size: "hello world".length,
     mtime: 1,
     hash: await hashOf("hello world"),
+    blob: await hashOf("hello world"),
   });
   const { writer, files } = fakeLocalWriter();
   files.set("a.md", "hello world");
@@ -1178,6 +1260,7 @@ test("executeSyncPlan: a pullDelete whose local file is edited while the manifes
     size: "as snapshotted".length,
     mtime: 1,
     hash: await hashOf("as snapshotted"),
+    blob: await hashOf("as snapshotted"),
   });
   const { writer, files } = fakeLocalWriter();
   files.set("a.md", "as snapshotted");
@@ -1238,7 +1321,7 @@ test("executeSyncPlan: a conflict fetches, stages and checks the manifest before
   };
   const remoteHash = await hashOf("remote edit");
   const { storage } = fakeStorage({
-    [blobKeyFor(remoteHash)]: "remote edit",
+    [blobKeyFor(remoteHash)]: wrapped("remote edit"),
     [MANIFEST_KEY]: "current",
   });
   const head = await storage.headObject(MANIFEST_KEY);
@@ -1299,7 +1382,10 @@ test("executeSyncPlan: a pull refused by manifest drift discards its staged payl
     };
   };
   const hash = await hashOf("hello");
-  const { storage } = fakeStorage({ [blobKeyFor(hash)]: "hello", [MANIFEST_KEY]: "irrelevant" });
+  const { storage } = fakeStorage({
+    [blobKeyFor(hash)]: wrapped("hello"),
+    [MANIFEST_KEY]: "irrelevant",
+  });
   const remote = snapshot(file("a.md", hash));
 
   const { failures } = await executeSyncPlan(
@@ -1338,7 +1424,10 @@ test("executeSyncPlan: a discard that itself fails never masks the failure that 
     };
   };
   const hash = await hashOf("hello");
-  const { storage } = fakeStorage({ [blobKeyFor(hash)]: "hello", [MANIFEST_KEY]: "irrelevant" });
+  const { storage } = fakeStorage({
+    [blobKeyFor(hash)]: wrapped("hello"),
+    [MANIFEST_KEY]: "irrelevant",
+  });
   const remote = snapshot(file("a.md", hash));
 
   const { failures } = await executeSyncPlan(
@@ -1368,7 +1457,7 @@ test("executeSyncPlan: a conflict restore refuses when the manifest has moved on
   files.set("a.md", "local edit");
   const hash = await hashOf("remote edit");
   const { storage, objects } = fakeStorage({
-    [blobKeyFor(hash)]: "remote edit",
+    [blobKeyFor(hash)]: wrapped("remote edit"),
     [MANIFEST_KEY]: "irrelevant",
   });
   const remote = snapshot(file("a.md", hash));
@@ -1398,7 +1487,7 @@ test("executeSyncPlan: conflict restore with hash mismatch is refused and nothin
   const reader = fakeReader({});
   const { writer, files } = fakeLocalWriter();
   const correctHash = await hashOf("correct content");
-  const { storage } = fakeStorage({ [blobKeyFor(correctHash)]: "wrong content" });
+  const { storage } = fakeStorage({ [blobKeyFor(correctHash)]: wrapped("wrong content") });
   const remote = snapshot(file("a.md", correctHash));
   const now = Date.parse("2026-07-14T10:00:00.000Z");
 
@@ -1430,7 +1519,7 @@ test("executeSyncPlan: conflict with hash mismatch on remote restore leaves the 
   const { writer, files } = fakeLocalWriter();
   files.set("a.md", "local edit");
   const correctHash = await hashOf("correct content");
-  const { storage, objects } = fakeStorage({ [blobKeyFor(correctHash)]: "wrong content" });
+  const { storage, objects } = fakeStorage({ [blobKeyFor(correctHash)]: wrapped("wrong content") });
   const remote = snapshot(file("a.md", correctHash));
   const now = Date.parse("2026-07-14T10:00:00.000Z");
 

--- a/src/sync/execute.ts
+++ b/src/sync/execute.ts
@@ -1,3 +1,4 @@
+import { unwrapObject, wrapObject } from "../storage/envelope.ts";
 import type { StorageClient } from "../storage/storage.ts";
 import {
   byPath,
@@ -16,6 +17,8 @@ import { blobKeyFor, conflictCopyPath, MANIFEST_KEY, type SyncAction } from "./p
 // vault/obsidian.ts), and both are the same event to a user: something changed underneath us.
 export const DRIFT_MESSAGE = "changed locally mid sync; sync again to reconcile";
 
+const BLOB_CORRUPT_MESSAGE = "stored blob is not in geode's object format";
+const BLOB_UNREADABLE_MESSAGE = "stored blob is a format this version of geode can't read";
 const HASH_MISMATCH_MESSAGE = "fetched bytes do not match manifest hash; sync again to reconcile";
 const MANIFEST_DRIFT_MESSAGE = "changed remotely mid sync; sync again to reconcile";
 const MANIFEST_MISSING_HASH_MESSAGE = "manifest missing expected hash for this path";
@@ -25,11 +28,13 @@ const MANIFEST_MISSING_HASH_MESSAGE = "manifest missing expected hash for this p
 // the FileState of every path a blob now exists under, hashed from those exact bytes. pushedFiles
 // is not limited to completed actions: a conflict's copy push can succeed even when the rest of
 // that same action later fails, and the copy still needs to reach the manifest. There is no
-// concurrency flag: a remote side write is either additive (a blob keyed by its own hash, which a
-// losing race still leaves holding the right bytes) or, for pushDelete, touches no bucket object at
-// all, so neither can ever discover on its own that the plan's remote view went stale mid pass. The
-// pull family (pull, pullDelete, and a conflict's restore) is different: a pull's own fetch reads a
-// specific blob by the hash the plan already decided on, which by construction always "succeeds"
+// concurrency flag: a remote side write is either additive (a blob keyed by its own address,
+// which a
+// losing race still leaves holding the right bytes) or, for pushDelete, touches no bucket object
+// at all, so neither can ever discover on its own that the plan's remote view went stale mid pass.
+// The pull family (pull, pullDelete, and a conflict's restore) is different: a pull's own fetch
+// reads a specific blob by the address the plan already decided on, which by construction always
+// "succeeds"
 // with exactly that content, and pullDelete has no bucket object of its own to check at all, so
 // neither can notice on its own that a newer manifest has since pointed the path elsewhere or
 // repopulated it; that is what manifestDrifted checks for, with nothing left between it and the
@@ -309,19 +314,24 @@ async function discardStaged(staged: StagedWrite): Promise<void> {
   }
 }
 
-// ensureBlobStored makes sure a blob holding bytes exists in the bucket at hash's key, uploading
-// only when it doesn't. The key is derived from the content itself, so an object already there is
-// guaranteed byte identical to what the caller would otherwise upload: a rename or a duplicate
-// attachment costs one HEAD and nothing more, never a re-upload. A losing ifAbsent PUT still means
-// another device wrote this exact content concurrently, so it counts as success rather than the
-// concurrency failure an ordinary conditional write would report; the key can only ever hold the
-// bytes its own hash names.
+// ensureBlobStored makes sure a blob holding bytes exists in the bucket at address's key,
+// uploading only when it doesn't. The address is derived from the content itself, so an object
+// already there is guaranteed byte identical to what the caller would otherwise upload: a rename or
+// a duplicate attachment costs one HEAD and nothing more, never a re-upload. A losing ifAbsent PUT
+// still means another device wrote this exact content concurrently, so it counts as success rather
+// than the concurrency failure an ordinary conditional write would report; the key can only ever
+// hold the bytes its own address names.
+//
+// The bytes go into the bucket wrapped in an envelope (#184), the same one every geode object
+// carries, so the object says what it is before anything tries to read it. The address is derived
+// from the payload, never from the wrapped body: what identifies content must not move when the
+// framing around it does.
 async function ensureBlobStored(
   storage: StorageClient,
-  hash: string,
+  address: string,
   bytes: Uint8Array,
 ): Promise<{ ok: true } | { ok: false; message: string }> {
-  const key = blobKeyFor(hash);
+  const key = blobKeyFor(address);
   const head = await storage.headObject(key);
   if (head.ok) {
     return { ok: true };
@@ -329,7 +339,7 @@ async function ensureBlobStored(
   if (head.status !== "not_found") {
     return { ok: false, message: head.message };
   }
-  const put = await storage.putObject(key, bytes, { kind: "ifAbsent" });
+  const put = await storage.putObject(key, wrapObject(bytes), { kind: "ifAbsent" });
   if (put.ok || put.status === "conflict") {
     return { ok: true };
   }
@@ -362,7 +372,7 @@ async function executeAction(
     // in the window between the snapshot and this read is never recorded in the manifest as
     // content the bucket doesn't actually hold.
     const pushed = await pushedFile(action.path, bytes, now);
-    const stored = await ensureBlobStored(storage, pushed.hash, bytes);
+    const stored = await ensureBlobStored(storage, pushed.blob, bytes);
     if (!stored.ok) {
       return failedAction(action.path, stored.message);
     }
@@ -554,8 +564,8 @@ function localFailureMessage(err: unknown): string {
 
 // manifestDrifted reports whether the remote manifest has changed since the pass began, checked
 // immediately before a pull family write commits fetched content to disk. A blob fetched by its
-// own hash always reads back exactly that content, so unlike a plaintext path keyed read this can
-// never itself notice a newer manifest having since pointed the path at a different hash; the
+// own address always reads back exactly that content, so unlike a plaintext path keyed read this
+// can never itself notice a newer manifest having since pointed the path at a different blob; the
 // manifest's own etag is the only signal left that the plan's remote view is stale. A HEAD, not a
 // full re-fetch, keeps this cheap enough to run before every such write, the same "check right
 // before the destructive write" shape checkLocalDrift already uses for the local side. A caller
@@ -570,11 +580,17 @@ async function manifestDrifted(storage: StorageClient, etag: string | null): Pro
   return !head.ok || head.etag !== etag;
 }
 
-// pullBlob reads the blob a path's expected FileState names and verifies it against that expected
-// hash before handing it back, so a caller's local write never receives storage's response
-// unchecked. expected comes from the remote manifest the plan was made from; missing it means the
-// plan itself is inconsistent (every pull carries a manifest entry through syncOnce) and there is
-// no key to even attempt a read against.
+// pullBlob reads the blob a path's expected FileState addresses, unwraps its envelope, and
+// verifies the payload against that entry's expected hash before handing it back, so a caller's
+// local write never receives storage's response unchecked. expected comes from the remote manifest
+// the plan was made from; missing it means the plan itself is inconsistent (every pull carries a
+// manifest entry through syncOnce) and there is no key to even attempt a read against.
+//
+// The two checks are not redundant. The envelope says whether this build can read the object at
+// all, which is what a bucket written by a newer geode answers with; the hash says whether the
+// payload inside is the content the manifest promised. An object whose envelope this build cannot
+// open is reported as needing a different build rather than as damage, the same posture the
+// manifest's own version marker takes, so an upgrade is the obvious fix rather than a restore.
 async function pullBlob(
   storage: StorageClient,
   path: string,
@@ -583,16 +599,23 @@ async function pullBlob(
   if (expected === undefined) {
     return { ok: false, failure: { path, message: MANIFEST_MISSING_HASH_MESSAGE } };
   }
-  const fetched = await storage.getObject(blobKeyFor(expected.hash), expected.size);
+  const fetched = await storage.getObject(blobKeyFor(expected.blob), expected.size);
   if (!fetched.ok || fetched.body === null) {
     return { ok: false, failure: { path, message: fetched.message } };
   }
-  const integrity = await verifyFetch(path, fetched.body, expected);
+  const opened = unwrapObject(fetched.body);
+  if (!opened.ok) {
+    if (opened.reason === "corrupt") {
+      return { ok: false, failure: { path, message: BLOB_CORRUPT_MESSAGE } };
+    }
+    return { ok: false, failure: { path, message: BLOB_UNREADABLE_MESSAGE } };
+  }
+  const integrity = await verifyFetch(path, opened.payload, expected);
   if (integrity !== null) {
     return { ok: false, failure: integrity };
   }
 
-  return { ok: true, body: fetched.body };
+  return { ok: true, body: opened.payload };
 }
 
 // pushConflictCopy stores the bytes a conflict moved aside and reports the FileState the manifest
@@ -609,7 +632,7 @@ async function pushConflictCopy(
   failures: SyncFailure[],
 ): Promise<ActionResult> {
   const copyFile = await pushedFile(copyPath, bytes, now);
-  const stored = await ensureBlobStored(storage, copyFile.hash, bytes);
+  const stored = await ensureBlobStored(storage, copyFile.blob, bytes);
   if (!stored.ok) {
     return { failures: [...failures, { path: copyPath, message: stored.message }], pushed: [] };
   }
@@ -618,9 +641,12 @@ async function pushConflictCopy(
 }
 
 // pushedFile returns the FileState for bytes just written to a blob in the bucket, hashed fresh
-// from those exact bytes.
+// from those exact bytes. Unencrypted, a blob is addressed by its own digest, so the two fields
+// hold the same string; see FileState in vault/vault.ts for why they are still recorded separately.
 async function pushedFile(path: string, bytes: Uint8Array, mtime: number): Promise<FileState> {
-  return { path, size: bytes.length, mtime, hash: await hashBytes(bytes) };
+  const hash = await hashBytes(bytes);
+
+  return { path, size: bytes.length, mtime, hash, blob: hash };
 }
 
 // stageForWrite writes fetched bytes to their staging file, converting a thrown I/O error into the
@@ -647,9 +673,9 @@ function successfulAction(pushed: FileState[] = []): ActionResult {
 
 // verifyFetch hashes fetched bytes and compares against the expected hash, closing the gap
 // between "storage answered ok" and "storage answered with the right bytes". A mismatch means the
-// response was truncated, corrupted, or (with a hash derived key) essentially impossible short of
-// storage corruption; writing it to disk would silently propagate damage to every other device on
-// the next sync.
+// response was truncated, corrupted, or (with a content derived key) essentially impossible
+// short of storage corruption; writing it to disk would silently propagate damage to every other
+// device on the next sync.
 async function verifyFetch(
   path: string,
   body: Uint8Array,

--- a/src/sync/fake.ts
+++ b/src/sync/fake.ts
@@ -1,3 +1,4 @@
+import { unwrapObject, wrapObject } from "../storage/envelope.ts";
 import type {
   DeleteResult,
   GetResult,
@@ -191,11 +192,33 @@ export function fakeStorage(objects: Record<string, string> = {}): {
 }
 
 // file builds a FileState for path with the given hash, using the hash length as a stand-in size.
+// The blob address matches the hash, as it does for every unencrypted vault.
 export function file(path: string, hash: string): FileState {
-  return { path, size: hash.length, mtime: 1, hash };
+  return { path, size: hash.length, mtime: 1, hash, blob: hash };
 }
 
 // snapshot builds a Snapshot from the given file states.
 export function snapshot(...files: FileState[]): Snapshot {
   return { files };
+}
+
+// unwrapped is the inverse of wrapped, for a test that wants to look inside an object a sync
+// wrote. A body that is not a geode object at all throws rather than returning a result to
+// inspect: the test asked for the payload of something it expected sync to have written, and
+// there is nothing sensible for it to assert on if that isn't what it got.
+export function unwrapped(body: string): string {
+  const opened = unwrapObject(new TextEncoder().encode(body));
+  if (!opened.ok) {
+    throw new Error(`not a geode object: ${opened.reason}`);
+  }
+
+  return new TextDecoder().decode(opened.payload);
+}
+
+// wrapped returns what the bucket actually holds for content: the payload inside its object
+// envelope (#184). Tests seed and assert through it so a fixture is the object a real bucket would
+// hold rather than a bare payload sync would refuse to read. The envelope header is ASCII safe, so
+// it survives fakeStorage keeping bodies as strings.
+export function wrapped(content: string): string {
+  return new TextDecoder().decode(wrapObject(new TextEncoder().encode(content)));
 }

--- a/src/sync/plan.test.ts
+++ b/src/sync/plan.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { isSafePath } from "../vault/vault.ts";
+import { isSafePath, SNAPSHOT_VERSION } from "../vault/vault.ts";
 import { empty, file, snapshot } from "./fake.ts";
 import {
   blobKeyFor,
@@ -361,7 +361,7 @@ test("encodeSentinel: the wire format carries the version marker and round-trips
 
   const raw = encodeSentinel(sentinel);
 
-  assert.equal((JSON.parse(raw) as { version: number }).version, 2);
+  assert.equal((JSON.parse(raw) as { version: number }).version, SNAPSHOT_VERSION);
   assert.deepEqual(decodeSentinel(raw), { ok: true, sentinel });
 });
 
@@ -369,7 +369,7 @@ test("decodeSentinel: version, shape, and field type are all validated", () => {
   const cases: { name: string; raw: string; want: DecodedSentinel }[] = [
     {
       name: "a well formed sentinel",
-      raw: JSON.stringify({ version: 2, vaultId: "abc-123", createdAt: 1000 }),
+      raw: JSON.stringify({ version: 3, vaultId: "abc-123", createdAt: 1000 }),
       want: { ok: true, sentinel: { vaultId: "abc-123", createdAt: 1000 } },
     },
     { name: "bytes that aren't JSON", raw: "not json", want: { ok: false, reason: "corrupt" } },
@@ -380,22 +380,22 @@ test("decodeSentinel: version, shape, and field type are all validated", () => {
     },
     {
       name: "a version from a newer build",
-      raw: JSON.stringify({ version: 3, vaultId: "abc-123", createdAt: 1000 }),
+      raw: JSON.stringify({ version: 4, vaultId: "abc-123", createdAt: 1000 }),
       want: { ok: false, reason: "unsupportedVersion" },
     },
     {
       name: "an empty vaultId",
-      raw: JSON.stringify({ version: 2, vaultId: "", createdAt: 1000 }),
+      raw: JSON.stringify({ version: 3, vaultId: "", createdAt: 1000 }),
       want: { ok: false, reason: "corrupt" },
     },
     {
       name: "a vaultId that isn't a string",
-      raw: JSON.stringify({ version: 2, vaultId: 42, createdAt: 1000 }),
+      raw: JSON.stringify({ version: 3, vaultId: 42, createdAt: 1000 }),
       want: { ok: false, reason: "corrupt" },
     },
     {
       name: "a createdAt that isn't a number",
-      raw: JSON.stringify({ version: 2, vaultId: "abc-123", createdAt: "yesterday" }),
+      raw: JSON.stringify({ version: 3, vaultId: "abc-123", createdAt: "yesterday" }),
       want: { ok: false, reason: "corrupt" },
     },
   ];

--- a/src/sync/plan.ts
+++ b/src/sync/plan.ts
@@ -7,17 +7,21 @@ import {
   type Snapshot,
 } from "../vault/vault.ts";
 
-// BLOB_PREFIX is where every file's content lives, keyed by its own SHA-256 hash rather than its
-// vault path: a rename touches no bytes (the manifest's path just points at the same key), a
-// duplicate attachment stores once (two paths, one key), and a delete never destroys bytes (the
-// manifest simply stops pointing at them; the blob is recoverable for as long as any retained
-// manifest, past or present, still names its hash). It sits under RESERVED_PREFIX, so blobs never
-// re-enter a sync as vault files.
+// BLOB_PREFIX is where every file's content lives, keyed by an address derived from the content
+// itself rather than by its vault path: a rename touches no bytes (the manifest's path just points
+// at the same key), a duplicate attachment stores once (two paths, one key), and a delete never
+// destroys bytes (the manifest simply stops pointing at them; the blob is recoverable for as long
+// as any retained manifest, past or present, still names its address). It sits under
+// RESERVED_PREFIX, so blobs never re-enter a sync as vault files.
+//
+// The address is the content's own SHA-256 while the vault is unencrypted, and a keyed hash of the
+// content once it isn't (#184), which is why the manifest records it per entry instead of every
+// reader deriving it (see FileState in vault/vault.ts).
 export const BLOB_PREFIX = ".geode/blobs/";
 
 // MANIFEST_KEY is the well known remote object holding the last synced snapshot, geode's source
 // of truth for both "what does the other side think exists" and, since a FileState already pairs
-// a path with its content hash, "which blob a path's content lives at". Reserved: never treated
+// a path with the address its content lives at, "which blob is which file". Reserved: never treated
 // as a real vault path, on either side, even if a vault happens to contain a file at this exact
 // path.
 export const MANIFEST_KEY = ".geode/manifest.json";
@@ -62,10 +66,10 @@ export type SyncAction =
 // newly minted or newly adopted, persist locally, or why the pass must refuse rather than guess.
 export type VaultIdentityCheck = { ok: true; vaultId: string } | { ok: false; message: string };
 
-// blobKeyFor returns the reserved key content with the given hash lives at, the same key
+// blobKeyFor returns the reserved key content with the given address lives at, the same key
 // regardless of which path, or how many paths, currently point at it.
-export function blobKeyFor(hash: string): string {
-  return `${BLOB_PREFIX}${hash}`;
+export function blobKeyFor(address: string): string {
+  return `${BLOB_PREFIX}${address}`;
 }
 
 // conflictCopyPath returns the name a locally diverged file is renamed to before the remote

--- a/src/sync/sync.itest.ts
+++ b/src/sync/sync.itest.ts
@@ -9,6 +9,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
 import { DEFAULT_SETTINGS, type GeodeSettings } from "../settings/settings.ts";
+import { unwrapObject } from "../storage/envelope.ts";
 import { createS3Client, fetchTransport, type StorageClient } from "../storage/storage.ts";
 import { nodeVault } from "../vault/fs.ts";
 import {
@@ -85,6 +86,19 @@ async function readLocal(d: Device, path: string): Promise<string | undefined> {
   } catch {
     return undefined;
   }
+}
+
+// contentOf returns the payload inside a bucket object's envelope (#184), so a test asserting on
+// what the bucket holds compares content rather than framing. A body that is not a geode object at
+// all throws: every object these tests read was written by a sync moments earlier, so anything
+// else is the test itself being wrong about what it fetched.
+function contentOf(body: Uint8Array | null): string {
+  const opened = unwrapObject(body ?? new Uint8Array());
+  if (!opened.ok) {
+    throw new Error(`not a geode object: ${opened.reason}`);
+  }
+
+  return new TextDecoder().decode(opened.payload);
 }
 
 // hashOf returns the real content hash of text, for reading back the blob a given piece of
@@ -216,7 +230,7 @@ test("sync: a two device conflict pushes the copy so the other device pulls it c
     // not referencing content that doesn't exist.
     const remoteCopy = await storage.getObject(blobKeyFor(await hashOf("B side edit")));
     assert.equal(remoteCopy.ok, true);
-    assert.equal(new TextDecoder().decode(remoteCopy.body ?? new Uint8Array()), "B side edit");
+    assert.equal(contentOf(remoteCopy.body), "B side edit");
 
     // A syncs again and must complete cleanly, pulling the conflict copy rather than erroring on a
     // 404 for an object that never existed. This is exactly what broke before the fix.
@@ -263,7 +277,7 @@ test("sync: a file deleted independently on both devices converges without a con
     // manifest describes no files at all.
     const manifestBody = await storage.getObject(MANIFEST_KEY);
     assert.equal(manifestBody.ok, true);
-    const decoded = decodeSnapshot(new TextDecoder().decode(manifestBody.body ?? new Uint8Array()));
+    const decoded = decodeSnapshot(contentOf(manifestBody.body));
     assert.ok(decoded.ok);
     assert.deepEqual(decoded.snapshot.files, []);
   } finally {
@@ -324,8 +338,8 @@ test("sync: a stale state.json from an older build never deletes the vault on th
     // Both files' blobs reached the bucket rather than being wiped from it.
     const one = await storage.getObject(blobKeyFor(await hashOf("first note")));
     const two = await storage.getObject(blobKeyFor(await hashOf("second note")));
-    assert.equal(new TextDecoder().decode(one.body ?? new Uint8Array()), "first note");
-    assert.equal(new TextDecoder().decode(two.body ?? new Uint8Array()), "second note");
+    assert.equal(contentOf(one.body), "first note");
+    assert.equal(contentOf(two.body), "second note");
 
     // A second device now syncs clean and converges, proving the manifest the first sync uploaded
     // is real and the ancestor reset was a one time first sync affordance, not a lasting behaviour.
@@ -415,7 +429,7 @@ test("sync: a deleted manifest with unexplained blobs reports and proceeds, rath
     // B's own file still pushed and a manifest still landed; A's blob is untouched, unreferenced
     // but not destroyed.
     const kept = await storage.getObject(survivorKey);
-    assert.equal(new TextDecoder().decode(kept.body ?? new Uint8Array()), "a's note");
+    assert.equal(contentOf(kept.body), "a's note");
     assert.equal((await storage.getObject(blobKeyFor(await hashOf("b's note")))).ok, true);
     assert.equal((await storage.getObject(MANIFEST_KEY)).ok, true);
 
@@ -455,7 +469,7 @@ test("sync: a deleted manifest over locally diverged content reports and proceed
     // A's original content is untouched, unreferenced but not destroyed; B's edit still pushed
     // under its own path.
     const kept = await storage.getObject(survivorKey);
-    assert.equal(new TextDecoder().decode(kept.body ?? new Uint8Array()), "from A");
+    assert.equal(contentOf(kept.body), "from A");
     assert.equal(await readLocal(b, "ten/note.md"), "B's own edit");
     assert.equal((await storage.getObject(MANIFEST_KEY)).ok, true);
 

--- a/src/sync/sync.test.ts
+++ b/src/sync/sync.test.ts
@@ -2,7 +2,16 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import { encodeSnapshot, hashBytes, type Snapshot } from "../vault/vault.ts";
 import type { LocalWriter } from "./execute.ts";
-import { empty, fakeLocalWriter, fakeReader, fakeStorage, file, snapshot } from "./fake.ts";
+import {
+  empty,
+  fakeLocalWriter,
+  fakeReader,
+  fakeStorage,
+  file,
+  snapshot,
+  unwrapped,
+  wrapped,
+} from "./fake.ts";
 import {
   blobKeyFor,
   conflictCopyPath,
@@ -36,7 +45,7 @@ test("readRemoteManifest: a 404 is treated as an empty snapshot", async () => {
 
 test("readRemoteManifest: valid JSON is parsed into a snapshot, with the manifest's etag", async () => {
   const want: Snapshot = snapshot(file("a.md", "h1"));
-  const { storage } = fakeStorage({ [MANIFEST_KEY]: encodeSnapshot(want) });
+  const { storage } = fakeStorage({ [MANIFEST_KEY]: wrapped(encodeSnapshot(want)) });
 
   const result = await readRemoteManifest(storage);
 
@@ -46,7 +55,7 @@ test("readRemoteManifest: valid JSON is parsed into a snapshot, with the manifes
 test("readRemoteManifest: a manifest without an etag is refused, not synced unsafely", async () => {
   // Without an etag the manifest upload can't be conditional, and an unconditional upload is the
   // concurrent clobber #83 fixed; the pass must refuse rather than proceed.
-  const { storage } = fakeStorage({ [MANIFEST_KEY]: encodeSnapshot(empty) });
+  const { storage } = fakeStorage({ [MANIFEST_KEY]: wrapped(encodeSnapshot(empty)) });
   const inner = storage.getObject;
   storage.getObject = async (key) => {
     const result = await inner(key);
@@ -59,11 +68,33 @@ test("readRemoteManifest: a manifest without an etag is refused, not synced unsa
 });
 
 test("readRemoteManifest: corrupt JSON is reported as a failure, not an empty snapshot", async () => {
-  const { storage } = fakeStorage({ [MANIFEST_KEY]: "not json" });
+  const { storage } = fakeStorage({ [MANIFEST_KEY]: wrapped("not json") });
 
   const result = await readRemoteManifest(storage);
 
   assert.deepEqual(result, { ok: false, message: "remote manifest is corrupt" });
+});
+
+test("readRemoteManifest: a manifest with no envelope is corrupt, and one from a newer suite needs an update", async () => {
+  // Bare JSON at the manifest key is not a geode object (#184): every manifest this build writes
+  // carries an envelope, so bytes without one were written by something else, and reading them
+  // leniently would make an unversioned object indistinguishable from a version 1 one.
+  const bare = fakeStorage({ [MANIFEST_KEY]: encodeSnapshot(snapshot(file("a.md", "h1"))) });
+
+  assert.deepEqual(await readRemoteManifest(bare.storage), {
+    ok: false,
+    message: "remote manifest is corrupt",
+  });
+
+  // A suite this build doesn't know, which at 0.3.0 is an encrypted manifest: the payload is
+  // unreadable here, and the fix is a newer plugin rather than a fresh bucket.
+  const newerSuite = new Uint8Array([0x47, 0x45, 0x4f, 0x44, 0x01, 0x09, 0x68, 0x69]);
+  const encrypted = fakeStorage({ [MANIFEST_KEY]: new TextDecoder().decode(newerSuite) });
+
+  assert.deepEqual(await readRemoteManifest(encrypted.storage), {
+    ok: false,
+    message: "remote manifest is a format this version of geode can't read",
+  });
 });
 
 test("readRemoteManifest: JSON of the wrong shape is corrupt, not a snapshot with an undefined files", async () => {
@@ -71,7 +102,7 @@ test("readRemoteManifest: JSON of the wrong shape is corrupt, not a snapshot wit
   // ok:true and later threw TypeError in planSync when byPath iterated remote.files; they must
   // instead surface as the corrupt-manifest result the signature promises.
   for (const body of ["{}", "[]", "null", "42", '"files"']) {
-    const { storage } = fakeStorage({ [MANIFEST_KEY]: body });
+    const { storage } = fakeStorage({ [MANIFEST_KEY]: wrapped(body) });
 
     const result = await readRemoteManifest(storage);
 
@@ -84,7 +115,7 @@ test("readRemoteManifest: a pre-marker manifest with no version field is refused
   // plaintext path keyed storage. This build only understands version 2, content addressed blobs,
   // so a version 1 manifest must be refused rather than misread against a layout it never used.
   const want: Snapshot = snapshot(file("a.md", "h1"));
-  const { storage } = fakeStorage({ [MANIFEST_KEY]: JSON.stringify(want) });
+  const { storage } = fakeStorage({ [MANIFEST_KEY]: wrapped(JSON.stringify(want)) });
 
   const result = await readRemoteManifest(storage);
 
@@ -96,7 +127,9 @@ test("readRemoteManifest: a pre-marker manifest with no version field is refused
 
 test("readRemoteManifest: a manifest from a format version this build doesn't know refuses the pass", async () => {
   // A bucket written in a format this build does not know must not be synced against.
-  const { storage } = fakeStorage({ [MANIFEST_KEY]: JSON.stringify({ version: 3, files: [] }) });
+  const { storage } = fakeStorage({
+    [MANIFEST_KEY]: wrapped(JSON.stringify({ version: 4, files: [] })),
+  });
 
   const result = await readRemoteManifest(storage);
 
@@ -110,10 +143,10 @@ test("readRemoteManifest: a manifest entry with a traversal path refuses the pas
   // A remote manifest is untrusted input: anyone who can write to the bucket can shape it. A
   // crafted path must never reach a local file operation.
   const raw = JSON.stringify({
-    version: 2,
-    files: [{ path: "../../etc/passwd", size: 1, mtime: 2, hash: "h" }],
+    version: 3,
+    files: [{ path: "../../etc/passwd", size: 1, mtime: 2, hash: "h", blob: "h" }],
   });
-  const { storage } = fakeStorage({ [MANIFEST_KEY]: raw });
+  const { storage } = fakeStorage({ [MANIFEST_KEY]: wrapped(raw) });
 
   const result = await readRemoteManifest(storage);
 
@@ -127,13 +160,13 @@ test("readRemoteManifest: two paths differing only by case refuse the pass (#94)
   // Bucket keys are case sensitive; macOS, Windows, and Android are not by default. Pulling both
   // would silently let one overwrite the other with no conflict ever raised.
   const raw = JSON.stringify({
-    version: 2,
+    version: 3,
     files: [
-      { path: "notes/Todo.md", size: 1, mtime: 2, hash: "h1" },
-      { path: "notes/todo.md", size: 1, mtime: 2, hash: "h2" },
+      { path: "notes/Todo.md", size: 1, mtime: 2, hash: "h1", blob: "h1" },
+      { path: "notes/todo.md", size: 1, mtime: 2, hash: "h2", blob: "h2" },
     ],
   });
-  const { storage } = fakeStorage({ [MANIFEST_KEY]: raw });
+  const { storage } = fakeStorage({ [MANIFEST_KEY]: wrapped(raw) });
 
   const result = await readRemoteManifest(storage);
 
@@ -168,7 +201,7 @@ test("readSentinel: a 404 is reported as sentinel: null, not a failure", async (
 
 test("readSentinel: valid JSON is parsed into a sentinel", async () => {
   const sentinel = { vaultId: "abc-123", createdAt: 1000 };
-  const { storage } = fakeStorage({ [SENTINEL_KEY]: encodeSentinel(sentinel) });
+  const { storage } = fakeStorage({ [SENTINEL_KEY]: wrapped(encodeSentinel(sentinel)) });
 
   const result = await readSentinel(storage);
 
@@ -176,7 +209,7 @@ test("readSentinel: valid JSON is parsed into a sentinel", async () => {
 });
 
 test("readSentinel: corrupt JSON is reported as a failure, not an absent sentinel", async () => {
-  const { storage } = fakeStorage({ [SENTINEL_KEY]: "not json" });
+  const { storage } = fakeStorage({ [SENTINEL_KEY]: wrapped("not json") });
 
   const result = await readSentinel(storage);
 
@@ -184,8 +217,8 @@ test("readSentinel: corrupt JSON is reported as a failure, not an absent sentine
 });
 
 test("readSentinel: an unknown format version refuses the pass", async () => {
-  const raw = JSON.stringify({ version: 3, vaultId: "abc-123", createdAt: 1000 });
-  const { storage } = fakeStorage({ [SENTINEL_KEY]: raw });
+  const raw = JSON.stringify({ version: 4, vaultId: "abc-123", createdAt: 1000 });
+  const { storage } = fakeStorage({ [SENTINEL_KEY]: wrapped(raw) });
 
   const result = await readSentinel(storage);
 
@@ -219,7 +252,7 @@ test("syncOnce: a manifest format this build doesn't know halts the pass before 
   };
 
   const { storage } = fakeStorage({
-    [MANIFEST_KEY]: JSON.stringify({ version: 3, files: [] }),
+    [MANIFEST_KEY]: wrapped(JSON.stringify({ version: 4, files: [] })),
   });
   const getObject = storage.getObject;
   storage.getObject = async (key) => {
@@ -267,7 +300,7 @@ test("syncOnce: a genuinely new bucket writes a sentinel too (#183)", async () =
   // against, so it must carry the same vaultId the pass just committed to.
   const written = objects.get(SENTINEL_KEY);
   assert.ok(written !== undefined);
-  assert.equal(JSON.parse(written as string).vaultId, "minted-id");
+  assert.equal(JSON.parse(unwrapped(written as string)).vaultId, "minted-id");
 });
 
 test("syncOnce: a device pointed at a different vault's sentinel refuses (#183)", async () => {
@@ -284,7 +317,7 @@ test("syncOnce: a device pointed at a different vault's sentinel refuses (#183)"
     throw new Error("unexpected local write");
   };
   const { storage } = fakeStorage({
-    [SENTINEL_KEY]: encodeSentinel({ vaultId: "known-id", createdAt: 1000 }),
+    [SENTINEL_KEY]: wrapped(encodeSentinel({ vaultId: "known-id", createdAt: 1000 })),
   });
   storage.putObject = async () => {
     throw new Error("unexpected remote write");
@@ -313,7 +346,7 @@ test("syncOnce: a never-synced device proceeds without a manifest (#109)", async
   const reader = fakeReader({ "a.md": "alpha" });
   const { writer } = fakeLocalWriter();
   const { storage } = fakeStorage({
-    [SENTINEL_KEY]: encodeSentinel({ vaultId: "known-id", createdAt: 1000 }),
+    [SENTINEL_KEY]: wrapped(encodeSentinel({ vaultId: "known-id", createdAt: 1000 })),
   });
 
   const outcome = await syncOnce(empty, reader, writer, storage, 1);
@@ -342,8 +375,8 @@ test("syncOnce: a stale ancestor is ignored on a first sync, so a populated vaul
   assert.equal(files.get("a.md"), "alpha");
   assert.equal(files.get("b.md"), "beta");
   // Both files' blobs reached the previously empty bucket.
-  assert.equal(objects.get(blobKeyFor(await hashOf("alpha"))), "alpha");
-  assert.equal(objects.get(blobKeyFor(await hashOf("beta"))), "beta");
+  assert.equal(objects.get(blobKeyFor(await hashOf("alpha"))), wrapped("alpha"));
+  assert.equal(objects.get(blobKeyFor(await hashOf("beta"))), wrapped("beta"));
 });
 
 test("syncOnce: a present but empty manifest still trusts the ancestor and pulls a real remote deletion", async () => {
@@ -353,11 +386,17 @@ test("syncOnce: a present but empty manifest still trusts the ancestor and pulls
   // reports the file at the same size and mtime as the ancestor so takeSnapshot reuses its hash and
   // sees no local change; the hash is the real content hash so the pullDelete's drift check also
   // sees the file as unchanged.
-  const previous = snapshot({ path: "a.md", size: 2, mtime: 1, hash: await hashOf("xy") });
+  const previous = snapshot({
+    path: "a.md",
+    size: 2,
+    mtime: 1,
+    hash: await hashOf("xy"),
+    blob: await hashOf("xy"),
+  });
   const reader = fakeReader({ "a.md": "xy" });
   const { writer, files } = fakeLocalWriter();
   files.set("a.md", "xy");
-  const { storage } = fakeStorage({ [MANIFEST_KEY]: encodeSnapshot(empty) });
+  const { storage } = fakeStorage({ [MANIFEST_KEY]: wrapped(encodeSnapshot(empty)) });
 
   const outcome = await syncOnce(previous, reader, writer, storage, 1);
 
@@ -376,7 +415,7 @@ test("syncOnce: a missing manifest with unexplained blobs reports and proceeds, 
   // proceed, push what is local, and report the stranded content as a failure so a human can still
   // notice it without every future sync being blocked on it.
   const strayHash = await hashOf("not local");
-  const { storage, objects } = fakeStorage({ [blobKeyFor(strayHash)]: "not local" });
+  const { storage, objects } = fakeStorage({ [blobKeyFor(strayHash)]: wrapped("not local") });
   const reader = fakeReader({ "a.md": "alpha" });
   const { writer } = fakeLocalWriter();
 
@@ -389,7 +428,7 @@ test("syncOnce: a missing manifest with unexplained blobs reports and proceeds, 
   ]);
   // The local file still pushed and a manifest still landed, ending firstSync state; the stray
   // blob is left exactly where it was, unreferenced but undestroyed.
-  assert.equal(objects.get(blobKeyFor(await hashOf("alpha"))), "alpha");
+  assert.equal(objects.get(blobKeyFor(await hashOf("alpha"))), wrapped("alpha"));
   assert.equal(objects.has(MANIFEST_KEY), true);
 
   // Because a manifest now exists, the next sync is an ordinary sync rather than a repeat of the
@@ -405,15 +444,15 @@ test("syncOnce: an interrupted first sync's own uploads never block the retry", 
   // vault still holds, so nothing is unexplained; the retry must fold it in and complete, not
   // refuse.
   const aHash = await hashOf("alpha");
-  const { storage, objects } = fakeStorage({ [blobKeyFor(aHash)]: "alpha" });
+  const { storage, objects } = fakeStorage({ [blobKeyFor(aHash)]: wrapped("alpha") });
   const reader = fakeReader({ "a.md": "alpha", "b.md": "beta" });
   const { writer } = fakeLocalWriter();
 
   const outcome = await syncOnce(empty, reader, writer, storage, 1);
 
   assert.equal(outcome.ok, true);
-  assert.equal(objects.get(blobKeyFor(aHash)), "alpha");
-  assert.equal(objects.get(blobKeyFor(await hashOf("beta"))), "beta");
+  assert.equal(objects.get(blobKeyFor(aHash)), wrapped("alpha"));
+  assert.equal(objects.get(blobKeyFor(await hashOf("beta"))), wrapped("beta"));
   assert.equal(objects.has(MANIFEST_KEY), true);
 });
 
@@ -458,7 +497,7 @@ test("syncOnce: a manifest overwritten by another device mid sync fails the pass
   // clobbered B's manifest, so b.md read as a remote deletion on B's next sync and was silently
   // deleted. A's conditional upload must instead lose the race and fail the pass.
   const ancestor = snapshot(file("a.md", "h1"));
-  const { storage, objects } = fakeStorage({ [MANIFEST_KEY]: encodeSnapshot(ancestor) });
+  const { storage, objects } = fakeStorage({ [MANIFEST_KEY]: wrapped(encodeSnapshot(ancestor)) });
   const beeHash = await hashOf("bee");
   const bManifest = encodeSnapshot(snapshot(file("a.md", "h1"), file("b.md", beeHash)));
   const inner = storage.putObject;
@@ -466,8 +505,8 @@ test("syncOnce: a manifest overwritten by another device mid sync fails the pass
   storage.putObject = async (key, body, condition) => {
     if (key === MANIFEST_KEY && !raced) {
       raced = true;
-      await inner(blobKeyFor(beeHash), new TextEncoder().encode("bee"));
-      await inner(MANIFEST_KEY, new TextEncoder().encode(bManifest));
+      await inner(blobKeyFor(beeHash), new TextEncoder().encode(wrapped("bee")));
+      await inner(MANIFEST_KEY, new TextEncoder().encode(wrapped(bManifest)));
     }
     return inner(key, body, condition);
   };
@@ -487,9 +526,9 @@ test("syncOnce: a manifest overwritten by another device mid sync fails the pass
     snapshot: null,
   });
   // B's manifest survived; A's never landed.
-  assert.equal(objects.get(MANIFEST_KEY), bManifest);
+  assert.equal(objects.get(MANIFEST_KEY), wrapped(bManifest));
   // A's push still reached the bucket (harmless: the next pass folds it into the manifest).
-  assert.equal(objects.get(blobKeyFor(await hashOf("ccc"))), "ccc");
+  assert.equal(objects.get(blobKeyFor(await hashOf("ccc"))), wrapped("ccc"));
   // Nothing was touched locally.
   assert.equal(files.get("a.md"), "xy");
   assert.equal(files.get("c.md"), "ccc");
@@ -507,8 +546,14 @@ test("syncOnce: retry adopts an identical orphaned upload with a HEAD, not anoth
   // manifest CAS is even attempted, so it survives a pass that then fails on the manifest race; a
   // naive retry that always PUTs again would waste the upload a second time. ensureBlobStored's
   // HEAD-before-PUT is what makes the retry free.
-  const ancestor = snapshot({ path: "a.md", size: 4, mtime: 1, hash: await hashOf("base") });
-  const { storage, objects } = fakeStorage({ [MANIFEST_KEY]: encodeSnapshot(ancestor) });
+  const ancestor = snapshot({
+    path: "a.md",
+    size: 4,
+    mtime: 1,
+    hash: await hashOf("base"),
+    blob: await hashOf("base"),
+  });
+  const { storage, objects } = fakeStorage({ [MANIFEST_KEY]: wrapped(encodeSnapshot(ancestor)) });
   const oursHash = await hashOf("ours!");
   const inner = storage.putObject;
   let filePuts = 0;
@@ -519,7 +564,7 @@ test("syncOnce: retry adopts an identical orphaned upload with a HEAD, not anoth
     }
     if (key === MANIFEST_KEY && raceManifest) {
       raceManifest = false;
-      await inner(MANIFEST_KEY, new TextEncoder().encode(encodeSnapshot(ancestor)));
+      await inner(MANIFEST_KEY, new TextEncoder().encode(wrapped(encodeSnapshot(ancestor))));
     }
     return inner(key, body, condition);
   };
@@ -535,7 +580,7 @@ test("syncOnce: retry adopts an identical orphaned upload with a HEAD, not anoth
     failures: [],
     snapshot: null,
   });
-  assert.equal(objects.get(blobKeyFor(oursHash)), "ours!");
+  assert.equal(objects.get(blobKeyFor(oursHash)), wrapped("ours!"));
   assert.equal(filePuts, 1);
 
   // The manifest is still at the ancestor while the blob already holds our bytes, so the retry's
@@ -545,7 +590,7 @@ test("syncOnce: retry adopts an identical orphaned upload with a HEAD, not anoth
   assert.deepEqual(retry, {
     ok: true,
     snapshot: {
-      files: [{ path: "a.md", size: 5, mtime: 1, hash: oursHash }],
+      files: [{ path: "a.md", size: 5, mtime: 1, hash: oursHash, blob: oursHash }],
       vaultId: "fixed-vault-id",
     },
     changeCount: 1,
@@ -555,7 +600,7 @@ test("syncOnce: retry adopts an identical orphaned upload with a HEAD, not anoth
   // The stored manifest never carries vaultId, only the snapshot syncOnce hands back for local
   // persistence does (#183), so the comparison strips it before checking the two agree.
   const { vaultId: _vaultId, ...storedShape } = retry.snapshot;
-  assert.equal(objects.get(MANIFEST_KEY), encodeSnapshot(storedShape));
+  assert.equal(objects.get(MANIFEST_KEY), wrapped(encodeSnapshot(storedShape)));
 });
 
 test("syncOnce: a file changed mid sync is not recorded in the manifest and is pushed next pass", async () => {
@@ -567,10 +612,10 @@ test("syncOnce: a file changed mid sync is not recorded in the manifest and is p
   // edit. The manifest must instead keep claiming only what the bucket holds, leaving both files
   // as local changes for the next pass to push.
   const xyHash = await hashOf("xy");
-  const ancestor = snapshot({ path: "a.md", size: 2, mtime: 1, hash: xyHash });
+  const ancestor = snapshot({ path: "a.md", size: 2, mtime: 1, hash: xyHash, blob: xyHash });
   const { storage, objects } = fakeStorage({
-    [MANIFEST_KEY]: encodeSnapshot(ancestor),
-    [blobKeyFor(xyHash)]: "xy",
+    [MANIFEST_KEY]: wrapped(encodeSnapshot(ancestor)),
+    [blobKeyFor(xyHash)]: wrapped("xy"),
   });
   // a.md matches the ancestor's size and mtime so takeSnapshot reuses its hash and sees no local
   // change there; b.md is the new local file whose push is the mid sync moment to interleave on.
@@ -596,7 +641,7 @@ test("syncOnce: a file changed mid sync is not recorded in the manifest and is p
   // file's new content ever reached the bucket.
   const manifestBody = objects.get(MANIFEST_KEY);
   assert.ok(manifestBody !== undefined);
-  const manifest = JSON.parse(manifestBody) as Snapshot;
+  const manifest = JSON.parse(unwrapped(manifestBody)) as Snapshot;
   const paths = manifest.files.map((f) => f.path);
   assert.deepEqual(paths.sort(), ["a.md", "b.md"]);
   assert.deepEqual(
@@ -608,8 +653,14 @@ test("syncOnce: a file changed mid sync is not recorded in the manifest and is p
   // The next pass sees both as plain local changes and pushes them.
   const retry = await syncOnce(outcome.snapshot, reader, writer, storage, 1);
   assert.equal(retry.ok, true);
-  assert.equal(objects.get(blobKeyFor(await hashOf("edited mid sync"))), "edited mid sync");
-  assert.equal(objects.get(blobKeyFor(await hashOf("created mid sync"))), "created mid sync");
+  assert.equal(
+    objects.get(blobKeyFor(await hashOf("edited mid sync"))),
+    wrapped("edited mid sync"),
+  );
+  assert.equal(
+    objects.get(blobKeyFor(await hashOf("created mid sync"))),
+    wrapped("created mid sync"),
+  );
 });
 
 test("syncOnce: a file edited mid sync is never overwritten by a pull, and the retry preserves it as a conflict copy", async () => {
@@ -621,14 +672,14 @@ test("syncOnce: a file edited mid sync is never overwritten by a pull, and the r
   const aV2Hash = await hashOf("a v2");
   const bV2Hash = await hashOf("b v2");
   const ancestor = snapshot(
-    { path: "a.md", size: 4, mtime: 1, hash: await hashOf("a v1") },
-    { path: "b.md", size: 4, mtime: 1, hash: await hashOf("b v1") },
+    { path: "a.md", size: 4, mtime: 1, hash: await hashOf("a v1"), blob: await hashOf("a v1") },
+    { path: "b.md", size: 4, mtime: 1, hash: await hashOf("b v1"), blob: await hashOf("b v1") },
   );
   const remoteManifest = encodeSnapshot(snapshot(file("a.md", aV2Hash), file("b.md", bV2Hash)));
   const { storage, objects } = fakeStorage({
-    [MANIFEST_KEY]: remoteManifest,
-    [blobKeyFor(aV2Hash)]: "a v2",
-    [blobKeyFor(bV2Hash)]: "b v2",
+    [MANIFEST_KEY]: wrapped(remoteManifest),
+    [blobKeyFor(aV2Hash)]: wrapped("a v2"),
+    [blobKeyFor(bV2Hash)]: wrapped("b v2"),
   });
   const readerFiles: Record<string, string> = { "a.md": "a v1", "b.md": "b v1" };
   const reader = fakeReader(readerFiles);
@@ -673,7 +724,7 @@ test("syncOnce: a file edited mid sync is never overwritten by a pull, and the r
   // both remote versions, untouched by this pass's pulls.
   const manifestBody = objects.get(MANIFEST_KEY);
   assert.ok(manifestBody !== undefined);
-  const manifest = JSON.parse(manifestBody) as Snapshot;
+  const manifest = JSON.parse(unwrapped(manifestBody)) as Snapshot;
   const hashes = new Map(manifest.files.map((f) => [f.path, f.hash]));
   assert.equal(hashes.get("a.md"), aV2Hash);
   assert.equal(hashes.get("b.md"), bV2Hash);
@@ -688,7 +739,10 @@ test("syncOnce: a file edited mid sync is never overwritten by a pull, and the r
   assert.equal(retry.ok, true);
   const copyPath = conflictCopyPath("b.md", now);
   assert.equal(files.get(copyPath), "edited mid sync");
-  assert.equal(objects.get(blobKeyFor(await hashOf("edited mid sync"))), "edited mid sync");
+  assert.equal(
+    objects.get(blobKeyFor(await hashOf("edited mid sync"))),
+    wrapped("edited mid sync"),
+  );
   assert.equal(files.get("b.md"), "b v2");
 });
 
@@ -697,13 +751,19 @@ test("syncOnce: a conflict copy carries the device that made the edit (#103)", a
   // copy. On a three device vault a timestamp alone leaves whose edit it holds to be guessed, so
   // the device this pass ran on has to be in the name, on disk and in the uploaded manifest.
   const remoteHash = await hashOf("from another device");
-  const ancestor = snapshot({ path: "a.md", size: 4, mtime: 1, hash: await hashOf("shared base") });
+  const ancestor = snapshot({
+    path: "a.md",
+    size: 4,
+    mtime: 1,
+    hash: await hashOf("shared base"),
+    blob: await hashOf("shared base"),
+  });
   const remoteManifest = encodeSnapshot(
-    snapshot({ path: "a.md", size: 19, mtime: 1, hash: remoteHash }),
+    snapshot({ path: "a.md", size: 19, mtime: 1, hash: remoteHash, blob: remoteHash }),
   );
   const { storage, objects } = fakeStorage({
-    [MANIFEST_KEY]: remoteManifest,
-    [blobKeyFor(remoteHash)]: "from another device",
+    [MANIFEST_KEY]: wrapped(remoteManifest),
+    [blobKeyFor(remoteHash)]: wrapped("from another device"),
   });
   const reader = fakeReader({ "a.md": "my own edit" });
   const { writer, files } = fakeLocalWriter();
@@ -719,10 +779,10 @@ test("syncOnce: a conflict copy carries the device that made the edit (#103)", a
   assert.equal(files.get(copyPath), "my own edit");
   assert.equal(files.get("a.md"), "from another device");
   // Other devices see it too: the copy reached the bucket and the manifest names it.
-  assert.equal(objects.get(blobKeyFor(await hashOf("my own edit"))), "my own edit");
+  assert.equal(objects.get(blobKeyFor(await hashOf("my own edit"))), wrapped("my own edit"));
   const manifestBody = objects.get(MANIFEST_KEY);
   assert.ok(manifestBody !== undefined);
-  const manifest = JSON.parse(manifestBody) as Snapshot;
+  const manifest = JSON.parse(unwrapped(manifestBody)) as Snapshot;
   const paths = manifest.files.map((f) => f.path);
   assert.ok(paths.includes(copyPath), paths.join(", "));
 });
@@ -738,13 +798,13 @@ test("syncOnce: a manifest that moves on mid pull is caught before stale content
   const aV1Hash = await hashOf("a v1");
   const aV2Hash = await hashOf("a v2");
   const aV3Hash = await hashOf("a v3");
-  const ancestor = snapshot({ path: "a.md", size: 4, mtime: 1, hash: aV1Hash });
+  const ancestor = snapshot({ path: "a.md", size: 4, mtime: 1, hash: aV1Hash, blob: aV1Hash });
   const remoteManifestV2 = encodeSnapshot(
-    snapshot({ path: "a.md", size: 4, mtime: 1, hash: aV2Hash }),
+    snapshot({ path: "a.md", size: 4, mtime: 1, hash: aV2Hash, blob: aV2Hash }),
   );
   const { storage, objects } = fakeStorage({
-    [MANIFEST_KEY]: remoteManifestV2,
-    [blobKeyFor(aV2Hash)]: "a v2",
+    [MANIFEST_KEY]: wrapped(remoteManifestV2),
+    [blobKeyFor(aV2Hash)]: wrapped("a v2"),
   });
   const reader = fakeReader({ "a.md": "a v1" });
   const { writer, files } = fakeLocalWriter();
@@ -757,10 +817,10 @@ test("syncOnce: a manifest that moves on mid pull is caught before stale content
       raced = true;
       // Another device wins outright: its own blob and manifest both land before this pass's pull
       // gets to write anything locally.
-      await storage.putObject(blobKeyFor(aV3Hash), new TextEncoder().encode("a v3"));
+      await storage.putObject(blobKeyFor(aV3Hash), new TextEncoder().encode(wrapped("a v3")));
       await storage.putObject(
         MANIFEST_KEY,
-        new TextEncoder().encode(encodeSnapshot(snapshot(file("a.md", aV3Hash)))),
+        new TextEncoder().encode(wrapped(encodeSnapshot(snapshot(file("a.md", aV3Hash))))),
       );
     }
     return inner(key);
@@ -774,7 +834,7 @@ test("syncOnce: a manifest that moves on mid pull is caught before stale content
   ]);
   // The stale v2 content was never written; the local file is untouched.
   assert.equal(files.get("a.md"), "a v1");
-  assert.equal(objects.get(MANIFEST_KEY), encodeSnapshot(snapshot(file("a.md", aV3Hash))));
+  assert.equal(objects.get(MANIFEST_KEY), wrapped(encodeSnapshot(snapshot(file("a.md", aV3Hash)))));
 
   // The failed pass never advanced state.json, so the retry re-reads the now current manifest and
   // pulls the real latest version.
@@ -816,10 +876,10 @@ test("syncOnce: a failed push doesn't discard the progress of the rest of the pa
   ]);
   // b.md's push landed and the manifest records it, so other devices can already see it; a.md
   // never reached the bucket and the manifest doesn't claim it.
-  assert.equal(objects.get(blobKeyFor(worldHash)), "world");
+  assert.equal(objects.get(blobKeyFor(worldHash)), wrapped("world"));
   const manifestBody = objects.get(MANIFEST_KEY);
   assert.ok(manifestBody !== undefined);
-  const manifest = JSON.parse(manifestBody) as Snapshot;
+  const manifest = JSON.parse(unwrapped(manifestBody)) as Snapshot;
   assert.deepEqual(
     manifest.files.map((f) => f.path),
     ["b.md"],
@@ -838,7 +898,7 @@ test("syncOnce: a failed push doesn't discard the progress of the rest of the pa
   const retry = await syncOnce(outcome.snapshot, reader, writer, storage, 1);
 
   assert.equal(retry.ok, true);
-  assert.equal(objects.get(blobKeyFor(alphaHash)), "alpha");
+  assert.equal(objects.get(blobKeyFor(alphaHash)), wrapped("alpha"));
   assert.equal(bPushes, 1);
 });
 
@@ -849,13 +909,19 @@ test("syncOnce: a conflict's copy push survives into the uploaded manifest even 
   // name it, the object sits there forever, invisible to every other device, until this same one
   // syncs again.
   const aV2Hash = await hashOf("a v2");
-  const ancestor = snapshot({ path: "a.md", size: 4, mtime: 1, hash: await hashOf("a v1") });
+  const ancestor = snapshot({
+    path: "a.md",
+    size: 4,
+    mtime: 1,
+    hash: await hashOf("a v1"),
+    blob: await hashOf("a v1"),
+  });
   const remoteManifest = encodeSnapshot(
-    snapshot({ path: "a.md", size: 4, mtime: 1, hash: aV2Hash }),
+    snapshot({ path: "a.md", size: 4, mtime: 1, hash: aV2Hash, blob: aV2Hash }),
   );
   const { storage, objects } = fakeStorage({
-    [MANIFEST_KEY]: remoteManifest,
-    [blobKeyFor(aV2Hash)]: "a v2",
+    [MANIFEST_KEY]: wrapped(remoteManifest),
+    [blobKeyFor(aV2Hash)]: wrapped("a v2"),
   });
   const reader = fakeReader({ "a.md": "a local" });
   const { writer } = fakeLocalWriter();
@@ -875,11 +941,11 @@ test("syncOnce: a conflict's copy push survives into the uploaded manifest even 
   assert.ok(!outcome.ok);
   assert.deepEqual(outcome.failures, [{ path: "a.md", message: "EACCES: permission denied" }]);
   // The copy really did reach the bucket.
-  assert.equal(objects.get(blobKeyFor(await hashOf("a local"))), "a local");
+  assert.equal(objects.get(blobKeyFor(await hashOf("a local"))), wrapped("a local"));
   // The uploaded manifest names it, even though the conflict as a whole is reported failed.
   const manifestBody = objects.get(MANIFEST_KEY);
   assert.ok(manifestBody !== undefined);
-  const manifest = JSON.parse(manifestBody) as Snapshot;
+  const manifest = JSON.parse(unwrapped(manifestBody)) as Snapshot;
   const hashes = new Map(manifest.files.map((f) => [f.path, f.hash]));
   assert.equal(hashes.get(copyPath), await hashOf("a local"));
 });
@@ -888,16 +954,22 @@ test("syncOnce: the failure message counts files, not operation failures", async
   // A conflict whose restore and copy push both fail reports two operation failures for one vault
   // path. The user facing message must count the one file, not the two operations.
   const aV2Hash = await hashOf("a v2");
-  const ancestor = snapshot({ path: "a.md", size: 4, mtime: 1, hash: await hashOf("a v1") });
+  const ancestor = snapshot({
+    path: "a.md",
+    size: 4,
+    mtime: 1,
+    hash: await hashOf("a v1"),
+    blob: await hashOf("a v1"),
+  });
   const remoteManifest = encodeSnapshot(
-    snapshot({ path: "a.md", size: 4, mtime: 1, hash: aV2Hash }),
+    snapshot({ path: "a.md", size: 4, mtime: 1, hash: aV2Hash, blob: aV2Hash }),
   );
   // Both sides changed relative to the ancestor, so the plan is a single conflict (deletedSide
   // "none") for a.md. Its restore fails on the commit and its copy push is rejected by the
   // override below.
   const { storage } = fakeStorage({
-    [MANIFEST_KEY]: remoteManifest,
-    [blobKeyFor(aV2Hash)]: "a v2",
+    [MANIFEST_KEY]: wrapped(remoteManifest),
+    [blobKeyFor(aV2Hash)]: wrapped("a v2"),
   });
   const copyBlobKey = blobKeyFor(await hashOf("a local"));
   const inner = storage.putObject;
@@ -937,17 +1009,17 @@ test("syncOnce: a failed pull records progress without the ancestor ever advanci
   const aV1Hash = await hashOf("a v1");
   const aV2Hash = await hashOf("a v2");
   const beeHash = await hashOf("bee");
-  const ancestor = snapshot({ path: "a.md", size: 4, mtime: 1, hash: aV1Hash });
+  const ancestor = snapshot({ path: "a.md", size: 4, mtime: 1, hash: aV1Hash, blob: aV1Hash });
   const remoteManifest = encodeSnapshot(
     snapshot(
-      { path: "a.md", size: 4, mtime: 1, hash: aV2Hash },
-      { path: "b.md", size: 3, mtime: 1, hash: beeHash },
+      { path: "a.md", size: 4, mtime: 1, hash: aV2Hash, blob: aV2Hash },
+      { path: "b.md", size: 3, mtime: 1, hash: beeHash, blob: beeHash },
     ),
   );
   const { storage, objects } = fakeStorage({
-    [MANIFEST_KEY]: remoteManifest,
-    [blobKeyFor(aV2Hash)]: "a v2",
-    [blobKeyFor(beeHash)]: "bee",
+    [MANIFEST_KEY]: wrapped(remoteManifest),
+    [blobKeyFor(aV2Hash)]: wrapped("a v2"),
+    [blobKeyFor(beeHash)]: wrapped("bee"),
   });
   const inner = storage.putObject;
   let aPushes = 0;
@@ -1000,7 +1072,7 @@ test("syncOnce: a failed pull records progress without the ancestor ever advanci
 
   assert.equal(retry.ok, true);
   assert.equal(readerFiles["a.md"], "a v2");
-  assert.equal(objects.get(blobKeyFor(aV2Hash)), "a v2");
+  assert.equal(objects.get(blobKeyFor(aV2Hash)), wrapped("a v2"));
   assert.equal(aPushes, 0);
 });
 
@@ -1014,7 +1086,7 @@ test("syncOnce: two first syncs racing for an empty bucket, the loser fails inst
   storage.putObject = async (key, body, condition) => {
     if (key === MANIFEST_KEY && !raced) {
       raced = true;
-      await inner(MANIFEST_KEY, new TextEncoder().encode(otherManifest));
+      await inner(MANIFEST_KEY, new TextEncoder().encode(wrapped(otherManifest)));
     }
     return inner(key, body, condition);
   };
@@ -1025,20 +1097,20 @@ test("syncOnce: two first syncs racing for an empty bucket, the loser fails inst
   const outcome = await syncOnce(empty, reader, writer, storage, 1);
 
   assert.equal(outcome.ok, false);
-  assert.equal(objects.get(MANIFEST_KEY), otherManifest);
+  assert.equal(objects.get(MANIFEST_KEY), wrapped(otherManifest));
   assert.equal(files.get("a.md"), "alpha");
 });
 
 test("adoptLiveStats: an entry whose content matches the live vault adopts the live stats", () => {
-  const manifest = snapshot({ path: "a.md", size: 2, mtime: 5, hash: "h1" });
-  const live = snapshot({ path: "a.md", size: 2, mtime: 9, hash: "h1" });
+  const manifest = snapshot({ path: "a.md", size: 2, mtime: 5, hash: "h1", blob: "h1" });
+  const live = snapshot({ path: "a.md", size: 2, mtime: 9, hash: "h1", blob: "h1" });
 
   assert.deepEqual(adoptLiveStats(manifest, live), live);
 });
 
 test("adoptLiveStats: a mid sync edit keeps the manifest's entry, so the next diff sees it", () => {
   const manifest = snapshot(file("a.md", "h1"));
-  const live = snapshot({ path: "a.md", size: 7, mtime: 9, hash: "h2" });
+  const live = snapshot({ path: "a.md", size: 7, mtime: 9, hash: "h2", blob: "h2" });
 
   assert.deepEqual(adoptLiveStats(manifest, live), manifest);
 });

--- a/src/sync/sync.ts
+++ b/src/sync/sync.ts
@@ -1,3 +1,4 @@
+import { unwrapObject, wrapObject } from "../storage/envelope.ts";
 import type { ObjectMeta, PutCondition, StorageClient } from "../storage/storage.ts";
 import {
   byPath,
@@ -86,7 +87,23 @@ export async function readRemoteManifest(
   const fetched = await storage.getObject(MANIFEST_KEY);
 
   if (fetched.ok && fetched.body !== null) {
-    const decoded = decodeSnapshot(new TextDecoder().decode(fetched.body));
+    // The envelope is read before the JSON inside it, and its two unsupported reasons report the
+    // same thing an unknown manifest version does: this bucket was written by a build that knows
+    // something this one doesn't, so update rather than start over. That is the whole reason the
+    // envelope carries a version and a suite at all (#184): at 0.3.0 the payload here is
+    // ciphertext, and a build with no idea how to decrypt it must say so instead of handing bytes
+    // to a JSON parser and reporting the vault as corrupt.
+    const opened = unwrapObject(fetched.body);
+    if (!opened.ok) {
+      if (opened.reason === "corrupt") {
+        return { ok: false, message: "remote manifest is corrupt" };
+      }
+      return {
+        ok: false,
+        message: "remote manifest is a format this version of geode can't read",
+      };
+    }
+    const decoded = decodeSnapshot(new TextDecoder().decode(opened.payload));
     if (!decoded.ok) {
       if (decoded.reason === "unsupportedVersion") {
         return {
@@ -137,7 +154,17 @@ export async function readSentinel(
   const fetched = await storage.getObject(SENTINEL_KEY);
 
   if (fetched.ok && fetched.body !== null) {
-    const decoded = decodeSentinel(new TextDecoder().decode(fetched.body));
+    const opened = unwrapObject(fetched.body);
+    if (!opened.ok) {
+      if (opened.reason === "corrupt") {
+        return { ok: false, message: "remote sentinel is corrupt" };
+      }
+      return {
+        ok: false,
+        message: "remote sentinel is a format this version of geode can't read",
+      };
+    }
+    const decoded = decodeSentinel(new TextDecoder().decode(opened.payload));
     if (!decoded.ok) {
       if (decoded.reason === "unsupportedVersion") {
         return {
@@ -236,9 +263,9 @@ export async function syncOnce(
   // A missing manifest usually means a fresh bucket, but not always: a lifecycle rule, manual
   // cleanup, or partial restore can remove the manifest while blob objects survive (#109). Unlike
   // the plaintext path keyed layout this replaced, that survival is not automatically a hazard: a
-  // blob's key is its own content hash, so a survivor whose hash matches something the local
-  // vault still holds needs no recovery at all, the ordinary push below finds it already there
-  // (one HEAD, no re-upload) and the manifest this pass writes describes it correctly. What
+  // blob's key is an address derived from its own content, so a survivor at an address the local
+  // vault still resolves to needs no recovery at all, the ordinary push below finds it already
+  // there (one HEAD, no re-upload) and the manifest this pass writes describes it correctly. What
   // remains dangerous is a survivor whose hash matches nothing local: unexplained content this
   // device cannot account for, most plausibly a different vault's data that once shared this
   // bucket, or the very race #109 first named.
@@ -301,7 +328,7 @@ export async function syncOnce(
   // the pass's pushes invisible to every other device (#87).
   const manifest = manifestAfterSync(remoteView, executed.completed, executed.pushedFiles);
   const final = adoptLiveStats(manifest, await takeSnapshot(reader, local));
-  const manifestBody = new TextEncoder().encode(encodeSnapshot(final));
+  const manifestBody = wrapObject(new TextEncoder().encode(encodeSnapshot(final)));
 
   // The upload is conditional on the remote manifest still being exactly what this pass read at
   // the start (or still absent, on a first sync). An unconditional put would last-writer-win
@@ -338,8 +365,8 @@ export async function syncOnce(
   // loser's pass fails here rather than overwriting a vaultId another device already committed to,
   // and its retry adopts whichever one actually won.
   if (sentinelResult.sentinel === null) {
-    const sentinelBody = new TextEncoder().encode(
-      encodeSentinel({ vaultId: identity.vaultId, createdAt: now }),
+    const sentinelBody = wrapObject(
+      new TextEncoder().encode(encodeSentinel({ vaultId: identity.vaultId, createdAt: now })),
     );
     const sentinelUploaded = await storage.putObject(SENTINEL_KEY, sentinelBody, {
       kind: "ifAbsent",
@@ -378,21 +405,23 @@ export async function syncOnce(
   };
 }
 
-// unexplainedBlobs returns the blob keys a first sync cannot account for: survivors whose content
-// hash matches nothing in the local vault, so nothing this pass is about to do would ever
-// reference them. Every other survivor, whose hash a local file already carries, needs no special
+// unexplainedBlobs returns the blob keys a first sync cannot account for: survivors sitting at an
+// address no local file resolves to, so nothing this pass is about to do would ever reference
+// them. Every other survivor, at an address a local file already carries, needs no special
 // handling: the ordinary push below finds it already there and folds it into the manifest for
-// free. Exported for its tests; syncOnce is the only production caller.
+// free. The comparison is against addresses rather than content hashes because an address is what
+// a key is, and the two only coincide while the vault is unencrypted (#184). Exported for its
+// tests; syncOnce is the only production caller.
 export function unexplainedBlobs(objects: ObjectMeta[], local: Snapshot): string[] {
-  const localHashes = new Set<string>();
+  const localAddresses = new Set<string>();
   for (const entry of local.files) {
-    localHashes.add(entry.hash);
+    localAddresses.add(entry.blob);
   }
 
   const unexplained: string[] = [];
   for (const object of objects) {
-    const hash = object.key.slice(BLOB_PREFIX.length);
-    if (!localHashes.has(hash)) {
+    const address = object.key.slice(BLOB_PREFIX.length);
+    if (!localAddresses.has(address)) {
       unexplained.push(object.key);
     }
   }

--- a/src/vault/obsidian.test.ts
+++ b/src/vault/obsidian.test.ts
@@ -386,7 +386,7 @@ test("createObsidianStore: state that parses but is the wrong shape reads back a
 });
 
 test("createObsidianStore: a well shaped snapshot round-trips through write and read", async () => {
-  const snapshot: Snapshot = { files: [{ path: "a.md", size: 1, mtime: 2, hash: "h" }] };
+  const snapshot: Snapshot = { files: [{ path: "a.md", size: 1, mtime: 2, hash: "h", blob: "h" }] };
   const store = createObsidianStore(fakeAdapter(), STATE_PATH, DEFAULT_SETTINGS);
 
   await store.write(snapshot);
@@ -404,7 +404,7 @@ test("createObsidianStore: an interrupted write leaves the previous state.json u
   // the next sync to misread as a corrupt or empty ancestor.
   const previous = JSON.stringify({
     version: 2,
-    files: [{ path: "a.md", size: 1, mtime: 2, hash: "h" }],
+    files: [{ path: "a.md", size: 1, mtime: 2, hash: "h", blob: "h" }],
   });
   const adapter = fakeAdapter({ [STATE_PATH]: previous });
   adapter.rename = async () => {
@@ -420,7 +420,7 @@ test("createObsidianStore: an interrupted write leaves the previous state.json u
 test("createObsidianStore: a fingerprint mismatch reads back as empty", async () => {
   const adapter = fakeAdapter();
   const store1 = createObsidianStore(adapter, STATE_PATH, DEFAULT_SETTINGS);
-  const snapshot: Snapshot = { files: [{ path: "a.md", size: 1, mtime: 2, hash: "h" }] };
+  const snapshot: Snapshot = { files: [{ path: "a.md", size: 1, mtime: 2, hash: "h", blob: "h" }] };
 
   await store1.write(snapshot);
 
@@ -435,7 +435,7 @@ test("createObsidianStore: repointing at a bucket prefix reads back as empty (#1
   // own sentinel. Carrying the old ancestor across would diff this vault against a stranger's.
   const adapter = fakeAdapter();
   const store1 = createObsidianStore(adapter, STATE_PATH, DEFAULT_SETTINGS);
-  const snapshot: Snapshot = { files: [{ path: "a.md", size: 1, mtime: 2, hash: "h" }] };
+  const snapshot: Snapshot = { files: [{ path: "a.md", size: 1, mtime: 2, hash: "h", blob: "h" }] };
 
   await store1.write(snapshot);
 
@@ -459,7 +459,7 @@ test("fingerprintSettings: a prefix only written differently is the same target 
 test("createObsidianStore: rotating credentials keeps state, it does not change the target", async () => {
   const adapter = fakeAdapter();
   const store1 = createObsidianStore(adapter, STATE_PATH, DEFAULT_SETTINGS);
-  const snapshot: Snapshot = { files: [{ path: "a.md", size: 1, mtime: 2, hash: "h" }] };
+  const snapshot: Snapshot = { files: [{ path: "a.md", size: 1, mtime: 2, hash: "h", blob: "h" }] };
 
   await store1.write(snapshot);
 
@@ -479,7 +479,7 @@ test("createObsidianStore: a pre-marker state file with no version field and no 
   // State written by a build before the format version marker existed (#91) is version 1 by
   // definition; an upgrader's ancestor must survive the upgrade, not silently reset.
   // With fingerprinting added, it does NOT survive unless it has a fingerprint matching current. So it reads back as empty.
-  const files = [{ path: "a.md", size: 1, mtime: 2, hash: "h" }];
+  const files = [{ path: "a.md", size: 1, mtime: 2, hash: "h", blob: "h" }];
   const store = createObsidianStore(
     fakeAdapter({ [STATE_PATH]: JSON.stringify({ files }) }),
     STATE_PATH,

--- a/src/vault/vault.test.ts
+++ b/src/vault/vault.test.ts
@@ -161,7 +161,7 @@ test("isSafePath: traversal, absolute paths, reserved prefixes, and unsafe segme
 });
 
 test("encodeSnapshot: the wire format carries the version marker and round-trips", () => {
-  const snapshot: Snapshot = { files: [{ path: "a.md", size: 1, mtime: 2, hash: "h" }] };
+  const snapshot: Snapshot = { files: [{ path: "a.md", size: 1, mtime: 2, hash: "h", blob: "h" }] };
 
   const raw = encodeSnapshot(snapshot);
 
@@ -170,16 +170,16 @@ test("encodeSnapshot: the wire format carries the version marker and round-trips
 });
 
 test("decodeSnapshot: only the current version is accepted; version 1, missing, and newer are all refused", () => {
-  const files = [{ path: "a.md", size: 1, mtime: 2, hash: "h" }];
+  const files = [{ path: "a.md", size: 1, mtime: 2, hash: "h", blob: "h" }];
   const cases: { name: string; raw: string; want: DecodedSnapshot }[] = [
     {
       name: "the current versioned format",
-      raw: JSON.stringify({ version: 2, files }),
+      raw: JSON.stringify({ version: 3, files }),
       want: { ok: true, snapshot: { files } },
     },
     {
       // Version 1, plaintext path keyed storage, predates the marker (#91) and is version 1 by
-      // definition. Its JSON shape is identical to version 2's (both are `{files: [...]}`), only
+      // definition. Its JSON shape is close enough to be mistaken for a current one, and only
       // the marker distinguishes them, so this build refuses it rather than misread its paths as
       // content addressed keys.
       name: "a pre-marker snapshot with no version field",
@@ -193,7 +193,7 @@ test("decodeSnapshot: only the current version is accepted; version 1, missing, 
     },
     {
       name: "a version from a newer build",
-      raw: JSON.stringify({ version: 3, files }),
+      raw: JSON.stringify({ version: 4, files }),
       want: { ok: false, reason: "unsupportedVersion" },
     },
     {
@@ -201,7 +201,7 @@ test("decodeSnapshot: only the current version is accepted; version 1, missing, 
       // itself (files as an encrypted blob, say), and it must read as "needs a newer build",
       // never as corrupt.
       name: "a newer version whose shape this build does not understand",
-      raw: JSON.stringify({ version: 3, files: "ciphertext" }),
+      raw: JSON.stringify({ version: 4, files: "ciphertext" }),
       want: { ok: false, reason: "unsupportedVersion" },
     },
     {
@@ -212,7 +212,7 @@ test("decodeSnapshot: only the current version is accepted; version 1, missing, 
     { name: "bytes that aren't JSON", raw: "not json", want: { ok: false, reason: "corrupt" } },
     {
       name: "JSON of the wrong shape at the current version",
-      raw: JSON.stringify({ version: 2 }),
+      raw: JSON.stringify({ version: 3 }),
       want: { ok: false, reason: "corrupt" },
     },
     {
@@ -228,16 +228,16 @@ test("decodeSnapshot: only the current version is accepted; version 1, missing, 
       // segment in an otherwise well formed entry (#132).
       name: "a traversal segment in an entry's path",
       raw: JSON.stringify({
-        version: 2,
-        files: [{ path: "../../etc/passwd", size: 1, mtime: 2, hash: "h" }],
+        version: 3,
+        files: [{ path: "../../etc/passwd", size: 1, mtime: 2, hash: "h", blob: "h" }],
       }),
       want: { ok: false, reason: "unsafePath" },
     },
     {
       name: "one unsafe entry fails the whole snapshot, not just that entry",
       raw: JSON.stringify({
-        version: 2,
-        files: [...files, { path: "/etc/passwd", size: 1, mtime: 2, hash: "h" }],
+        version: 3,
+        files: [...files, { path: "/etc/passwd", size: 1, mtime: 2, hash: "h", blob: "h" }],
       }),
       want: { ok: false, reason: "unsafePath" },
     },
@@ -245,19 +245,41 @@ test("decodeSnapshot: only the current version is accepted; version 1, missing, 
       // isSnapshot doesn't validate each entry's shape, so a path that isn't even a string reaches
       // decodeSnapshot's own loop and must read as corrupt rather than crash there.
       name: "an entry whose path isn't a string",
-      raw: JSON.stringify({ version: 2, files: [{ path: 42, size: 1, mtime: 2, hash: "h" }] }),
+      raw: JSON.stringify({
+        version: 3,
+        files: [{ path: 42, size: 1, mtime: 2, hash: "h", blob: "h" }],
+      }),
+      want: { ok: false, reason: "corrupt" },
+    },
+    {
+      // A version 3 entry names the blob its content lives at (#184); one without an address is
+      // an older shape wearing a current marker, and guessing an address for it would fetch
+      // `.geode/blobs/undefined`.
+      name: "an entry with no blob address",
+      raw: JSON.stringify({ version: 3, files: [{ path: "a.md", size: 1, mtime: 2, hash: "h" }] }),
+      want: { ok: false, reason: "corrupt" },
+    },
+    {
+      // An address becomes the last segment of a bucket key, and a signed URL collapses relative
+      // segments itself, so one carrying a traversal would read an object outside the configured
+      // prefix entirely.
+      name: "a blob address that would steer a key out of the blob prefix",
+      raw: JSON.stringify({
+        version: 3,
+        files: [{ path: "a.md", size: 1, mtime: 2, hash: "h", blob: "../../elsewhere" }],
+      }),
       want: { ok: false, reason: "corrupt" },
     },
     {
       // A bare `null` array element reads .path on null, which throws rather than returning
       // undefined; the entry shape check must catch this before that property read happens.
       name: "a null entry",
-      raw: JSON.stringify({ version: 2, files: [null] }),
+      raw: JSON.stringify({ version: 3, files: [null] }),
       want: { ok: false, reason: "corrupt" },
     },
     {
       name: "a non-object entry",
-      raw: JSON.stringify({ version: 2, files: ["not-an-object"] }),
+      raw: JSON.stringify({ version: 3, files: ["not-an-object"] }),
       want: { ok: false, reason: "corrupt" },
     },
     {
@@ -265,10 +287,10 @@ test("decodeSnapshot: only the current version is accepted; version 1, missing, 
       // insensitive filesystems, so pulling both would silently let one overwrite the other (#94).
       name: "two paths differing only by case",
       raw: JSON.stringify({
-        version: 2,
+        version: 3,
         files: [
-          { path: "notes/Todo.md", size: 1, mtime: 2, hash: "h1" },
-          { path: "notes/todo.md", size: 1, mtime: 2, hash: "h2" },
+          { path: "notes/Todo.md", size: 1, mtime: 2, hash: "h1", blob: "h1" },
+          { path: "notes/todo.md", size: 1, mtime: 2, hash: "h2", blob: "h2" },
         ],
       }),
       want: { ok: false, reason: "caseCollision" },
@@ -276,10 +298,10 @@ test("decodeSnapshot: only the current version is accepted; version 1, missing, 
     {
       name: "paths that share a case fold but are otherwise identical are still a collision",
       raw: JSON.stringify({
-        version: 2,
+        version: 3,
         files: [
-          { path: "A.md", size: 1, mtime: 2, hash: "h1" },
-          { path: "a.md", size: 1, mtime: 2, hash: "h2" },
+          { path: "A.md", size: 1, mtime: 2, hash: "h1", blob: "h1" },
+          { path: "a.md", size: 1, mtime: 2, hash: "h2", blob: "h2" },
         ],
       }),
       want: { ok: false, reason: "caseCollision" },
@@ -382,7 +404,7 @@ test("diffSnapshots: an NFC and NFD pair for one file is not a change (#134)", a
 });
 
 test("decodeSnapshot: an NFD path in a manifest decodes to NFC (#134)", () => {
-  const nfdFile = { path: "café.md", size: 5, mtime: 1, hash: "abc" };
+  const nfdFile = { path: "café.md", size: 5, mtime: 1, hash: "abc", blob: "abc" };
   const raw = JSON.stringify({ version: SNAPSHOT_VERSION, files: [nfdFile] });
 
   const decoded = decodeSnapshot(raw);
@@ -396,8 +418,8 @@ test("decodeSnapshot: an NFD path in a manifest decodes to NFC (#134)", () => {
 test("decodeSnapshot: an NFC and NFD entry for one path is refused (#134)", () => {
   // Two entries, one file. Deciding which wins would silently drop an edit, and normalizing them
   // together would leave two manifest rows fighting over the same path on every later pass.
-  const nfcFile = { path: "café.md", size: 5, mtime: 1, hash: "abc" };
-  const nfdFile = { path: "café.md", size: 5, mtime: 1, hash: "def" };
+  const nfcFile = { path: "café.md", size: 5, mtime: 1, hash: "abc", blob: "abc" };
+  const nfdFile = { path: "café.md", size: 5, mtime: 1, hash: "def", blob: "def" };
   const raw = JSON.stringify({ version: SNAPSHOT_VERSION, files: [nfcFile, nfdFile] });
 
   const decoded = decodeSnapshot(raw);
@@ -408,8 +430,8 @@ test("decodeSnapshot: an NFC and NFD entry for one path is refused (#134)", () =
 test("decodeSnapshot: a duplicate path is refused even when the content matches", () => {
   // Identical hashes make this look harmless, but the manifest still names one path twice, and
   // nothing downstream is built to have two rows answer for one file.
-  const nfcFile = { path: "café.md", size: 5, mtime: 1, hash: "abc" };
-  const nfdFile = { path: "café.md", size: 5, mtime: 1, hash: "abc" };
+  const nfcFile = { path: "café.md", size: 5, mtime: 1, hash: "abc", blob: "abc" };
+  const nfdFile = { path: "café.md", size: 5, mtime: 1, hash: "abc", blob: "abc" };
   const raw = JSON.stringify({ version: SNAPSHOT_VERSION, files: [nfcFile, nfdFile] });
 
   const decoded = decodeSnapshot(raw);
@@ -420,8 +442,8 @@ test("decodeSnapshot: a duplicate path is refused even when the content matches"
 test("decodeSnapshot: NFC folding happens before the case fold, so both are caught (#134)", () => {
   // Normalizing first is what makes the #94 case check mean what it says: on the raw bytes an NFD
   // "Café.md" and an NFC "café.md" fold to different lowercase strings and both slip through.
-  const upper = { path: "CAFÉ.md", size: 5, mtime: 1, hash: "abc" };
-  const lower = { path: "café.md", size: 5, mtime: 1, hash: "def" };
+  const upper = { path: "CAFÉ.md", size: 5, mtime: 1, hash: "abc", blob: "abc" };
+  const lower = { path: "café.md", size: 5, mtime: 1, hash: "def", blob: "def" };
   const raw = JSON.stringify({ version: SNAPSHOT_VERSION, files: [upper, lower] });
 
   assert.deepEqual(decodeSnapshot(raw), { ok: false, reason: "caseCollision" });

--- a/src/vault/vault.ts
+++ b/src/vault/vault.ts
@@ -12,10 +12,18 @@ import {
 // moved file content off the vault path and onto a content addressed key under the manifest's own
 // bucket (`.geode/blobs/<hash>`, see sync/plan.ts); a version 1 manifest is refused rather than
 // read, since its paths point at objects this build never looks for again, and reading it as
-// version 2 would plan every push and pull against keys that were never written. There is no
-// migration path at this version: a bucket written before this change needs a fresh bucket, not an
-// upgrade.
-export const SNAPSHOT_VERSION = 2;
+// version 2 would plan every push and pull against keys that were never written. Version 3 split
+// where a file's content lives from what that content hashes to (FileState.blob against
+// FileState.hash, #184), so a version 2 manifest names no address for any of its entries and is
+// refused rather than have one guessed for it.
+//
+// None of these versions migrate: a bucket written before this change needs a fresh bucket, not an
+// upgrade. That is only acceptable because every one of them was settled before 0.1.0, while the
+// only vaults in a bucket were the project's own. From 0.1.0 onwards a bucket must be migrated
+// forward instead, so a version below SNAPSHOT_VERSION but at or above 3 is a decoder's job to
+// read and upgrade in place, never to refuse. Only a version above it stays refused, since no
+// build can migrate forward from a format that did not exist when it shipped.
+export const SNAPSHOT_VERSION = 3;
 
 // SNAPSHOT_BYTE_BUDGET caps how many bytes takeSnapshot buffers across its concurrent reads, low
 // enough that a vault of large attachments cannot pile eight full files into memory at once and
@@ -87,11 +95,27 @@ export type FileStat = {
 };
 
 // FileState is what geode remembers about one vault file as of the last snapshot.
+//
+// hash and blob answer two different questions that happen to have the same answer today. hash is
+// the SHA-256 of the file's own bytes: what the content is, how a diff notices an edit, and what a
+// pulled body is verified against before it lands on disk. blob is where those bytes live in the
+// bucket (`.geode/blobs/<blob>`, see blobKeyFor): an address, not a claim about content.
+//
+// They are separate fields because at 0.3.0 they stop being the same string (#184). An encrypted
+// vault addresses a blob by a keyed hash of the plaintext rather than its bare digest, so that
+// anyone who can list the bucket cannot test whether a file they already hold is in it; deriving
+// that address needs the vault key, which a device pulling a file it has never seen does not have
+// a plaintext to apply it to. So the address has to be written down against the path, next to,
+// rather than instead of, the digest that says whether the bytes came back intact.
+//
+// Every producer of a FileState derives blob from the file's own content, so two entries with the
+// same hash always carry the same blob and nothing downstream has to reconcile the two.
 export type FileState = {
   path: string;
   size: number;
   mtime: number;
   hash: string;
+  blob: string;
 };
 
 // Reader lists files present in the vault right now, reads their bytes, and reports what the index
@@ -158,6 +182,12 @@ export function byPath(files: FileState[]): Map<string, FileState> {
 // The returned snapshot carries only the in-memory shape; the version is a wire concern that
 // encodeSnapshot stamps back on at the next write.
 //
+// Refusing every version but the current one is only correct while every older version predates
+// 0.1.0 and so has no vaults to strand. Once a released format is superseded, this is where its
+// migration belongs: read the older shape, upgrade it to the current one, and hand it back ok, so
+// the next write stamps the new version and the bucket moves forward on its own. Only a version
+// above SNAPSHOT_VERSION stays refused (see the constant).
+//
 // Every entry's path is checked with isSafePath before the snapshot is handed back: both callers
 // are untrusted input (a remote manifest can be shaped by anyone who can write to the bucket, and
 // state.json flows through this same decoder), and a single unsafe path fails the whole snapshot
@@ -199,6 +229,17 @@ export function decodeSnapshot(raw: string): DecodedSnapshot {
     // .path off null or undefined throws) or a non-string path here despite what the narrowed
     // type above claims.
     if (typeof file !== "object" || file === null || typeof file.path !== "string") {
+      return { ok: false, reason: "corrupt" };
+    }
+
+    // A blob address is the only field here that becomes a bucket key, and it arrives from the
+    // same untrusted place every path does. encodeKey preserves "/" as a separator and leaves
+    // dots alone, and a signed URL collapses relative segments itself, so an address of
+    // "../../elsewhere" would read an object outside the configured prefix entirely; the same
+    // reasoning storage.ts refuses a bad prefix for. A missing address is refused by the same
+    // check, which is how a version 2 shaped entry smuggled in under a version 3 marker fails
+    // here rather than fetching `.geode/blobs/undefined`.
+    if (!isSafeAddress(file.blob)) {
       return { ok: false, reason: "corrupt" };
     }
 
@@ -405,12 +446,16 @@ export async function takeSnapshot(
     try {
       const bytes = await reader.readFile(file.path);
       hold.resize(bytes.length);
+      // Unencrypted, a blob is addressed by its own digest, so the two fields hold the same
+      // string; see FileState for why they are still recorded separately.
+      const hash = await hashBytes(bytes);
 
       return {
         path: normalizedPath,
         size: file.size,
         mtime: file.mtime,
-        hash: await hashBytes(bytes),
+        hash,
+        blob: hash,
       };
     } finally {
       hold.release();
@@ -485,6 +530,23 @@ function byteSemaphore(budget: number): { acquire: (bytes: number) => Promise<Ho
       });
     },
   };
+}
+
+// isSafeAddress reports whether value can be used as the last segment of a blob key. It is
+// deliberately a statement about keys rather than about digests: an address is 64 lowercase hex
+// characters today, but a future suite is free to encode it differently (#184), and a check that
+// pinned the alphabet would have to be relaxed exactly when the format changed. What must hold for
+// every scheme is that an address addresses one object under the blob prefix and cannot steer a
+// request anywhere else, so a separator or a relative segment is what's refused here.
+function isSafeAddress(value: unknown): boolean {
+  if (typeof value !== "string" || value === "") {
+    return false;
+  }
+  if (value.includes("/") || value.includes("\\")) {
+    return false;
+  }
+
+  return value !== "." && value !== "..";
 }
 
 // isWindowsReservedName reports whether segment is a Windows reserved device name, matched


### PR DESCRIPTION
Resolves [#184](https://github.com/8thpark/geode/issues/184)

## Problem

- Blobs are written to the bucket as raw bytes, so an encrypted blob and a plaintext one would be indistinguishable, leaving `0.3.0` to either bolt a discriminator onto a format with no room for one or force every user to re-upload their vault
- The manifest records a single hash per path, doing double duty as both the content digest and the bucket key, and those stop being the same string the moment addressing is keyed
- The window to settle this closes at `0.2.0`, when phones put real vaults in real buckets

## Changes

- Adds a six byte envelope, magic plus a version byte plus a suite byte, around every object geode writes: blobs, the manifest, and the sentinel
- Splits `FileState.blob`, the address content lives at, from `FileState.hash`, the digest of that content; identical today, different once addressing is keyed
- Bumps the snapshot version to `3`, since a version 2 manifest names no address for its entries; the last bump that asks for a fresh bucket, as from `0.1.0` a bucket is migrated forward instead
- Validates a blob address as a single safe key segment when a manifest is decoded, closing a path a crafted manifest could use to address objects outside the configured prefix
- Documents the bucket layout, the envelope, and exactly what encryption changes in `docs/object-format.md`

## Why

- An unknown version or suite now reports as needing a newer build rather than as corruption, which is the same posture the manifest version marker already takes, and the difference between a user updating the plugin and a user reaching for a backup
- Recording the address per entry is what lets `0.3.0` key blobs by an HMAC of the plaintext instead of its bare digest, so anyone who can list the bucket can no longer test whether a file they already hold is in the vault
- Settling the format while the only vaults in the field are ours costs one version bump; settling it after `0.2.0` costs everyone a full re-upload

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR reserves a versioned six-byte envelope for every Geode-owned bucket object and separates content digests from blob addresses in snapshot entries.
- Wraps and unwraps blobs, manifests, and sentinels at the storage boundary.
- Advances the snapshot format to version 3 and validates manifest-provided blob addresses.
- Updates sync execution, planning, fixtures, tests, and object-format documentation for the new representation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete changed-code defect identified.

The production paths consistently apply one envelope at each storage boundary, validate decoded addresses before use, and preserve digest-based integrity verification independently of object addressing.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/storage/envelope.ts | Introduces a small, consistently validated envelope with distinct corrupt, unsupported-version, and unsupported-suite outcomes. |
| src/sync/execute.ts | Wraps uploaded blobs, unwraps fetched blobs before integrity verification, and consistently uses the manifest's blob address for storage lookup. |
| src/sync/sync.ts | Applies the envelope exactly once to manifest and sentinel reads and writes while preserving conditional manifest publication. |
| src/vault/vault.ts | Adds mandatory blob addresses, advances snapshot versioning, and rejects addresses that are not safe single key segments. |
| src/sync/plan.ts | Recasts blob-key construction around explicit addresses without changing planning behavior. |
| docs/object-format.md | Documents the bucket layout, envelope bytes, refusal behavior, manifest fields, and planned encryption transition consistently with the implementation. |

<sub>Reviews (1): Last reviewed commit: ["Reserve an encryption envelope in the ob..."](https://github.com/8thpark/geode/commit/041c0622ee2005107ed8573e47817c4c2f91811d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50143241)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Sync flow](https://app.greptile.com/8thpark/-/custom-context/knowledge-base/8thpark/geode/-/docs/sync-flow.md)
- Knowledge Base — [Storage module](https://app.greptile.com/8thpark/-/custom-context/knowledge-base/8thpark/geode/-/docs/storage-module.md)
- Knowledge Base — [Vault module](https://app.greptile.com/8thpark/-/custom-context/knowledge-base/8thpark/geode/-/docs/vault-module.md)
</details>

<!-- /greptile_comment -->