### PR TITLE
[#102] Sync → Skip the manifest upload when a pass changes nothing

### DIFF
--- a/src/sync/sync.test.ts
+++ b/src/sync/sync.test.ts
@@ -303,6 +303,99 @@ test("syncOnce: a genuinely new bucket writes a sentinel too (#183)", async () =
   assert.equal(JSON.parse(unwrapped(written as string)).vaultId, "minted-id");
 });
 
+test("syncOnce: a pass with nothing to do writes nothing at all (#102)", async () => {
+  // Ancestor, local vault, and remote manifest all agree, so planSync produces no actions. Every
+  // manifest upload is a compare-and-swap, so a device with nothing to say is a device that can
+  // lose a race it had no reason to enter; under automatic sync (#93) two idle devices on a timer
+  // would trade "another device synced at the same time" errors over a vault nobody touched.
+  const ancestor: Snapshot = { files: [file("a.md", "h1")], vaultId: "known-id" };
+  const remoteManifest = wrapped(encodeSnapshot(snapshot(file("a.md", "h1"))));
+  const { storage, objects } = fakeStorage({
+    [MANIFEST_KEY]: remoteManifest,
+    [SENTINEL_KEY]: wrapped(encodeSentinel({ vaultId: "known-id", createdAt: 1000 })),
+  });
+  const written: string[] = [];
+  const inner = storage.putObject;
+  storage.putObject = async (key, body, condition) => {
+    written.push(key);
+    return inner(key, body, condition);
+  };
+  // "h1" and "xy" are both two bytes, so takeSnapshot stat-skips a.md and reuses the ancestor's
+  // hash: the local side is genuinely unchanged, not merely hashing to the same thing by luck.
+  const reader = fakeReader({ "a.md": "xy" });
+  const { writer } = fakeLocalWriter();
+
+  const outcome = await syncOnce(ancestor, reader, writer, storage, 1);
+
+  assert.ok(outcome.ok);
+  assert.equal(outcome.changeCount, 0);
+  assert.deepEqual(written, []);
+  // The bucket holds exactly what it held before the pass ran, down to the bytes.
+  assert.equal(objects.get(MANIFEST_KEY), remoteManifest);
+  // state.json still advances: skipping the remote write must never cost the next pass its
+  // stat-skip, or an idle sync would trade one wasted upload for a full rehash of the vault.
+  assert.deepEqual(outcome.snapshot.files, [file("a.md", "h1")]);
+  assert.equal(outcome.snapshot.vaultId, "known-id");
+});
+
+test("syncOnce: a first sync with nothing to do still writes the manifest (#102)", async () => {
+  // An empty vault against an empty bucket plans nothing, but the manifest existing is what tells
+  // every later pass this bucket has been synced before (see resolveVaultIdentity). Skipping it
+  // because the plan was empty would leave the bucket stuck in first sync state forever.
+  const reader = fakeReader({});
+  const { writer } = fakeLocalWriter();
+  const { storage, objects } = fakeStorage();
+
+  const outcome = await syncOnce(empty, reader, writer, storage, 1, () => "minted-id");
+
+  assert.ok(outcome.ok);
+  assert.equal(outcome.changeCount, 0);
+  assert.ok(objects.has(MANIFEST_KEY));
+  assert.ok(objects.has(SENTINEL_KEY));
+
+  // And the bootstrap really does end: the next pass reads a real manifest, is no longer a first
+  // sync, and goes back to writing nothing.
+  const written: string[] = [];
+  const inner = storage.putObject;
+  storage.putObject = async (key, body, condition) => {
+    written.push(key);
+    return inner(key, body, condition);
+  };
+
+  const again = await syncOnce(outcome.snapshot, reader, writer, storage, 1);
+
+  assert.ok(again.ok);
+  assert.deepEqual(written, []);
+});
+
+test("syncOnce: a pass with nothing to do still writes a missing sentinel (#102, #183)", async () => {
+  // The manifest exists but the sentinel does not: an upgrade from before sentinels existed, or a
+  // crash between the two writes of an otherwise successful first sync. Skipping the manifest write
+  // must not skip the repair. The sentinel write carries its own condition precisely so a bucket
+  // that lost one heals on the next pass, whether or not that pass had anything else to do.
+  const ancestor: Snapshot = { files: [file("a.md", "h1")] };
+  const { storage, objects } = fakeStorage({
+    [MANIFEST_KEY]: wrapped(encodeSnapshot(snapshot(file("a.md", "h1")))),
+  });
+  const written: string[] = [];
+  const inner = storage.putObject;
+  storage.putObject = async (key, body, condition) => {
+    written.push(key);
+    return inner(key, body, condition);
+  };
+  const reader = fakeReader({ "a.md": "xy" });
+  const { writer } = fakeLocalWriter();
+
+  const outcome = await syncOnce(ancestor, reader, writer, storage, 1, () => "minted-id");
+
+  assert.ok(outcome.ok);
+  assert.equal(outcome.changeCount, 0);
+  // The sentinel, and only the sentinel.
+  assert.deepEqual(written, [SENTINEL_KEY]);
+  assert.ok(objects.has(SENTINEL_KEY));
+  assert.equal(outcome.snapshot.vaultId, "minted-id");
+});
+
 test("syncOnce: a device pointed at a different vault's sentinel refuses (#183)", async () => {
   // This device already trusts a different vaultId (its state.json carries one from a prior
   // successful sync), and the bucket it is pointed at now belongs to a genuinely different vault.

--- a/src/sync/sync.ts
+++ b/src/sync/sync.ts
@@ -212,7 +212,8 @@ export function revertFailedPaths(
 // syncOnce runs one full sync pass over the injected local vault (reader/localWriter) and remote
 // bucket (storage): it snapshots the local vault against previous (the last synced snapshot),
 // reads the remote manifest, plans and executes the reconciliation, then uploads a manifest
-// reflecting what the bucket now actually holds. previous is passed in and the new
+// reflecting what the bucket now actually holds, unless it planned nothing and the manifest
+// already there already describes exactly that (#102). previous is passed in and the new
 // snapshot returned rather than read or written internally, so the caller owns persistence (the
 // plugin through state.json, tests through their own store) and this stays pure over its inputs.
 // now is injected so a conflict copy's name is deterministic under test. newVaultId mints the
@@ -328,34 +329,57 @@ export async function syncOnce(
   // the pass's pushes invisible to every other device (#87).
   const manifest = manifestAfterSync(remoteView, executed.completed, executed.pushedFiles);
   const final = adoptLiveStats(manifest, await takeSnapshot(reader, local));
-  const manifestBody = wrapObject(new TextEncoder().encode(encodeSnapshot(final)));
 
-  // The upload is conditional on the remote manifest still being exactly what this pass read at
-  // the start (or still absent, on a first sync). An unconditional put would last-writer-win
-  // against a device syncing at overlapping times, and the loser's pushes would then read as
-  // remote deletions on the winner's next sync: files silently deleted (#83). Losing the race
-  // fails this pass loudly instead; state.json doesn't advance, and the next sync re-reads the
-  // fresh manifest and reconciles both devices' work with nothing lost.
-  let condition: PutCondition = { kind: "ifAbsent" };
-  if (!remote.firstSync) {
-    condition = { kind: "ifMatch", etag: remote.etag };
-  }
-  const uploaded = await storage.putObject(MANIFEST_KEY, manifestBody, condition);
-  if (!uploaded.ok) {
-    if (uploaded.status === "conflict") {
+  // A pass that planned nothing did nothing, so the manifest it would write names exactly the
+  // paths, hashes, and blob addresses the one already in the bucket names. Only the per entry size
+  // and mtime differ, and no reader of a remote manifest consults either: diffSnapshots compares
+  // hashes, and the stat-skip that does read them reads state.json, never the bucket.
+  //
+  // Writing it anyway is not merely a wasted request (#102). Every manifest upload is a
+  // compare-and-swap, so a device with nothing to say is a device that can lose a race it had no
+  // reason to enter and report "another device synced at the same time" over a vault nobody
+  // touched. Under manual sync that costs one baffling click; under automatic sync (#93) it
+  // becomes a recurring error on a vault at rest, which is how a user learns to stop reading the
+  // status bar.
+  //
+  // A first sync uploads even having planned nothing: the manifest existing is what tells every
+  // later pass this bucket has been synced before (see resolveVaultIdentity), so an empty vault
+  // against an empty bucket must still write one or stay in first sync state forever. The sentinel
+  // write below is on its own condition for the same reason, and so still self heals a bucket that
+  // lost one, whether or not this pass had anything else to do.
+  //
+  // state.json is unaffected either way: the snapshot returned below still carries the fresh local
+  // stats adoptLiveStats just folded in, so skipping the remote write never costs the next pass
+  // its stat-skip.
+  if (actions.length > 0 || remote.firstSync) {
+    // The upload is conditional on the remote manifest still being exactly what this pass read at
+    // the start (or still absent, on a first sync). An unconditional put would last-writer-win
+    // against a device syncing at overlapping times, and the loser's pushes would then read as
+    // remote deletions on the winner's next sync: files silently deleted (#83). Losing the race
+    // fails this pass loudly instead; state.json doesn't advance, and the next sync re-reads the
+    // fresh manifest and reconciles both devices' work with nothing lost.
+    let condition: PutCondition = { kind: "ifAbsent" };
+    if (!remote.firstSync) {
+      condition = { kind: "ifMatch", etag: remote.etag };
+    }
+    const manifestBody = wrapObject(new TextEncoder().encode(encodeSnapshot(final)));
+    const uploaded = await storage.putObject(MANIFEST_KEY, manifestBody, condition);
+    if (!uploaded.ok) {
+      if (uploaded.status === "conflict") {
+        return {
+          ok: false,
+          message: "another device synced at the same time; sync again",
+          failures: executed.failures,
+          snapshot: null,
+        };
+      }
       return {
         ok: false,
-        message: "another device synced at the same time; sync again",
+        message: uploaded.message,
         failures: executed.failures,
         snapshot: null,
       };
     }
-    return {
-      ok: false,
-      message: uploaded.message,
-      failures: executed.failures,
-      snapshot: null,
-    };
   }
 
   // The manifest existing now is what every future pass uses to tell this bucket apart from one


### PR DESCRIPTION
Resolves [#102](https://github.com/8thpark/geode/issues/102)

## Problem

- Every sync pass uploads the full manifest, even when the plan is empty and neither side moved
- Each upload is a compare-and-swap, so a device with nothing to say can still lose a race it had no reason to enter, and report `another device synced at the same time` over a vault nobody touched
- Under manual sync that costs one baffling click; under automatic sync it becomes a recurring error on a vault at rest, which is how a user learns to stop reading the status bar

## Changes

- Skips the manifest write when the plan is empty, since the manifest it would upload names exactly the paths, hashes, and blob addresses the one already in the bucket names
- Keeps the write on a first sync, where the manifest existing is what tells every later pass this bucket has been synced before
- Leaves the sentinel write on its own condition, so a bucket that lost one still heals whether or not the pass had anything else to do

## Why

- Only the per entry size and mtime would have differed, and no reader of a remote manifest consults either; `diffSnapshots` compares hashes, and the stat-skip that does read them reads `state.json`
- `state.json` still advances with the fresh local stats, so skipping the remote write never costs the next pass its stat-skip
- Automatic sync is gated on this; two idle devices on a timer would otherwise trade conflict errors forever over a vault at rest

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR avoids unnecessary conditional manifest uploads for established buckets when a sync plan has no actions, while preserving manifest creation during first sync and independent repair of missing sentinels.
- Gates manifest serialization and upload on a nonempty plan or first sync.
- Continues returning fresh local snapshot metadata for state.json stat-skipping.
- Adds unit coverage for idle passes, empty first syncs, and missing-sentinel repair.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the skipped upload would not change remote paths, hashes, or blob mappings, and all required initialization and repair writes remain intact.

Empty established-vault plans now avoid only a semantically redundant manifest write; first sync still creates the manifest, missing sentinels still self-heal, and the returned snapshot retains fresh local metadata for subsequent stat-skipping.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/sync/sync.ts | Safely skips redundant manifest compare-and-swap writes on established no-op passes while retaining first-sync publication, sentinel repair, and local snapshot advancement. |
| src/sync/sync.test.ts | Adds focused regression coverage for the no-op skip, first-sync exception, subsequent idle pass, and sentinel-only repair path. |

<sub>Reviews (1): Last reviewed commit: ["Skip the manifest upload when a pass cha..."](https://github.com/8thpark/geode/commit/126f95d107750c1d65b1367bf0da67ed661e7dda) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50355399)</sub>

**Context used:**

- Knowledge Base — [Sync flow](https://app.greptile.com/8thpark/-/custom-context/knowledge-base/8thpark/geode/-/docs/sync-flow.md)

<!-- /greptile_comment -->