### PR TITLE
[#93] Sync → Sync automatically on local changes, focus, and a poll

### DIFF
--- a/docs/syncing.md
+++ b/docs/syncing.md
@@ -1,0 +1,94 @@
+<!-- omit in toc -->
+# Syncing
+
+When **Geode** syncs on its own, what stops it, and what happens when it can't. There is nothing to
+configure here; the only control is a pause, and it applies to one device.
+
+- [When Geode Syncs](#when-geode-syncs)
+- [What Never Happens Automatically](#what-never-happens-automatically)
+- [Pausing](#pausing)
+- [When A Sync Fails](#when-a-sync-fails)
+- [Why There Is No Interval Setting](#why-there-is-no-interval-setting)
+
+## When Geode Syncs
+
+Local changes have a signal: Obsidian tells the plugin the instant a file appears, changes, moves,
+or goes away. Remote changes have none, because no S3 compatible provider can notify a plugin, so
+the only way to find out is to ask. Everything below follows from that split.
+
+| Trigger      | Fires when                                            | Delay                |
+| ------------ | ----------------------------------------------------- | -------------------- |
+| Startup      | Obsidian has finished loading the vault               | Within a few seconds |
+| Local change | A file appears, changes, moves, or is deleted         | 5 seconds of quiet   |
+| Focus        | You come back to a window that has been away a while  | Immediately          |
+| Poll         | A timer, while the Obsidian window has focus          | Every 5 minutes      |
+| Manual       | You click the status bar, or run the **Sync** command | Immediately          |
+
+Some detail worth knowing:
+
+- **Local changes wait for quiet, not for a timer.** Five seconds after you stop typing, your work
+  is on its way. A burst of edits becomes one sync rather than one per keystroke, and typing that
+  never stops still syncs at least every 30 seconds so a long writing session is never stranded.
+- **A window without focus does not poll.** There is nothing to show you, and coming back to the
+  window is itself a trigger, so the gap closes in one sync the moment you look.
+- **Local changes sync even when the window is unfocused**, since a file can change without you
+  touching Obsidian.
+- **Coming back to a window syncs only if it has been away for at least a minute.** Switching
+  between apps is not a reason to sync.
+
+## What Never Happens Automatically
+
+**The first sync against a bucket is always something you ask for.** It creates the vault's
+identity, uploads everything, and is the one pass with no previous state to fall back on if
+something is misconfigured. Geode will not start it unattended. Once one has completed, everything
+in the table above takes over.
+
+The same applies if you point Geode at a different bucket: until a sync completes against the new
+one, automatic sync waits.
+
+Automatic sync also stays off while storage is not fully configured.
+
+## Pausing
+
+Two commands in the palette:
+
+- **Pause automatic sync**
+- **Resume automatic sync**
+
+Pausing applies to the device you run it on and survives a restart. It is deliberately not a
+setting, because settings live in your vault and travel to every device that syncs it; pausing your
+laptop should never quietly pause your desktop.
+
+While paused, the status bar shows a dimmed cloud with a line through it. Clicking it still syncs
+once, and the **Sync** command still works. Pause stops the timer, never the escape hatch.
+
+## When A Sync Fails
+
+Nothing is lost by a failed sync. Local edits stay local, remote edits stay remote, and the next
+successful pass reconciles both. What changes is how soon that next pass is attempted.
+
+| What went wrong                              | What Geode does                       |
+| -------------------------------------------- | ------------------------------------- |
+| Network, timeout, provider error             | Retries, waiting longer each time     |
+| Another device synced at the same moment     | Retries; both devices' work survives  |
+| One file failed, the rest went               | Keeps the progress, retries that file |
+| Secret access key missing                    | Stops automatic sync until you fix it |
+| Provider does not support conditional writes | Stops automatic sync until you fix it |
+
+The retry delay starts at 2 minutes and doubles with each consecutive failure, up to 30 minutes. A
+single success resets it, so an unreliable connection costs you one slow retry rather than a
+permanently slow client.
+
+The two cases that **stop** automatic sync do so because retrying cannot fix them, and retrying
+every few minutes for a week would only generate noise. Saving your settings, or syncing by hand,
+starts it again.
+
+## Why There Is No Interval Setting
+
+Because it would be a question you cannot answer. The right delay for pushing an edit we already
+know about is seconds; the right delay for asking a provider a question whose answer is almost
+always "nothing changed" is minutes. One number cannot be both, and every plugin that offers one
+gets both halves wrong at once.
+
+If the delays above turn out to be wrong, that is a bug to fix in a release rather than a dial to
+hand you.

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import { createLogSink } from "./log/adapter";
 import { createLogBus, createLogger, type LogBus, type Logger, type LogSink } from "./log/log";
 import { GeodeLogView, LOG_VIEW_TYPE } from "./log/view";
 import {
+  armed,
   DEFAULT_STATE,
   due,
   noteFocus,
@@ -299,14 +300,13 @@ export default class GeodePlugin extends Plugin {
     setTooltip(this.statusBarEl, tooltipFor(status, detail));
   }
 
-  // tick asks the scheduler, every TICK_MS, whether a pass is due. Every gate that is about
-  // whether a pass may run at all lives here, and every gate about whether it is time for one
-  // lives in the scheduler: configuration is the plugin's business, timing is not.
+  // tick asks the scheduler, every TICK_MS, whether a pass is due. Both questions it asks are
+  // answered in schedule.ts; all this contributes is reading the settings that armed needs, since
+  // knowing what a setting looks like is the one thing the scheduler is kept away from.
   private tick(): void {
-    if (this.paused || !this.syncedBefore) {
-      return;
-    }
-    if (!hasConnectionConfig(this.settings) || prefixError(this.settings.prefix) !== "") {
+    const configured =
+      hasConnectionConfig(this.settings) && prefixError(this.settings.prefix) === "";
+    if (!armed({ configured, paused: this.paused, syncedBefore: this.syncedBefore })) {
       return;
     }
     const decision = due(this.schedule, Date.now());

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,20 @@ import { createLogSink } from "./log/adapter";
 import { createLogBus, createLogger, type LogBus, type Logger, type LogSink } from "./log/log";
 import { GeodeLogView, LOG_VIEW_TYPE } from "./log/view";
 import {
+  DEFAULT_STATE,
+  due,
+  noteFocus,
+  notePassFinished,
+  notePassStarted,
+  noteResumed,
+  noteVaultChange,
+  PAUSE_KEY,
+  type PassResult,
+  type State,
+  TICK_MS,
+  type Trigger,
+} from "./schedule/schedule";
+import {
   DEFAULT_SETTINGS,
   type GeodeSettings,
   hasConnectionConfig,
@@ -21,7 +35,6 @@ import {
   createObsidianStore,
   flushOpenEditors,
 } from "./vault/obsidian";
-import { diffSnapshots, takeSnapshot } from "./vault/vault";
 
 // LOG_MIN_LEVEL is fixed rather than user configurable: there's no meaningful "quiet" mode to
 // offer today, so a verbosity setting would be a toggle with no observable effect.
@@ -30,10 +43,6 @@ const LOG_MIN_LEVEL = "debug";
 // MAX_LOG_LINES caps how many lines geode.log keeps on disk, so a long running session can't
 // grow it unbounded.
 const MAX_LOG_LINES = 500;
-
-// VAULT_STATE_DEBOUNCE_MS delays a vault state refresh after the last file event, so a burst of
-// edits (autosave, bulk rename, etc.) collapses into one snapshot instead of one per file.
-const VAULT_STATE_DEBOUNCE_MS = 2000;
 
 // DEVICE_SUFFIX_BYTES is how much randomness separates two devices carrying the same platform
 // label. Five bytes encode to exactly eight base32 characters with nothing left over.
@@ -51,7 +60,7 @@ type AppWithSetting = App & {
 };
 
 // SyncStatus is the state the status bar item reflects.
-type SyncStatus = "idle" | "syncing" | "error";
+type SyncStatus = "idle" | "syncing" | "error" | "paused";
 
 // deviceLabel returns the human recognisable half of this device's ID, lowercase to match the rest
 // of the suffix a conflict copy carries. The mobile checks come first: an iPad reports itself as
@@ -85,6 +94,9 @@ function iconFor(status: SyncStatus): string {
   if (status === "error") {
     return "cloud-alert";
   }
+  if (status === "paused") {
+    return "cloud-off";
+  }
   return "cloud";
 }
 
@@ -95,6 +107,9 @@ function tooltipFor(status: SyncStatus, detail: string): string {
   }
   if (status === "error") {
     return `Geode: ${detail}`;
+  }
+  if (status === "paused") {
+    return "Geode: automatic sync paused; click to sync once";
   }
   return "Geode: click to sync";
 }
@@ -111,10 +126,19 @@ export default class GeodePlugin extends Plugin {
   private logBus!: LogBus;
   private logSink!: LogSink;
   private statusBarEl!: HTMLElement;
-  private refreshTimer: number | undefined;
-  private refreshInFlight: Promise<void> | null = null;
-  private refreshQueued = false;
-  private syncing = false;
+  // schedule decides when an automatic pass is due (#93). It holds the in flight flag too, so
+  // "a pass is running" has one home rather than a plugin field and a scheduler field that can
+  // disagree.
+  private schedule: State = DEFAULT_STATE;
+  // paused is this device's own answer to whether automatic sync runs at all, remembered across
+  // restarts in localStorage (see PAUSE_KEY). Manual sync ignores it entirely.
+  private paused = false;
+  // syncedBefore gates automatic sync on a completed sync already existing for this bucket. A
+  // bucket's first pass mints its identity, uploads the whole vault, and has no ancestor to fall
+  // back on if the configuration is wrong, so it stays something a user asks for rather than
+  // something that happens to them. Reloaded whenever settings change, which is what makes
+  // repointing at a fresh bucket demote it back to a manual first sync.
+  private syncedBefore = false;
   // The manifest compare-and-swap that keeps overlapping syncs from clobbering each other (#83)
   // only holds if the provider honours conditional writes. testConnection probes for this, but
   // nothing forces a user to run it, so sync verifies once per session before it trusts the CAS
@@ -125,6 +149,7 @@ export default class GeodePlugin extends Plugin {
   async onload() {
     await this.loadSettings();
     this.deviceId = this.loadDeviceId();
+    this.paused = this.app.loadLocalStorage(PAUSE_KEY) === true;
 
     this.logSink = createLogSink(this.app.vault.adapter, this.manifest.dir, MAX_LOG_LINES);
     this.logBus = createLogBus();
@@ -144,33 +169,75 @@ export default class GeodePlugin extends Plugin {
     this.addCommand({
       id: "sync",
       name: "Sync",
-      callback: () => void this.syncNow(),
+      callback: () => void this.syncNow("manual"),
+    });
+    // Two commands rather than one toggle, so the palette only ever offers the one that would do
+    // something, and its name says what that is without the user having to know the current state.
+    this.addCommand({
+      id: "pause",
+      name: "Pause automatic sync",
+      checkCallback: (checking) => {
+        if (this.paused) {
+          return false;
+        }
+        if (!checking) {
+          this.setPaused(true);
+        }
+        return true;
+      },
+    });
+    this.addCommand({
+      id: "resume",
+      name: "Resume automatic sync",
+      checkCallback: (checking) => {
+        if (!this.paused) {
+          return false;
+        }
+        if (!checking) {
+          this.setPaused(false);
+        }
+        return true;
+      },
     });
     this.register(() => this.app.workspace.detachLeavesOfType(LOG_VIEW_TYPE));
 
     this.statusBarEl = this.addStatusBarItem();
     this.statusBarEl.addClass("geode-status-bar", "mod-clickable");
-    this.statusBarEl.addEventListener("click", () => void this.syncNow());
-    this.setSyncStatus("idle", "");
+    this.statusBarEl.addEventListener("click", () => void this.syncNow("manual"));
+    this.setSyncStatus(this.restingStatus(), "");
 
     this.addSettingTab(new GeodeSettingTab(this.app, this));
     this.logger.info(`loaded (provider=${this.settings.provider}, device=${this.deviceId})`);
 
     // onLayoutReady, not onload directly: the vault isn't guaranteed fully indexed yet at
-    // onload time, and a snapshot taken too early would see an incomplete file list.
+    // onload time, and every file would otherwise arrive as a create event the moment the index
+    // caught up (#44).
     this.app.workspace.onLayoutReady(() => {
-      void this.refreshVaultState();
+      void this.loadSyncedBefore();
+      this.schedule = noteFocus(this.schedule, document.hasFocus(), Date.now());
 
-      this.registerEvent(this.app.vault.on("create", () => this.scheduleVaultStateRefresh()));
-      this.registerEvent(this.app.vault.on("modify", () => this.scheduleVaultStateRefresh()));
-      this.registerEvent(this.app.vault.on("delete", () => this.scheduleVaultStateRefresh()));
-      this.registerEvent(this.app.vault.on("rename", () => this.scheduleVaultStateRefresh()));
-    });
+      this.registerEvent(this.app.vault.on("create", () => this.noteVaultChanged()));
+      this.registerEvent(this.app.vault.on("modify", () => this.noteVaultChanged()));
+      this.registerEvent(this.app.vault.on("delete", () => this.noteVaultChanged()));
+      this.registerEvent(this.app.vault.on("rename", () => this.noteVaultChanged()));
 
-    this.register(() => {
-      if (this.refreshTimer !== undefined) {
-        window.clearTimeout(this.refreshTimer);
-      }
+      // Focus is both a gate and a trigger: an unfocused window polls for nothing, and coming back
+      // to a machine is the moment stale content is most likely and most visible.
+      this.registerDomEvent(window, "focus", () => {
+        this.schedule = noteFocus(this.schedule, true, Date.now());
+      });
+      this.registerDomEvent(window, "blur", () => {
+        this.schedule = noteFocus(this.schedule, false, Date.now());
+      });
+      // Reconnecting is not treated as proof anything works, only as reason enough to stop waiting
+      // out a backoff whose premise has visibly expired. Nothing gates on navigator.onLine, which
+      // reports being on a network rather than being able to reach anything: trusting it would
+      // turn one wrong answer into a sync that silently never runs.
+      this.registerDomEvent(window, "online", () => {
+        this.schedule = noteResumed(this.schedule);
+      });
+
+      this.registerInterval(window.setInterval(() => this.tick(), TICK_MS));
     });
   }
 
@@ -201,20 +268,62 @@ export default class GeodePlugin extends Plugin {
     app.setting.openTabById(this.manifest.id);
   }
 
+  // restingStatus returns the status bar state to fall back to once nothing is happening, which is
+  // "paused" rather than "idle" on a device where automatic sync is switched off. Silence means
+  // everything is fine only if a device that has stopped syncing says so.
+  private restingStatus(): SyncStatus {
+    if (this.paused) {
+      return "paused";
+    }
+
+    return "idle";
+  }
+
+  // setPaused switches automatic sync on or off for this device and remembers the answer.
+  private setPaused(paused: boolean): void {
+    this.paused = paused;
+    this.app.saveLocalStorage(PAUSE_KEY, paused);
+    this.setSyncStatus(this.restingStatus(), "");
+    if (paused) {
+      this.logger.info("automatic sync paused on this device");
+      return;
+    }
+    this.logger.info("automatic sync resumed on this device");
+  }
+
   // setSyncStatus updates the status bar icon and tooltip to reflect status.
   private setSyncStatus(status: SyncStatus, detail: string): void {
-    this.statusBarEl.removeClass("is-idle", "is-syncing", "is-error");
+    this.statusBarEl.removeClass("is-idle", "is-syncing", "is-error", "is-paused");
     this.statusBarEl.addClass(`is-${status}`);
     setIcon(this.statusBarEl, iconFor(status));
     setTooltip(this.statusBarEl, tooltipFor(status, detail));
   }
 
+  // tick asks the scheduler, every TICK_MS, whether a pass is due. Every gate that is about
+  // whether a pass may run at all lives here, and every gate about whether it is time for one
+  // lives in the scheduler: configuration is the plugin's business, timing is not.
+  private tick(): void {
+    if (this.paused || !this.syncedBefore) {
+      return;
+    }
+    if (!hasConnectionConfig(this.settings) || prefixError(this.settings.prefix) !== "") {
+      return;
+    }
+    const decision = due(this.schedule, Date.now());
+    if (!decision.due) {
+      return;
+    }
+    void this.syncNow(decision.trigger);
+  }
+
   // syncNow pushes every local change since the last sync to remote storage, pulls every remote
   // change since then down locally, and renames the local side of anything that changed on both
   // ends to a conflict copy rather than ever guessing which edit should win. Refuses to start a
-  // second sync while one is already running.
-  async syncNow(): Promise<void> {
-    if (this.syncing) {
+  // second sync while one is already running. A manual pass ignores a pause and clears any halt:
+  // the escape hatch has to work in every state, especially the one where the automatic path has
+  // given up.
+  async syncNow(trigger: Trigger = "manual"): Promise<void> {
+    if (this.schedule.syncing) {
       return;
     }
     if (!hasConnectionConfig(this.settings)) {
@@ -239,10 +348,14 @@ export default class GeodePlugin extends Plugin {
       return;
     }
 
-    this.syncing = true;
+    if (trigger === "manual") {
+      this.schedule = noteResumed(this.schedule);
+    }
+    this.schedule = notePassStarted(this.schedule);
     this.setSyncStatus("syncing", "");
+    let result: PassResult = "retry";
     try {
-      await this.runSync(dir);
+      result = await this.runSync(dir, trigger);
     } catch (err) {
       let message = "unexpected error";
       if (err instanceof Error) {
@@ -251,18 +364,21 @@ export default class GeodePlugin extends Plugin {
       this.logger.error(`sync: ${message}`);
       this.setSyncStatus("error", message);
     } finally {
-      this.syncing = false;
+      this.schedule = notePassFinished(this.schedule, result, Date.now());
     }
   }
 
   // runSync does the actual work of syncNow, split out so syncNow can own the in flight guard
-  // and status bar bookkeeping around it without this getting lost in indentation.
-  private async runSync(dir: string): Promise<void> {
+  // and status bar bookkeeping around it without this getting lost in indentation. Its result is
+  // what the scheduler backs off from: "retry" for anything a later attempt could plausibly fix,
+  // "stop" for the failures where retrying every few minutes is just noise (a secret that isn't
+  // there, a provider that won't honour the conditional writes every safety property rests on).
+  private async runSync(dir: string, trigger: Trigger): Promise<PassResult> {
     const secretAccessKey = this.app.secretStorage.getSecret(this.settings.secretId);
     if (secretAccessKey === null || secretAccessKey === "") {
       this.logger.error(`sync: secret access key not found for ID "${this.settings.secretId}"`);
       this.setSyncStatus("error", "secret access key not found; open settings to reconfigure");
-      return;
+      return "stop";
     }
 
     const storage = createS3Client(this.settings, secretAccessKey, obsidianTransport);
@@ -272,7 +388,7 @@ export default class GeodePlugin extends Plugin {
       if (!probe.ok) {
         this.logger.error(`sync: conditional write check failed: ${probe.message}`);
         this.setSyncStatus("error", probe.message);
-        return;
+        return "stop";
       }
       this.conditionalWritesVerified = true;
       this.logger.info("sync: conditional write support verified");
@@ -311,12 +427,22 @@ export default class GeodePlugin extends Plugin {
       }
       this.logger.error(`sync: ${outcome.message}`);
       this.setSyncStatus("error", outcome.message);
-      return;
+      return "retry";
     }
 
     await stateStore.write(outcome.snapshot);
-    this.logger.info(`sync: complete (${outcome.changeCount} change(s) applied)`);
-    this.setSyncStatus("idle", "");
+    this.syncedBefore = true;
+    // A pass that changed nothing is the ordinary case once sync is automatic, and a line for each
+    // one would push everything worth reading out of a 500 line file inside two days. A pass a user
+    // asked for always reports, since they are standing there waiting for an answer. Nothing is
+    // logged when a pass starts, for the same reason: a "starting" line with no matching "complete"
+    // is how a perfectly ordinary idle poll would come to look like a hang.
+    if (outcome.changeCount > 0 || trigger === "manual") {
+      this.logger.info(`sync: complete (${trigger}, ${outcome.changeCount} change(s) applied)`);
+    }
+    this.setSyncStatus(this.restingStatus(), "");
+
+    return "ok";
   }
 
   // loadDeviceId returns this device's identity, minting and storing one the first time it runs on
@@ -339,77 +465,42 @@ export default class GeodePlugin extends Plugin {
     this.settings = normalizeSettings(await this.loadData());
   }
 
+  // loadSyncedBefore records whether this vault has already completed a sync against the currently
+  // configured bucket, which is what automatic sync waits for. The answer comes from state.json
+  // carrying a vaultId, and createObsidianStore refuses a state file written against different
+  // settings (#89), so repointing at another bucket reads back as never synced and correctly
+  // demands a manual first pass rather than starting one unattended.
+  private async loadSyncedBefore(): Promise<void> {
+    const dir = this.manifest.dir;
+    if (dir === undefined) {
+      return;
+    }
+    const store = createObsidianStore(this.app.vault.adapter, `${dir}/state.json`, this.settings);
+    try {
+      const snapshot = await store.read();
+      this.syncedBefore = snapshot.vaultId !== undefined;
+    } catch (err) {
+      this.syncedBefore = false;
+      this.logger.error(`could not read sync state: ${err}`);
+    }
+  }
+
+  // noteVaultChanged records a local file appearing, changing, moving, or going away, which is
+  // what starts the quiet period before the next push. No debounce here: the scheduler owns every
+  // delay, and this stays a single assignment on the hot path of a vault event.
+  private noteVaultChanged(): void {
+    this.schedule = noteVaultChange(this.schedule, Date.now());
+  }
+
   async saveSettings() {
     await this.saveData(this.settings);
     // A settings change may point at a different provider, so the next sync must re-verify
     // conditional write support rather than trust the last provider's result.
     this.conditionalWritesVerified = false;
+    // Saving settings is the one action most likely to have fixed whatever a halt was about, and
+    // it may also have repointed the vault at a bucket it has never synced.
+    this.schedule = noteResumed(this.schedule);
+    await this.loadSyncedBefore();
     this.logger.info("settings saved");
-  }
-
-  // scheduleVaultStateRefresh debounces refreshVaultState so a burst of vault events collapses
-  // into a single snapshot instead of one per file.
-  private scheduleVaultStateRefresh() {
-    if (this.refreshTimer !== undefined) {
-      window.clearTimeout(this.refreshTimer);
-    }
-    this.refreshTimer = window.setTimeout(() => {
-      this.refreshTimer = undefined;
-      void this.refreshVaultState();
-    }, VAULT_STATE_DEBOUNCE_MS);
-  }
-
-  // refreshVaultState logs how many local changes have accumulated since the last successful
-  // sync. It deliberately does NOT persist anything: state.json is the last synced snapshot, the
-  // common ancestor sync diffs both sides against, and only a completed sync may write it. Writing
-  // the live vault here would poison that ancestor, so a brand new local file would look like a
-  // remote deletion on the next sync and get wiped.
-  //
-  // While a refresh is already running, subsequent calls are coalesced: at most one extra refresh
-  // runs after the in-flight one finishes, catching any changes that arrived mid-snapshot.
-  async refreshVaultState(): Promise<void> {
-    if (this.refreshInFlight !== null) {
-      this.refreshQueued = true;
-      return this.refreshInFlight;
-    }
-
-    let runQueued = false;
-    this.refreshInFlight = this.doRefresh();
-    try {
-      await this.refreshInFlight;
-      runQueued = this.refreshQueued;
-    } finally {
-      this.refreshInFlight = null;
-      this.refreshQueued = false;
-    }
-
-    if (runQueued) {
-      return this.refreshVaultState();
-    }
-  }
-
-  // doRefresh does the actual snapshot and diff work, split out so refreshVaultState can own the
-  // in flight guard without this getting lost in indentation.
-  private async doRefresh(): Promise<void> {
-    const dir = this.manifest.dir;
-    if (dir === undefined) {
-      return;
-    }
-
-    const store = createObsidianStore(this.app.vault.adapter, `${dir}/state.json`, this.settings);
-    const reader = createObsidianReader(this.app.vault);
-
-    // Both callers fire this and forget (void), so a rejection here would surface as an
-    // unhandled promise rejection. takeSnapshot can throw when a file vanishes mid-snapshot
-    // (a live vault race), so convert any failure to a logged result at this boundary.
-    try {
-      const previous = await store.read();
-      const current = await takeSnapshot(reader, previous);
-      const changes = diffSnapshots(previous, current);
-
-      this.logger.info(`vault state refreshed (${changes.length} change(s) since last run)`);
-    } catch (err) {
-      this.logger.error(`vault state refresh failed: ${err}`);
-    }
   }
 }

--- a/src/schedule/schedule.test.ts
+++ b/src/schedule/schedule.test.ts
@@ -1,0 +1,245 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  BACKOFF_BASE_MS,
+  BACKOFF_MAX_MS,
+  DEFAULT_STATE,
+  type Due,
+  due,
+  FOCUS_MIN_GAP_MS,
+  LOCAL_MAX_WAIT_MS,
+  LOCAL_QUIET_MS,
+  noteFocus,
+  notePassFinished,
+  notePassStarted,
+  noteResumed,
+  noteVaultChange,
+  POLL_INTERVAL_MS,
+  type State,
+} from "./schedule.ts";
+
+// NOW is the clock reading every case measures back from. Nothing depends on the value beyond it
+// being large enough that subtracting any delay below stays comfortably positive.
+const NOW = 10_000_000;
+
+// idle returns a scheduler that finished a pass at NOW and holds focus it gained before that pass,
+// so neither the poll nor the focus rule is armed. Almost every case starts here and moves exactly
+// one thing, since a case that arms two rules at once proves nothing about which one answered.
+function idle(over: Partial<State> = {}): State {
+  return { ...DEFAULT_STATE, lastPassAt: NOW, focusedAt: NOW - FOCUS_MIN_GAP_MS, ...over };
+}
+
+// pending returns the two fields a vault change sets, for a case that needs local work waiting
+// without caring how it got there.
+function pending(since: number, last: number): Partial<State> {
+  return { pendingSince: since, lastEventAt: last };
+}
+
+test("due: each rule fires on its own terms, and the order between them holds", () => {
+  const cases: { name: string; state: State; want: Due }[] = [
+    {
+      name: "nothing has ever synced, so the first tick is the startup catch up",
+      state: DEFAULT_STATE,
+      want: { due: true, trigger: "startup" },
+    },
+    {
+      name: "a pass already in flight outranks every reason to start another",
+      state: idle({ syncing: true, ...pending(NOW - LOCAL_QUIET_MS, NOW - LOCAL_QUIET_MS) }),
+      want: { due: false },
+    },
+    {
+      name: "a halt outranks every reason to start one, including the startup catch up",
+      state: idle({ stopped: true, lastPassAt: 0 }),
+      want: { due: false },
+    },
+    {
+      name: "local changes push once the vault has been quiet long enough",
+      state: idle(pending(NOW - LOCAL_QUIET_MS, NOW - LOCAL_QUIET_MS)),
+      want: { due: true, trigger: "local" },
+    },
+    {
+      name: "local changes wait while the vault is still busy",
+      state: idle(pending(NOW - 1_000, NOW - 1_000)),
+      want: { due: false },
+    },
+    {
+      name: "typing that never goes quiet still pushes at the ceiling",
+      state: idle(pending(NOW - LOCAL_MAX_WAIT_MS, NOW)),
+      want: { due: true, trigger: "local" },
+    },
+    {
+      name: "local changes push even while the window is unfocused, since files move without it",
+      state: idle({ focusedAt: 0, ...pending(NOW - LOCAL_QUIET_MS, NOW - LOCAL_QUIET_MS) }),
+      want: { due: true, trigger: "local" },
+    },
+    {
+      name: "an unfocused window never polls, however long it has been",
+      state: idle({ focusedAt: 0, lastPassAt: NOW - POLL_INTERVAL_MS }),
+      want: { due: false },
+    },
+    {
+      name: "a focused window polls once the interval has passed",
+      state: idle({ lastPassAt: NOW - POLL_INTERVAL_MS, focusedAt: NOW - POLL_INTERVAL_MS - 1 }),
+      want: { due: true, trigger: "poll" },
+    },
+    {
+      name: "regaining focus after a long absence syncs without waiting for the poll",
+      state: idle({ lastPassAt: NOW - FOCUS_MIN_GAP_MS, focusedAt: NOW }),
+      want: { due: true, trigger: "focus" },
+    },
+    {
+      name: "alt tabbing back within the gap is not a sync trigger",
+      state: idle({ lastPassAt: NOW - 1_000, focusedAt: NOW }),
+      want: { due: false },
+    },
+    {
+      name: "a backoff outranks local work, so a failing vault is not retried every quiet period",
+      state: idle({
+        failures: 1,
+        lastPassAt: NOW - BACKOFF_BASE_MS + 1,
+        ...pending(NOW - LOCAL_QUIET_MS, NOW - LOCAL_QUIET_MS),
+      }),
+      want: { due: false },
+    },
+    {
+      name: "the retry runs the moment the backoff expires",
+      state: idle({
+        failures: 1,
+        lastPassAt: NOW - BACKOFF_BASE_MS,
+        ...pending(NOW - LOCAL_QUIET_MS, NOW - LOCAL_QUIET_MS),
+      }),
+      want: { due: true, trigger: "local" },
+    },
+    {
+      name: "three consecutive failures wait four times the base delay, not one",
+      state: idle({
+        failures: 3,
+        lastPassAt: NOW - BACKOFF_BASE_MS * 4 + 1,
+        ...pending(NOW - LOCAL_QUIET_MS, NOW - LOCAL_QUIET_MS),
+      }),
+      want: { due: false },
+    },
+    {
+      name: "and run once that longer delay expires",
+      state: idle({
+        failures: 3,
+        lastPassAt: NOW - BACKOFF_BASE_MS * 4,
+        ...pending(NOW - LOCAL_QUIET_MS, NOW - LOCAL_QUIET_MS),
+      }),
+      want: { due: true, trigger: "local" },
+    },
+    {
+      name: "a long offline stretch stops doubling at the cap rather than growing forever",
+      state: idle({
+        failures: 20,
+        lastPassAt: NOW - BACKOFF_MAX_MS,
+        ...pending(NOW - LOCAL_QUIET_MS, NOW - LOCAL_QUIET_MS),
+      }),
+      want: { due: true, trigger: "local" },
+    },
+  ];
+
+  for (const c of cases) {
+    assert.deepEqual(due(c.state, NOW), c.want, c.name);
+  }
+});
+
+test("noteVaultChange: the first change starts the ceiling, every change resets the quiet period", () => {
+  const first = noteVaultChange(DEFAULT_STATE, 100);
+  assert.equal(first.pendingSince, 100);
+  assert.equal(first.lastEventAt, 100);
+
+  // The ceiling is measured from the oldest pending change, so a second edit must not push it
+  // forward; only the quiet period restarts. Otherwise continuous typing would reset both clocks
+  // together and nothing would ever be pushed.
+  const second = noteVaultChange(first, 900);
+  assert.equal(second.pendingSince, 100);
+  assert.equal(second.lastEventAt, 900);
+});
+
+test("notePassStarted: pending work is cleared, because the pass about to run covers it", () => {
+  const started = notePassStarted(noteVaultChange(DEFAULT_STATE, 100));
+
+  assert.equal(started.syncing, true);
+  assert.equal(started.pendingSince, 0);
+  assert.equal(started.lastEventAt, 0);
+});
+
+test("notePassStarted: an edit landing mid pass is still pending once the pass finishes", () => {
+  // The pass snapshots the vault at its own start, so an edit arriving after that is not covered
+  // by it and has to survive into the next one. Clearing pending at the end of a pass rather than
+  // the start is exactly how that edit would get lost.
+  let state = notePassStarted(noteVaultChange(DEFAULT_STATE, 100));
+  state = noteVaultChange(state, 200);
+  state = notePassFinished(state, "ok", 300);
+
+  assert.equal(state.pendingSince, 200);
+  assert.deepEqual(due(state, 200 + LOCAL_QUIET_MS), { due: true, trigger: "local" });
+});
+
+test("notePassFinished: a success wipes the slate, a failure counts, a terminal failure halts", () => {
+  const failed = notePassFinished(notePassFinished(DEFAULT_STATE, "retry", 100), "retry", 200);
+  assert.equal(failed.failures, 2);
+  assert.equal(failed.stopped, false);
+  // lastPassAt advances on a failure too: it is what the backoff is measured from, so a pass that
+  // failed still has to have happened at a time.
+  assert.equal(failed.lastPassAt, 200);
+
+  const recovered = notePassFinished(failed, "ok", 300);
+  assert.equal(recovered.failures, 0);
+  assert.equal(recovered.syncing, false);
+
+  const halted = notePassFinished(failed, "stop", 300);
+  assert.equal(halted.stopped, true);
+  assert.deepEqual(due(halted, 300 + BACKOFF_MAX_MS * 10), { due: false });
+});
+
+test("noteResumed: clears a halt and the accumulated backoff, and nothing else does", () => {
+  let state = notePassFinished(DEFAULT_STATE, "stop", 100);
+  // A halt survives anything that is not a deliberate resume, so a stopped scheduler cannot drift
+  // back into retrying credentials that are still wrong.
+  state = noteVaultChange(state, 200);
+  state = noteFocus(state, true, 300);
+  assert.equal(state.stopped, true);
+
+  const resumed = noteResumed(state);
+  assert.equal(resumed.stopped, false);
+  assert.equal(resumed.failures, 0);
+});
+
+test("noteFocus: losing focus clears the timestamp rather than setting a second flag", () => {
+  const focused = noteFocus(DEFAULT_STATE, true, 100);
+  assert.equal(focused.focusedAt, 100);
+
+  const blurred = noteFocus(focused, false, 200);
+  assert.equal(blurred.focusedAt, 0);
+});
+
+test("a burst of edits collapses into one pass, and the vault then goes quiet", () => {
+  // The scenario the quiet period exists for: forty keystrokes' worth of vault events a hundred
+  // milliseconds apart, which must produce exactly one pass rather than forty.
+  let state = { ...DEFAULT_STATE, lastPassAt: NOW, focusedAt: NOW - FOCUS_MIN_GAP_MS };
+  let at = NOW;
+  let passes = 0;
+  for (let i = 0; i < 40; i++) {
+    at = at + 100;
+    state = noteVaultChange(state, at);
+    const decision = due(state, at);
+    if (decision.due) {
+      passes++;
+      state = notePassFinished(notePassStarted(state), "ok", at);
+    }
+  }
+
+  // Still nothing, since the vault has not been quiet for long enough at any point in the burst.
+  assert.equal(passes, 0);
+
+  // The typing stops, and one pass follows.
+  at = at + LOCAL_QUIET_MS;
+  assert.deepEqual(due(state, at), { due: true, trigger: "local" });
+  state = notePassFinished(notePassStarted(state), "ok", at);
+
+  // And nothing follows that one, until the poll interval comes round.
+  assert.deepEqual(due(state, at + 1_000), { due: false });
+  assert.deepEqual(due(state, at + POLL_INTERVAL_MS), { due: true, trigger: "poll" });
+});

--- a/src/schedule/schedule.test.ts
+++ b/src/schedule/schedule.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
+  armed,
   BACKOFF_BASE_MS,
   BACKOFF_MAX_MS,
   DEFAULT_STATE,
@@ -23,8 +24,9 @@ import {
 const NOW = 10_000_000;
 
 // idle returns a scheduler that finished a pass at NOW and holds focus it gained before that pass,
-// so neither the poll nor the focus rule is armed. Almost every case starts here and moves exactly
-// one thing, since a case that arms two rules at once proves nothing about which one answered.
+// having never been away, so none of the poll, focus, or retry rules is armed. Almost every case
+// starts here and moves exactly one thing, since a case that arms two rules at once proves nothing
+// about which one answered.
 function idle(over: Partial<State> = {}): State {
   return { ...DEFAULT_STATE, lastPassAt: NOW, focusedAt: NOW - FOCUS_MIN_GAP_MS, ...over };
 }
@@ -83,13 +85,29 @@ test("due: each rule fires on its own terms, and the order between them holds", 
       want: { due: true, trigger: "poll" },
     },
     {
-      name: "regaining focus after a long absence syncs without waiting for the poll",
-      state: idle({ lastPassAt: NOW - FOCUS_MIN_GAP_MS, focusedAt: NOW }),
+      name: "coming back after a long absence syncs without waiting for the poll",
+      state: idle({
+        lastPassAt: NOW - FOCUS_MIN_GAP_MS,
+        blurredAt: NOW - FOCUS_MIN_GAP_MS,
+        focusedAt: NOW,
+      }),
       want: { due: true, trigger: "focus" },
     },
     {
-      name: "alt tabbing back within the gap is not a sync trigger",
-      state: idle({ lastPassAt: NOW - 1_000, focusedAt: NOW }),
+      // The absence is what has to be short here, not the pass. A window someone has been working
+      // in for five unbroken minutes has a five minute old pass and no absence at all, so
+      // measuring the gap from the pass would make every two second switch to another app a sync.
+      name: "a two second switch to another app is not an absence, however old the last pass is",
+      state: idle({
+        lastPassAt: NOW - POLL_INTERVAL_MS + 1,
+        blurredAt: NOW - 2_000,
+        focusedAt: NOW,
+      }),
+      want: { due: false },
+    },
+    {
+      name: "a window that has never been away has no absence to come back from",
+      state: idle({ lastPassAt: NOW - POLL_INTERVAL_MS + 1, blurredAt: 0, focusedAt: NOW }),
       want: { due: false },
     },
     {
@@ -103,45 +121,48 @@ test("due: each rule fires on its own terms, and the order between them holds", 
     },
     {
       name: "the retry runs the moment the backoff expires",
-      state: idle({
-        failures: 1,
-        lastPassAt: NOW - BACKOFF_BASE_MS,
-        ...pending(NOW - LOCAL_QUIET_MS, NOW - LOCAL_QUIET_MS),
-      }),
-      want: { due: true, trigger: "local" },
+      state: idle({ failures: 1, lastPassAt: NOW - BACKOFF_BASE_MS }),
+      want: { due: true, trigger: "retry" },
+    },
+    {
+      // The failure this rule exists for. A push that fails has already had its pending work
+      // cleared by notePassStarted, and an unfocused window has neither a poll nor a focus event
+      // to fall back on, so without a retry of its own the edits would sit there unsynced.
+      name: "a failed pass retries even with the window unfocused and nothing pending",
+      state: idle({ failures: 1, focusedAt: 0, lastPassAt: NOW - BACKOFF_BASE_MS }),
+      want: { due: true, trigger: "retry" },
     },
     {
       name: "three consecutive failures wait four times the base delay, not one",
-      state: idle({
-        failures: 3,
-        lastPassAt: NOW - BACKOFF_BASE_MS * 4 + 1,
-        ...pending(NOW - LOCAL_QUIET_MS, NOW - LOCAL_QUIET_MS),
-      }),
+      state: idle({ failures: 3, lastPassAt: NOW - BACKOFF_BASE_MS * 4 + 1 }),
       want: { due: false },
     },
     {
       name: "and run once that longer delay expires",
-      state: idle({
-        failures: 3,
-        lastPassAt: NOW - BACKOFF_BASE_MS * 4,
-        ...pending(NOW - LOCAL_QUIET_MS, NOW - LOCAL_QUIET_MS),
-      }),
-      want: { due: true, trigger: "local" },
+      state: idle({ failures: 3, lastPassAt: NOW - BACKOFF_BASE_MS * 4 }),
+      want: { due: true, trigger: "retry" },
     },
     {
       name: "a long offline stretch stops doubling at the cap rather than growing forever",
-      state: idle({
-        failures: 20,
-        lastPassAt: NOW - BACKOFF_MAX_MS,
-        ...pending(NOW - LOCAL_QUIET_MS, NOW - LOCAL_QUIET_MS),
-      }),
-      want: { due: true, trigger: "local" },
+      state: idle({ failures: 20, lastPassAt: NOW - BACKOFF_MAX_MS }),
+      want: { due: true, trigger: "retry" },
     },
   ];
 
   for (const c of cases) {
     assert.deepEqual(due(c.state, NOW), c.want, c.name);
   }
+});
+
+test("armed: automatic sync runs only once configured, synced once already, and not paused", () => {
+  const ready = { configured: true, paused: false, syncedBefore: true };
+
+  assert.equal(armed(ready), true);
+  assert.equal(armed({ ...ready, paused: true }), false);
+  // A bucket's first pass mints its identity and has no ancestor to fall back on, so it stays
+  // something a user asks for rather than something that happens to them.
+  assert.equal(armed({ ...ready, syncedBefore: false }), false);
+  assert.equal(armed({ ...ready, configured: false }), false);
 });
 
 test("noteVaultChange: the first change starts the ceiling, every change resets the quiet period", () => {
@@ -207,12 +228,37 @@ test("noteResumed: clears a halt and the accumulated backoff, and nothing else d
   assert.equal(resumed.failures, 0);
 });
 
-test("noteFocus: losing focus clears the timestamp rather than setting a second flag", () => {
+test("noteFocus: losing focus records when, so the absence can be measured on the way back", () => {
   const focused = noteFocus(DEFAULT_STATE, true, 100);
   assert.equal(focused.focusedAt, 100);
 
   const blurred = noteFocus(focused, false, 200);
   assert.equal(blurred.focusedAt, 0);
+  assert.equal(blurred.blurredAt, 200);
+
+  const back = noteFocus(blurred, true, 200 + FOCUS_MIN_GAP_MS);
+  assert.deepEqual(due({ ...back, lastPassAt: 1 }, back.focusedAt), {
+    due: true,
+    trigger: "focus",
+  });
+});
+
+test("a failed push retries on its own, having already cleared the work it was covering", () => {
+  // End to end over the rule above: an edit on an unfocused window pushes, the push fails, and
+  // nothing else is ever going to fire. No poll, because the window is unfocused. No focus event,
+  // because nobody has touched it. No further edit, because the user has walked away. The retry
+  // has to come from the failure itself or the work sits there.
+  let state = { ...DEFAULT_STATE, lastPassAt: NOW - POLL_INTERVAL_MS, focusedAt: 0 };
+  state = noteVaultChange(state, NOW);
+
+  const at = NOW + LOCAL_QUIET_MS;
+  assert.deepEqual(due(state, at), { due: true, trigger: "local" });
+
+  state = notePassFinished(notePassStarted(state), "retry", at);
+  assert.equal(state.pendingSince, 0);
+
+  assert.deepEqual(due(state, at + BACKOFF_BASE_MS - 1), { due: false });
+  assert.deepEqual(due(state, at + BACKOFF_BASE_MS), { due: true, trigger: "retry" });
 });
 
 test("a burst of edits collapses into one pass, and the vault then goes quiet", () => {

--- a/src/schedule/schedule.ts
+++ b/src/schedule/schedule.ts
@@ -55,6 +55,7 @@ export const TICK_MS = 5_000;
 // DEFAULT_STATE is the complete zero value: nothing pending, nothing failed, nothing synced yet,
 // and a window assumed unfocused until the plugin says otherwise.
 export const DEFAULT_STATE: State = {
+  blurredAt: 0,
   failures: 0,
   focusedAt: 0,
   lastEventAt: 0,
@@ -75,10 +76,26 @@ export type Due = { due: false } | { due: true; trigger: Trigger };
 // listening; noteResumed is how a halt ends.
 export type PassResult = "ok" | "retry" | "stop";
 
+// Readiness is everything outside the scheduler that decides whether automatic sync may run at
+// all, which is a different question from whether a pass is due. Passed in as plain answers rather
+// than read from settings here, so this module stays free of every other package.
+export type Readiness = {
+  // configured is whether storage is filled in and usable.
+  configured: boolean;
+  // paused is whether the user switched automatic sync off on this device.
+  paused: boolean;
+  // syncedBefore is whether a sync has ever completed against the configured bucket.
+  syncedBefore: boolean;
+};
+
 // State is everything the scheduler needs to make its decision. Every field is a millisecond
 // timestamp or a flag, so the whole thing is comparable, copyable, and inspectable in a log line.
 // Zero means "never" throughout, which is safe because no real clock reading is ever zero.
 export type State = {
+  // blurredAt is when the window last lost focus, and zero if it never has. It is what makes the
+  // length of an absence knowable: without it the only measure to hand is the age of the last
+  // pass, and an hour of unbroken work in a focused window would read as an hour spent away.
+  blurredAt: number;
   // failures counts consecutive failed passes, and resets to zero on any success.
   failures: number;
   // focusedAt is when the window last gained focus, and zero for as long as it does not have it,
@@ -100,7 +117,21 @@ export type State = {
 // Trigger names why a pass ran, for the log and for the caller's own branching. due() returns the
 // automatic ones; "manual" is the caller's own name for a pass a user asked for, which bypasses
 // every rule here, including a halt.
-export type Trigger = "startup" | "local" | "poll" | "focus" | "manual";
+export type Trigger = "startup" | "local" | "poll" | "focus" | "retry" | "manual";
+
+// armed reports whether automatic sync may run at all on this device. Kept here rather than in the
+// plugin so the answer is one testable expression rather than a stack of early returns on a class,
+// and taken as plain booleans so this module never learns what a setting is.
+export function armed(readiness: Readiness): boolean {
+  if (readiness.paused) {
+    return false;
+  }
+  if (!readiness.syncedBefore) {
+    return false;
+  }
+
+  return readiness.configured;
+}
 
 // due reports whether a pass should start at now, and which trigger asked for it. The order of the
 // checks is the priority order: local work outranks polling because pushing an edit we already
@@ -110,8 +141,18 @@ export function due(state: State, now: number): Due {
   if (state.syncing || state.stopped) {
     return { due: false };
   }
-  if (state.failures > 0 && now - state.lastPassAt < backoffFor(state.failures)) {
-    return { due: false };
+  // A failed pass is its own reason to run again, ahead of every other rule and regardless of
+  // focus. Without this a failure would have to hope some other trigger came along: notePassStarted
+  // clears the pending local work the pass was covering, so a push that fails on an unfocused
+  // window has nothing left to fire it, and the edits would sit there until the user happened to
+  // click back into Obsidian. Silence with unsynced work behind it is the one failure this whole
+  // design exists to avoid.
+  if (state.failures > 0) {
+    if (now - state.lastPassAt < backoffFor(state.failures)) {
+      return { due: false };
+    }
+
+    return { due: true, trigger: "retry" };
   }
   // Nothing has ever synced in this session, so catch up on whatever the other devices did while
   // this one was closed. This is the startup sync: it needs no timer of its own, since the first
@@ -128,7 +169,7 @@ export function due(state: State, now: number): Due {
   if (state.focusedAt === 0) {
     return { due: false };
   }
-  if (state.focusedAt > state.lastPassAt && now - state.lastPassAt >= FOCUS_MIN_GAP_MS) {
+  if (returnedFromAway(state)) {
     return { due: true, trigger: "focus" };
   }
   if (now - state.lastPassAt >= POLL_INTERVAL_MS) {
@@ -142,7 +183,7 @@ export function due(state: State, now: number): Due {
 // setting a second flag, so "not focused" and "focused at no particular time" cannot disagree.
 export function noteFocus(state: State, focused: boolean, now: number): State {
   if (!focused) {
-    return { ...state, focusedAt: 0 };
+    return { ...state, focusedAt: 0, blurredAt: now };
   }
 
   return { ...state, focusedAt: now };
@@ -224,4 +265,20 @@ function localSettled(state: State, now: number): boolean {
   }
 
   return now - state.pendingSince >= LOCAL_MAX_WAIT_MS;
+}
+
+// returnedFromAway reports whether the window has come back from an absence long enough to be
+// worth a sync, and has not already synced since coming back. The absence is measured from when
+// focus was actually lost, never from the age of the last pass: an hour of unbroken work in a
+// focused window is not an absence, and measuring it that way would turn every two second switch
+// to another app into a full pass. A window that has never been away has no absence to measure.
+function returnedFromAway(state: State): boolean {
+  if (state.focusedAt <= state.lastPassAt) {
+    return false;
+  }
+  if (state.blurredAt === 0) {
+    return false;
+  }
+
+  return state.focusedAt - state.blurredAt >= FOCUS_MIN_GAP_MS;
 }

--- a/src/schedule/schedule.ts
+++ b/src/schedule/schedule.ts
@@ -1,0 +1,227 @@
+// Deciding when to sync, kept apart from doing it. Every rule here is a policy question with a
+// defensible answer rather than a number someone should have to configure (#93), and every one of
+// them is a pure comparison against a clock the caller passes in, so the whole policy is table
+// testable without a timer, a fake clock, or Obsidian.
+//
+// The shape is deliberately dull: the plugin ticks this every TICK_MS and asks one question, "is a
+// pass due, and why". There is no timer per trigger, no rescheduling, and nothing to interpret; a
+// tick that finds nothing due does a handful of subtractions and returns. The cost of that
+// simplicity is that every delay below is accurate only to within one tick, which no user can
+// perceive and no correctness argument rests on.
+
+// BACKOFF_BASE_MS is how long to wait after a single failed pass. Deliberately longer than
+// POLL_INTERVAL_MS is short: the first retry after a failure is the one most likely to fail for
+// the same reason, so there is nothing to gain by rushing it.
+export const BACKOFF_BASE_MS = 120_000;
+
+// BACKOFF_MAX_MS caps the doubling. Half an hour is long enough that a genuinely broken setup
+// stops generating requests, short enough that a laptop reopened after lunch catches up on its own
+// rather than waiting for someone to notice and click.
+export const BACKOFF_MAX_MS = 1_800_000;
+
+// FOCUS_MIN_GAP_MS is how long a window must have been away before regaining focus counts as a
+// reason to sync. Without a floor, alt tabbing would be a sync trigger.
+export const FOCUS_MIN_GAP_MS = 60_000;
+
+// LOCAL_MAX_WAIT_MS is the longest pending local changes may wait for quiet. An unbroken hour of
+// typing never goes quiet, and without this ceiling it would never push either.
+export const LOCAL_MAX_WAIT_MS = 30_000;
+
+// LOCAL_QUIET_MS is how long the vault must be still before pending local changes are pushed.
+// Obsidian's own autosave debounce is around two seconds (see flushOpenEditors in
+// vault/obsidian.ts), so this sits just past it: a burst of typing collapses into one pass rather
+// than one per keystroke, and the file is already on disk by the time the pass reads it.
+export const LOCAL_QUIET_MS = 5_000;
+
+// PAUSE_KEY is where a paused sync is remembered: Obsidian's vault scoped localStorage, for the
+// same reason DEVICE_ID_KEY lives there rather than in data.json. Pause is a statement about this
+// machine ("not while I'm tethered"), and settings travel to every device that reads a synced
+// .obsidian/ folder, so storing it there would silently pause the desktop because someone paused
+// the laptop. Persisted rather than held for the session, because a pause that quietly expires on
+// restart breaks the only promise the control makes.
+export const PAUSE_KEY = "geode-sync-paused";
+
+// POLL_INTERVAL_MS is how often a focused window asks whether another device has synced. Polling
+// is the only way to find out: no S3 compatible provider can notify a plugin. Five minutes is the
+// conservative opening value, since every poll is currently a full pass; it drops once a pass can
+// rule itself out with a single HEAD on the manifest (#93, step 5).
+export const POLL_INTERVAL_MS = 300_000;
+
+// TICK_MS is how often the plugin asks due() for a decision. Small enough that every delay here is
+// accurate to the second or so, cheap enough to be irrelevant: a tick with nothing to do is a
+// handful of integer comparisons.
+export const TICK_MS = 5_000;
+
+// DEFAULT_STATE is the complete zero value: nothing pending, nothing failed, nothing synced yet,
+// and a window assumed unfocused until the plugin says otherwise.
+export const DEFAULT_STATE: State = {
+  failures: 0,
+  focusedAt: 0,
+  lastEventAt: 0,
+  lastPassAt: 0,
+  pendingSince: 0,
+  stopped: false,
+  syncing: false,
+};
+
+// Due is the answer to "should a pass start right now": either no, or yes and what to call it.
+export type Due = { due: false } | { due: true; trigger: Trigger };
+
+// PassResult is how a finished pass bears on when the next one runs, which is all the scheduler
+// needs to know about it. "ok" clears any backoff, "retry" backs off and tries again, and "stop"
+// halts automatic passes entirely, for a failure no amount of retrying can fix (credentials, an
+// unusable configuration, a bucket written in a format this build cannot read). Retrying one of
+// those every few minutes for a week is not resilience, it is a machine that has stopped
+// listening; noteResumed is how a halt ends.
+export type PassResult = "ok" | "retry" | "stop";
+
+// State is everything the scheduler needs to make its decision. Every field is a millisecond
+// timestamp or a flag, so the whole thing is comparable, copyable, and inspectable in a log line.
+// Zero means "never" throughout, which is safe because no real clock reading is ever zero.
+export type State = {
+  // failures counts consecutive failed passes, and resets to zero on any success.
+  failures: number;
+  // focusedAt is when the window last gained focus, and zero for as long as it does not have it,
+  // so one field answers both "is it focused" and "since when".
+  focusedAt: number;
+  // lastEventAt is when the most recent vault change arrived, the clock the quiet period runs off.
+  lastEventAt: number;
+  // lastPassAt is when the last pass finished, zero if none ever has.
+  lastPassAt: number;
+  // pendingSince is when the oldest unsynced vault change arrived, zero when there are none, and
+  // the clock the ceiling on waiting for quiet runs off.
+  pendingSince: number;
+  // stopped is set by a failure retrying cannot fix, and cleared only by noteResumed.
+  stopped: boolean;
+  // syncing is true while a pass is in flight, so a tick never starts a second one.
+  syncing: boolean;
+};
+
+// Trigger names why a pass ran, for the log and for the caller's own branching. due() returns the
+// automatic ones; "manual" is the caller's own name for a pass a user asked for, which bypasses
+// every rule here, including a halt.
+export type Trigger = "startup" | "local" | "poll" | "focus" | "manual";
+
+// due reports whether a pass should start at now, and which trigger asked for it. The order of the
+// checks is the priority order: local work outranks polling because pushing an edit we already
+// know about beats asking a question whose answer is almost always no, and it sits above the focus
+// gate because a file can change while the window is in the background.
+export function due(state: State, now: number): Due {
+  if (state.syncing || state.stopped) {
+    return { due: false };
+  }
+  if (state.failures > 0 && now - state.lastPassAt < backoffFor(state.failures)) {
+    return { due: false };
+  }
+  // Nothing has ever synced in this session, so catch up on whatever the other devices did while
+  // this one was closed. This is the startup sync: it needs no timer of its own, since the first
+  // tick after the plugin arms the scheduler is already the right moment.
+  if (state.lastPassAt === 0) {
+    return { due: true, trigger: "startup" };
+  }
+  if (localSettled(state, now)) {
+    return { due: true, trigger: "local" };
+  }
+  // An unfocused window polls for nothing. Coming back to a machine is itself a trigger, so the
+  // gap is closed in one pass the moment someone looks, rather than by spending a request every
+  // few minutes on a screen nobody is reading.
+  if (state.focusedAt === 0) {
+    return { due: false };
+  }
+  if (state.focusedAt > state.lastPassAt && now - state.lastPassAt >= FOCUS_MIN_GAP_MS) {
+    return { due: true, trigger: "focus" };
+  }
+  if (now - state.lastPassAt >= POLL_INTERVAL_MS) {
+    return { due: true, trigger: "poll" };
+  }
+
+  return { due: false };
+}
+
+// noteFocus records the window gaining or losing focus. Losing it clears focusedAt rather than
+// setting a second flag, so "not focused" and "focused at no particular time" cannot disagree.
+export function noteFocus(state: State, focused: boolean, now: number): State {
+  if (!focused) {
+    return { ...state, focusedAt: 0 };
+  }
+
+  return { ...state, focusedAt: now };
+}
+
+// notePassFinished records a pass ending, whatever it ended as. lastPassAt advances on failure
+// too: it is what the backoff is measured from, so a pass that failed still has to have happened
+// at a time. Counting consecutive failures rather than total is what lets one success wipe the
+// slate, so a flaky train journey costs one slow retry rather than a permanently slow client.
+export function notePassFinished(state: State, result: PassResult, now: number): State {
+  if (result === "ok") {
+    return { ...state, syncing: false, lastPassAt: now, failures: 0 };
+  }
+  if (result === "stop") {
+    return {
+      ...state,
+      syncing: false,
+      lastPassAt: now,
+      failures: state.failures + 1,
+      stopped: true,
+    };
+  }
+
+  return { ...state, syncing: false, lastPassAt: now, failures: state.failures + 1 };
+}
+
+// notePassStarted records a pass beginning, and clears the pending local work it is about to
+// cover. Clearing here rather than on success is deliberate: the pass takes its own fresh snapshot
+// of the vault, so every edit made before this moment is already its responsibility, and an edit
+// landing mid pass sets pendingSince again from zero and so is still pending afterwards. A pass
+// that then fails does not lose that work either; the changes are still on disk, and the next pass
+// re-plans them from the ancestor that never advanced.
+export function notePassStarted(state: State): State {
+  return { ...state, syncing: true, pendingSince: 0, lastEventAt: 0 };
+}
+
+// noteResumed clears a halt and any accumulated backoff, the response to something changing that
+// could plausibly fix whatever failed: settings saved, the network coming back, or a user asking
+// by hand. Nothing else clears stopped, which is the point of it.
+export function noteResumed(state: State): State {
+  return { ...state, failures: 0, stopped: false };
+}
+
+// noteVaultChange records a local file appearing, changing, moving, or going away. The first one
+// starts the clock the ceiling runs off; every one of them resets the clock the quiet period runs
+// off.
+export function noteVaultChange(state: State, now: number): State {
+  if (state.pendingSince !== 0) {
+    return { ...state, lastEventAt: now };
+  }
+
+  return { ...state, pendingSince: now, lastEventAt: now };
+}
+
+// backoffFor returns how long to wait after count consecutive failures: the base delay doubled
+// once per failure beyond the first, capped. Doubled in a loop rather than by exponentiation so a
+// long lived offline session cannot overflow the delay into something meaningless.
+function backoffFor(count: number): number {
+  let delay = BACKOFF_BASE_MS;
+  for (let i = 1; i < count; i++) {
+    delay = delay * 2;
+    if (delay >= BACKOFF_MAX_MS) {
+      return BACKOFF_MAX_MS;
+    }
+  }
+
+  return delay;
+}
+
+// localSettled reports whether pending local changes have waited long enough to push: either the
+// vault has been quiet for LOCAL_QUIET_MS, or the oldest pending change has waited
+// LOCAL_MAX_WAIT_MS without the vault ever going quiet.
+function localSettled(state: State, now: number): boolean {
+  if (state.pendingSince === 0) {
+    return false;
+  }
+  if (now - state.lastEventAt >= LOCAL_QUIET_MS) {
+    return true;
+  }
+
+  return now - state.pendingSince >= LOCAL_MAX_WAIT_MS;
+}

--- a/styles.css
+++ b/styles.css
@@ -164,6 +164,10 @@
   color: var(--text-error);
 }
 
+.geode-status-bar.is-paused {
+  color: var(--text-faint);
+}
+
 .geode-status-bar.is-syncing .svg-icon {
   animation: geode-status-spin 1s linear infinite;
 }


### PR DESCRIPTION
Part of [#93](https://github.com/8thpark/geode/issues/93)

## Problem

- Sync only runs when someone clicks the status bar or runs the command, so two devices drift apart between clicks
- Every hour of drift is an hour in which the same note can be edited in two places, and the size of that window is the single biggest lever on how often a conflict copy gets written
- The vision is sync nobody thinks about, and a tool you have to remember to use is not that

## Changes

Every point at which a sync now happens, and nothing else does:

| Trigger          | Fires when                                                     | Delay                                       |
| ---------------- | -------------------------------------------------------------- | ------------------------------------------- |
| **Startup**      | Obsidian has finished loading the vault                         | Within a few seconds                        |
| **Local change** | A file appears, changes, moves, or is deleted                   | 5 seconds of quiet, 30 seconds at the latest |
| **Focus**        | Returning to a window that has been away for over a minute      | Immediately                                 |
| **Poll**         | A timer, and only while the Obsidian window has focus           | Every 5 minutes                             |
| **Manual**       | The status bar is clicked, or the `Sync` command is run         | Immediately, ignoring a pause and any backoff |
| **First sync**   | Never automatically; a bucket's first pass is always asked for  | Not applicable                              |

- Backs off after a failure, doubling to a cap and resetting on any success, and halts automatic passes outright for the failures no retry can fix, such as a missing secret or a provider that refuses conditional writes
- Keeps the first sync against a bucket manual, since it mints the vault identity and has no previous state to fall back on; repointing at another bucket demotes back to a manual first pass
- Adds `Pause automatic sync` and `Resume automatic sync`, remembered per device rather than in settings, so pausing a laptop never quietly pauses a desktop
- Documents every row above, the pause, and the failure behaviour in `docs/syncing.md`

## Why

- Local changes have a perfect signal and remote changes have none, so a single interval cannot serve both; one interval setting is how every comparable plugin gets both halves wrong at once
- Nothing here is configurable, deliberately: the right delay is not a question a user can answer, and if these numbers are wrong that is a bug to fix rather than a dial to hand over
- The policy is a pure module the plugin ticks, so every row above is a table test with no clock, no timer, and no Obsidian, rather than flags spread across five event handlers
- Failing silently in automatic mode is the common choice and the wrong one; failing visibly but backing off is what lets silence keep meaning everything is fine

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds automatic synchronization on startup, local changes, focus, and polling, together with retry backoff, terminal-failure handling, and per-device pause controls.
- Introduces a pure scheduling state module with table-driven tests.
- Wires automatic triggers and persisted pause state into the Obsidian plugin lifecycle.
- Documents automatic-sync timing and failure behavior and adds paused status-bar styling.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/schedule/schedule.ts | Adds the pure automatic-sync scheduler, trigger prioritization, focus tracking, retry backoff, and pause/readiness gating. |
| src/schedule/schedule.test.ts | Adds table-driven coverage for scheduler triggers, focus duration, pending local work, retry behavior, and terminal stops. |
| src/main.ts | Integrates automatic scheduling, focus and vault events, pause persistence, first-sync gating, and pass-result handling into the plugin lifecycle. |
| docs/syncing.md | Documents automatic triggers, first-sync restrictions, per-device pause behavior, and retry policy. |
| styles.css | Adds visual styling for the paused synchronization status. |

<sub>Reviews (2): Last reviewed commit: ["Address comments"](https://github.com/8thpark/geode/commit/b150ec3c6472bc70a8e46aeba78083ab5e75f937) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50727137)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/8thpark/geode/blob/main/AGENTS.md))

<!-- /greptile_comment -->