### PR TITLE
[#93] Sync → Classify pass failures so terminal ones stop retrying

### DIFF
--- a/docs/syncing.md
+++ b/docs/syncing.md
@@ -67,21 +67,27 @@ once, and the **Sync** command still works. Pause stops the timer, never the esc
 Nothing is lost by a failed sync. Local edits stay local, remote edits stay remote, and the next
 successful pass reconciles both. What changes is how soon that next pass is attempted.
 
-| What went wrong                              | What Geode does                       |
-| -------------------------------------------- | ------------------------------------- |
-| Network, timeout, provider error             | Retries, waiting longer each time     |
-| Another device synced at the same moment     | Retries; both devices' work survives  |
-| One file failed, the rest went               | Keeps the progress, retries that file |
-| Secret access key missing                    | Stops automatic sync until you fix it |
-| Provider does not support conditional writes | Stops automatic sync until you fix it |
+| What went wrong                                | What Geode does                        |
+| ---------------------------------------------- | -------------------------------------- |
+| Network, timeout, provider error               | Retries, waiting longer each time      |
+| One file failed, the rest went                 | Keeps the progress, retries that file  |
+| Another device synced at the same moment       | Retries in a few seconds                |
+| Access key rejected, or storage misconfigured  | Stops automatic sync until you fix it  |
+| Secret access key missing                      | Stops automatic sync until you fix it  |
+| Provider does not support conditional writes   | Stops automatic sync until you fix it  |
+| Bucket was written by a newer version of Geode | Stops automatic sync; update Geode     |
 
 The retry delay starts at 2 minutes and doubles with each consecutive failure, up to 30 minutes. A
 single success resets it, so an unreliable connection costs you one slow retry rather than a
 permanently slow client.
 
-The two cases that **stop** automatic sync do so because retrying cannot fix them, and retrying
-every few minutes for a week would only generate noise. Saving your settings, or syncing by hand,
-starts it again.
+**Two devices syncing at the same moment is not a failure.** One of them wins, the other notices
+and tries again seconds later, and both devices' work survives either way. It never counts towards
+the delay above, so a vault in constant use across two machines never slows itself down.
+
+**The cases that stop automatic sync** do so because retrying cannot fix them. Trying a rejected
+access key again every few minutes for a week is noise, not resilience. Saving your settings, or
+syncing by hand, starts it again.
 
 ## Why There Is No Interval Setting
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,7 +29,7 @@ import {
 import { GeodeSettingTab } from "./settings/tab";
 import { obsidianTransport } from "./storage/obsidian";
 import { createS3Client, probeConditionalWrites } from "./storage/storage";
-import { syncOnce } from "./sync/sync";
+import { type SyncFault, syncOnce } from "./sync/sync";
 import {
   createObsidianLocalWriter,
   createObsidianReader,
@@ -99,6 +99,21 @@ function iconFor(status: SyncStatus): string {
     return "cloud-off";
   }
   return "cloud";
+}
+
+// passResultFor maps how a pass failed onto what the scheduler should do about it. The two
+// vocabularies are kept apart deliberately: sync says what went wrong without knowing there is a
+// timer, the scheduler decides when to try again without knowing what a bucket is, and this line
+// is the whole of what either needs from the other.
+function passResultFor(fault: SyncFault): PassResult {
+  if (fault === "raced") {
+    return "raced";
+  }
+  if (fault === "permanent") {
+    return "stop";
+  }
+
+  return "retry";
 }
 
 // tooltipFor returns the status bar hover text for status. detail is folded into the error case.
@@ -427,7 +442,8 @@ export default class GeodePlugin extends Plugin {
       }
       this.logger.error(`sync: ${outcome.message}`);
       this.setSyncStatus("error", outcome.message);
-      return "retry";
+
+      return passResultFor(outcome.fault);
     }
 
     await stateStore.write(outcome.snapshot);

--- a/src/schedule/schedule.test.ts
+++ b/src/schedule/schedule.test.ts
@@ -16,6 +16,7 @@ import {
   noteResumed,
   noteVaultChange,
   POLL_INTERVAL_MS,
+  RACE_RETRY_MS,
   type State,
 } from "./schedule.ts";
 
@@ -111,17 +112,13 @@ test("due: each rule fires on its own terms, and the order between them holds", 
       want: { due: false },
     },
     {
-      name: "a backoff outranks local work, so a failing vault is not retried every quiet period",
-      state: idle({
-        failures: 1,
-        lastPassAt: NOW - BACKOFF_BASE_MS + 1,
-        ...pending(NOW - LOCAL_QUIET_MS, NOW - LOCAL_QUIET_MS),
-      }),
+      name: "a pending retry outranks local work, so a failing vault is not tried every quiet period",
+      state: idle({ retryAfter: NOW + 1, ...pending(NOW - LOCAL_QUIET_MS, NOW - LOCAL_QUIET_MS) }),
       want: { due: false },
     },
     {
-      name: "the retry runs the moment the backoff expires",
-      state: idle({ failures: 1, lastPassAt: NOW - BACKOFF_BASE_MS }),
+      name: "the retry runs the moment its delay expires",
+      state: idle({ retryAfter: NOW }),
       want: { due: true, trigger: "retry" },
     },
     {
@@ -129,22 +126,7 @@ test("due: each rule fires on its own terms, and the order between them holds", 
       // cleared by notePassStarted, and an unfocused window has neither a poll nor a focus event
       // to fall back on, so without a retry of its own the edits would sit there unsynced.
       name: "a failed pass retries even with the window unfocused and nothing pending",
-      state: idle({ failures: 1, focusedAt: 0, lastPassAt: NOW - BACKOFF_BASE_MS }),
-      want: { due: true, trigger: "retry" },
-    },
-    {
-      name: "three consecutive failures wait four times the base delay, not one",
-      state: idle({ failures: 3, lastPassAt: NOW - BACKOFF_BASE_MS * 4 + 1 }),
-      want: { due: false },
-    },
-    {
-      name: "and run once that longer delay expires",
-      state: idle({ failures: 3, lastPassAt: NOW - BACKOFF_BASE_MS * 4 }),
-      want: { due: true, trigger: "retry" },
-    },
-    {
-      name: "a long offline stretch stops doubling at the cap rather than growing forever",
-      state: idle({ failures: 20, lastPassAt: NOW - BACKOFF_MAX_MS }),
+      state: idle({ retryAfter: NOW, focusedAt: 0 }),
       want: { due: true, trigger: "retry" },
     },
   ];
@@ -202,20 +184,57 @@ test("notePassFinished: a success wipes the slate, a failure counts, a terminal 
   const failed = notePassFinished(notePassFinished(DEFAULT_STATE, "retry", 100), "retry", 200);
   assert.equal(failed.failures, 2);
   assert.equal(failed.stopped, false);
-  // lastPassAt advances on a failure too: it is what the backoff is measured from, so a pass that
-  // failed still has to have happened at a time.
+  // lastPassAt advances on a failure too, since the poll and focus rules measure from it: a pass
+  // that failed still has to have happened at a time.
   assert.equal(failed.lastPassAt, 200);
 
   const recovered = notePassFinished(failed, "ok", 300);
   assert.equal(recovered.failures, 0);
+  assert.equal(recovered.retryAfter, 0);
   assert.equal(recovered.syncing, false);
 
   const halted = notePassFinished(failed, "stop", 300);
   assert.equal(halted.stopped, true);
+  // A halt is not a slow retry; nothing is waiting, and no amount of time changes the answer.
+  assert.equal(halted.retryAfter, 0);
   assert.deepEqual(due(halted, 300 + BACKOFF_MAX_MS * 10), { due: false });
 });
 
-test("noteResumed: clears a halt and the accumulated backoff, and nothing else does", () => {
+test("notePassFinished: the retry delay doubles with each consecutive failure, up to the cap", () => {
+  let state = notePassFinished(DEFAULT_STATE, "retry", 1_000);
+  assert.equal(state.retryAfter, 1_000 + BACKOFF_BASE_MS);
+
+  state = notePassFinished(state, "retry", 2_000);
+  assert.equal(state.retryAfter, 2_000 + BACKOFF_BASE_MS * 2);
+
+  state = notePassFinished(state, "retry", 3_000);
+  assert.equal(state.retryAfter, 3_000 + BACKOFF_BASE_MS * 4);
+
+  // A long stretch offline stops doubling rather than growing into a delay nothing would ever
+  // reach, so a laptop reopened after lunch still catches up on its own.
+  let long = DEFAULT_STATE;
+  for (let i = 0; i < 20; i++) {
+    long = notePassFinished(long, "retry", 0);
+  }
+  assert.equal(long.retryAfter, BACKOFF_MAX_MS);
+});
+
+test("notePassFinished: losing a race retries soon and never counts towards giving up", () => {
+  // Two devices syncing at overlapping times is ordinary once sync runs on a timer rather than a
+  // click, and the loser has lost nothing: its work is intact and the manifest it needs to
+  // reconcile against is now sitting there fresh. Counting these would let an entirely healthy
+  // two device vault escalate itself into a half hour backoff.
+  let state = DEFAULT_STATE;
+  for (let i = 0; i < 10; i++) {
+    state = notePassFinished(state, "raced", 1_000);
+  }
+
+  assert.equal(state.failures, 0);
+  assert.equal(state.retryAfter, 1_000 + RACE_RETRY_MS);
+  assert.deepEqual(due(state, 1_000 + RACE_RETRY_MS), { due: true, trigger: "retry" });
+});
+
+test("noteResumed: clears a halt and any pending retry, and nothing else does", () => {
   let state = notePassFinished(DEFAULT_STATE, "stop", 100);
   // A halt survives anything that is not a deliberate resume, so a stopped scheduler cannot drift
   // back into retrying credentials that are still wrong.
@@ -226,6 +245,7 @@ test("noteResumed: clears a halt and the accumulated backoff, and nothing else d
   const resumed = noteResumed(state);
   assert.equal(resumed.stopped, false);
   assert.equal(resumed.failures, 0);
+  assert.equal(resumed.retryAfter, 0);
 });
 
 test("noteFocus: losing focus records when, so the absence can be measured on the way back", () => {

--- a/src/schedule/schedule.test.ts
+++ b/src/schedule/schedule.test.ts
@@ -234,6 +234,23 @@ test("notePassFinished: losing a race retries soon and never counts towards givi
   assert.deepEqual(due(state, 1_000 + RACE_RETRY_MS), { due: true, trigger: "retry" });
 });
 
+test("notePassFinished: a race breaks a failure streak, since it proves the round trip works", () => {
+  // A raced pass reached the provider, read the manifest, moved the files, and lost only the final
+  // compare-and-swap, so the network and the credentials are demonstrably fine. Merely holding the
+  // count instead of clearing it would charge the next unrelated blip a doubled delay for a streak
+  // that a working round trip had already broken, and a long enough interleaving of blips and
+  // races would reach the half hour cap without ever failing twice in a row.
+  let state = notePassFinished(DEFAULT_STATE, "retry", 1_000);
+  assert.equal(state.failures, 1);
+
+  state = notePassFinished(state, "raced", 2_000);
+  assert.equal(state.failures, 0);
+
+  state = notePassFinished(state, "retry", 3_000);
+  assert.equal(state.failures, 1);
+  assert.equal(state.retryAfter, 3_000 + BACKOFF_BASE_MS);
+});
+
 test("noteResumed: clears a halt and any pending retry, and nothing else does", () => {
   let state = notePassFinished(DEFAULT_STATE, "stop", 100);
   // A halt survives anything that is not a deliberate resume, so a stopped scheduler cannot drift

--- a/src/schedule/schedule.ts
+++ b/src/schedule/schedule.ts
@@ -19,6 +19,20 @@ export const BACKOFF_BASE_MS = 120_000;
 // rather than waiting for someone to notice and click.
 export const BACKOFF_MAX_MS = 1_800_000;
 
+// DEFAULT_STATE is the complete zero value: nothing pending, nothing failed, nothing synced yet,
+// and a window assumed unfocused until the plugin says otherwise.
+export const DEFAULT_STATE: State = {
+  blurredAt: 0,
+  failures: 0,
+  focusedAt: 0,
+  lastEventAt: 0,
+  lastPassAt: 0,
+  pendingSince: 0,
+  retryAfter: 0,
+  stopped: false,
+  syncing: false,
+};
+
 // FOCUS_MIN_GAP_MS is how long a window must have been away before regaining focus counts as a
 // reason to sync. Without a floor, alt tabbing would be a sync trigger.
 export const FOCUS_MIN_GAP_MS = 60_000;
@@ -47,34 +61,28 @@ export const PAUSE_KEY = "geode-sync-paused";
 // rule itself out with a single HEAD on the manifest (#93, step 5).
 export const POLL_INTERVAL_MS = 300_000;
 
+// RACE_RETRY_MS is how long to wait after losing the manifest compare-and-swap to another device.
+// Short, and nothing like a backoff, because nothing went wrong: the other device finished first,
+// this one's work is untouched, and the manifest it needed to reconcile against is now sitting
+// there fresh. Waiting out a two minute backoff would be waiting for nothing to change.
+export const RACE_RETRY_MS = 10_000;
+
 // TICK_MS is how often the plugin asks due() for a decision. Small enough that every delay here is
 // accurate to the second or so, cheap enough to be irrelevant: a tick with nothing to do is a
 // handful of integer comparisons.
 export const TICK_MS = 5_000;
 
-// DEFAULT_STATE is the complete zero value: nothing pending, nothing failed, nothing synced yet,
-// and a window assumed unfocused until the plugin says otherwise.
-export const DEFAULT_STATE: State = {
-  blurredAt: 0,
-  failures: 0,
-  focusedAt: 0,
-  lastEventAt: 0,
-  lastPassAt: 0,
-  pendingSince: 0,
-  stopped: false,
-  syncing: false,
-};
-
 // Due is the answer to "should a pass start right now": either no, or yes and what to call it.
 export type Due = { due: false } | { due: true; trigger: Trigger };
 
 // PassResult is how a finished pass bears on when the next one runs, which is all the scheduler
-// needs to know about it. "ok" clears any backoff, "retry" backs off and tries again, and "stop"
-// halts automatic passes entirely, for a failure no amount of retrying can fix (credentials, an
-// unusable configuration, a bucket written in a format this build cannot read). Retrying one of
-// those every few minutes for a week is not resilience, it is a machine that has stopped
-// listening; noteResumed is how a halt ends.
-export type PassResult = "ok" | "retry" | "stop";
+// needs to know about it. "ok" clears everything. "raced" lost the manifest compare-and-swap to
+// another device, and comes back quickly without counting as a failure at all. "retry" backs off
+// and tries again. "stop" halts automatic passes entirely, for a failure no amount of retrying can
+// fix (credentials, an unusable configuration, a bucket written in a format this build cannot
+// read); retrying one of those every few minutes for a week is not resilience, it is a machine
+// that has stopped listening, and noteResumed is how a halt ends.
+export type PassResult = "ok" | "raced" | "retry" | "stop";
 
 // Readiness is everything outside the scheduler that decides whether automatic sync may run at
 // all, which is a different question from whether a pass is due. Passed in as plain answers rather
@@ -96,7 +104,9 @@ export type State = {
   // length of an absence knowable: without it the only measure to hand is the age of the last
   // pass, and an hour of unbroken work in a focused window would read as an hour spent away.
   blurredAt: number;
-  // failures counts consecutive failed passes, and resets to zero on any success.
+  // failures counts consecutive failed passes, and resets to zero on any success. It exists only
+  // to decide how loudly to complain (#182 escalates at the third in a row); when to try again is
+  // retryAfter's job, so that one counter is never asked two questions at once.
   failures: number;
   // focusedAt is when the window last gained focus, and zero for as long as it does not have it,
   // so one field answers both "is it focused" and "since when".
@@ -108,6 +118,12 @@ export type State = {
   // pendingSince is when the oldest unsynced vault change arrived, zero when there are none, and
   // the clock the ceiling on waiting for quiet runs off.
   pendingSince: number;
+  // retryAfter is when a pass that did not succeed may be tried again, and zero when there is
+  // nothing waiting to be retried. Written where the failure is recorded rather than derived here
+  // from a counter, so a delay that varies by reason (ten seconds for a lost race, a doubling
+  // backoff for a real failure) is one timestamp to compare against instead of arithmetic every
+  // caller has to reproduce.
+  retryAfter: number;
   // stopped is set by a failure retrying cannot fix, and cleared only by noteResumed.
   stopped: boolean;
   // syncing is true while a pass is in flight, so a tick never starts a second one.
@@ -141,14 +157,14 @@ export function due(state: State, now: number): Due {
   if (state.syncing || state.stopped) {
     return { due: false };
   }
-  // A failed pass is its own reason to run again, ahead of every other rule and regardless of
-  // focus. Without this a failure would have to hope some other trigger came along: notePassStarted
-  // clears the pending local work the pass was covering, so a push that fails on an unfocused
-  // window has nothing left to fire it, and the edits would sit there until the user happened to
-  // click back into Obsidian. Silence with unsynced work behind it is the one failure this whole
-  // design exists to avoid.
-  if (state.failures > 0) {
-    if (now - state.lastPassAt < backoffFor(state.failures)) {
+  // A pass that did not succeed is its own reason to run again, ahead of every other rule and
+  // regardless of focus. Without this it would have to hope some other trigger came along:
+  // notePassStarted clears the pending local work the pass was covering, so a push that fails on an
+  // unfocused window has nothing left to fire it, and the edits would sit there until the user
+  // happened to click back into Obsidian. Silence with unsynced work behind it is the one outcome
+  // this whole design exists to avoid.
+  if (state.retryAfter !== 0) {
+    if (now < state.retryAfter) {
       return { due: false };
     }
 
@@ -189,25 +205,30 @@ export function noteFocus(state: State, focused: boolean, now: number): State {
   return { ...state, focusedAt: now };
 }
 
-// notePassFinished records a pass ending, whatever it ended as. lastPassAt advances on failure
-// too: it is what the backoff is measured from, so a pass that failed still has to have happened
-// at a time. Counting consecutive failures rather than total is what lets one success wipe the
-// slate, so a flaky train journey costs one slow retry rather than a permanently slow client.
+// notePassFinished records a pass ending, whatever it ended as, and decides there and then when
+// the next attempt may run. lastPassAt advances on a failure too, since a pass that failed still
+// has to have happened at a time for the poll and focus rules to measure from. Counting
+// consecutive failures rather than total is what lets one success wipe the slate, so a flaky train
+// journey costs one slow retry rather than a permanently slow client.
 export function notePassFinished(state: State, result: PassResult, now: number): State {
+  const finished = { ...state, syncing: false, lastPassAt: now };
   if (result === "ok") {
-    return { ...state, syncing: false, lastPassAt: now, failures: 0 };
+    return { ...finished, failures: 0, retryAfter: 0 };
   }
+  // Losing the race is not this device failing, and must never count towards giving up. Two
+  // devices syncing at overlapping times is ordinary once sync is automatic rather than clicked,
+  // nothing is lost by it, and the loser's next pass reconciles both sides. Counting it would let
+  // an ordinary two device vault escalate itself into a half hour backoff over passes where
+  // everything worked exactly as designed.
+  if (result === "raced") {
+    return { ...finished, retryAfter: now + RACE_RETRY_MS };
+  }
+  const failures = state.failures + 1;
   if (result === "stop") {
-    return {
-      ...state,
-      syncing: false,
-      lastPassAt: now,
-      failures: state.failures + 1,
-      stopped: true,
-    };
+    return { ...finished, failures, retryAfter: 0, stopped: true };
   }
 
-  return { ...state, syncing: false, lastPassAt: now, failures: state.failures + 1 };
+  return { ...finished, failures, retryAfter: now + backoffFor(failures) };
 }
 
 // notePassStarted records a pass beginning, and clears the pending local work it is about to
@@ -224,7 +245,7 @@ export function notePassStarted(state: State): State {
 // could plausibly fix whatever failed: settings saved, the network coming back, or a user asking
 // by hand. Nothing else clears stopped, which is the point of it.
 export function noteResumed(state: State): State {
-  return { ...state, failures: 0, stopped: false };
+  return { ...state, failures: 0, retryAfter: 0, stopped: false };
 }
 
 // noteVaultChange records a local file appearing, changing, moving, or going away. The first one

--- a/src/schedule/schedule.ts
+++ b/src/schedule/schedule.ts
@@ -220,8 +220,15 @@ export function notePassFinished(state: State, result: PassResult, now: number):
   // nothing is lost by it, and the loser's next pass reconciles both sides. Counting it would let
   // an ordinary two device vault escalate itself into a half hour backoff over passes where
   // everything worked exactly as designed.
+  //
+  // The streak resets rather than merely holding. A raced pass reached the provider, read the
+  // manifest, moved the files, and lost only the final compare-and-swap, which is proof that the
+  // network is up and the credentials are good: precisely what an earlier transient failure left
+  // in doubt. Carrying that failure past this point would let an unlucky interleaving of a dropped
+  // connection, a race, and another dropped connection charge the second one a four minute delay
+  // for a streak that a working round trip had already broken.
   if (result === "raced") {
-    return { ...finished, retryAfter: now + RACE_RETRY_MS };
+    return { ...finished, failures: 0, retryAfter: now + RACE_RETRY_MS };
   }
   const failures = state.failures + 1;
   if (result === "stop") {

--- a/src/sync/sync.test.ts
+++ b/src/sync/sync.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
+import type { ResultStatus } from "../storage/storage.ts";
 import { encodeSnapshot, hashBytes, type Snapshot } from "../vault/vault.ts";
 import type { LocalWriter } from "./execute.ts";
 import {
@@ -21,9 +22,11 @@ import {
 } from "./plan.ts";
 import {
   adoptLiveStats,
+  faultFor,
   readRemoteManifest,
   readSentinel,
   revertFailedPaths,
+  type SyncFault,
   syncOnce,
   unexplainedBlobs,
 } from "./sync.ts";
@@ -34,6 +37,47 @@ import {
 async function hashOf(text: string): Promise<string> {
   return hashBytes(new TextEncoder().encode(text));
 }
+
+test("faultFor: trying again is worth something, or it never will be, and a race is neither", () => {
+  const cases: { status: ResultStatus; want: SyncFault }[] = [
+    // The compare-and-swap doing its job. Nothing failed, nothing is lost, and the manifest the
+    // loser needs to reconcile against is now sitting there fresh.
+    { status: "conflict", want: "raced" },
+    // The provider saying we are wrong rather than unlucky. No number of retries argues with it.
+    { status: "auth", want: "permanent" },
+    { status: "client", want: "permanent" },
+    // Worth another go, including 429 and 5xx, which statusForHttp already folds into server.
+    { status: "server", want: "transient" },
+    { status: "network", want: "transient" },
+    // Never reaches here as a failure, since a 404 on the manifest is a first sync rather than an
+    // error, but transient is the harmless answer if one ever does.
+    { status: "not_found", want: "transient" },
+  ];
+
+  for (const c of cases) {
+    assert.equal(faultFor(c.status), c.want, c.status);
+  }
+});
+
+test("syncOnce: a rejected access key halts rather than being retried forever (#93)", async () => {
+  // The gap this closed: every failed pass used to report a bare message, so nothing above could
+  // tell a rotated key from a dropped connection, and a 403 was retried on a timer indefinitely.
+  const { storage } = fakeStorage();
+  storage.getObject = async () => ({
+    ok: false,
+    status: "auth",
+    message: "Storage rejected the read (403)",
+    body: null,
+    etag: null,
+  });
+  const reader = fakeReader({ "a.md": "alpha" });
+  const { writer } = fakeLocalWriter();
+
+  const outcome = await syncOnce(empty, reader, writer, storage, 1);
+
+  assert.ok(!outcome.ok);
+  assert.equal(outcome.fault, "permanent");
+});
 
 test("readRemoteManifest: a 404 is treated as an empty snapshot", async () => {
   const { storage } = fakeStorage();
@@ -64,7 +108,11 @@ test("readRemoteManifest: a manifest without an etag is refused, not synced unsa
 
   const result = await readRemoteManifest(storage);
 
-  assert.deepEqual(result, { ok: false, message: "remote manifest has no etag" });
+  assert.deepEqual(result, {
+    ok: false,
+    fault: "permanent",
+    message: "remote manifest has no etag",
+  });
 });
 
 test("readRemoteManifest: corrupt JSON is reported as a failure, not an empty snapshot", async () => {
@@ -72,7 +120,11 @@ test("readRemoteManifest: corrupt JSON is reported as a failure, not an empty sn
 
   const result = await readRemoteManifest(storage);
 
-  assert.deepEqual(result, { ok: false, message: "remote manifest is corrupt" });
+  assert.deepEqual(result, {
+    ok: false,
+    fault: "permanent",
+    message: "remote manifest is corrupt",
+  });
 });
 
 test("readRemoteManifest: a manifest with no envelope is corrupt, and one from a newer suite needs an update", async () => {
@@ -83,6 +135,7 @@ test("readRemoteManifest: a manifest with no envelope is corrupt, and one from a
 
   assert.deepEqual(await readRemoteManifest(bare.storage), {
     ok: false,
+    fault: "permanent",
     message: "remote manifest is corrupt",
   });
 
@@ -93,6 +146,7 @@ test("readRemoteManifest: a manifest with no envelope is corrupt, and one from a
 
   assert.deepEqual(await readRemoteManifest(encrypted.storage), {
     ok: false,
+    fault: "permanent",
     message: "remote manifest is a format this version of geode can't read",
   });
 });
@@ -106,7 +160,11 @@ test("readRemoteManifest: JSON of the wrong shape is corrupt, not a snapshot wit
 
     const result = await readRemoteManifest(storage);
 
-    assert.deepEqual(result, { ok: false, message: "remote manifest is corrupt" }, body);
+    assert.deepEqual(
+      result,
+      { ok: false, fault: "permanent", message: "remote manifest is corrupt" },
+      body,
+    );
   }
 });
 
@@ -121,6 +179,7 @@ test("readRemoteManifest: a pre-marker manifest with no version field is refused
 
   assert.deepEqual(result, {
     ok: false,
+    fault: "permanent",
     message: "remote manifest is a format this version of geode can't read",
   });
 });
@@ -135,6 +194,7 @@ test("readRemoteManifest: a manifest from a format version this build doesn't kn
 
   assert.deepEqual(result, {
     ok: false,
+    fault: "permanent",
     message: "remote manifest is a format this version of geode can't read",
   });
 });
@@ -152,6 +212,7 @@ test("readRemoteManifest: a manifest entry with a traversal path refuses the pas
 
   assert.deepEqual(result, {
     ok: false,
+    fault: "permanent",
     message: "remote manifest contains a path unsafe to write",
   });
 });
@@ -172,6 +233,7 @@ test("readRemoteManifest: two paths differing only by case refuse the pass (#94)
 
   assert.deepEqual(result, {
     ok: false,
+    fault: "permanent",
     message: "remote manifest contains two paths that differ only by case",
   });
 });
@@ -188,7 +250,11 @@ test("readRemoteManifest: a non 404 failure is reported, never guessed at as emp
 
   const result = await readRemoteManifest(storage);
 
-  assert.deepEqual(result, { ok: false, message: "Storage rejected the read (500)" });
+  assert.deepEqual(result, {
+    ok: false,
+    fault: "transient",
+    message: "Storage rejected the read (500)",
+  });
 });
 
 test("readSentinel: a 404 is reported as sentinel: null, not a failure", async () => {
@@ -213,7 +279,11 @@ test("readSentinel: corrupt JSON is reported as a failure, not an absent sentine
 
   const result = await readSentinel(storage);
 
-  assert.deepEqual(result, { ok: false, message: "remote sentinel is corrupt" });
+  assert.deepEqual(result, {
+    ok: false,
+    fault: "permanent",
+    message: "remote sentinel is corrupt",
+  });
 });
 
 test("readSentinel: an unknown format version refuses the pass", async () => {
@@ -224,6 +294,7 @@ test("readSentinel: an unknown format version refuses the pass", async () => {
 
   assert.deepEqual(result, {
     ok: false,
+    fault: "permanent",
     message: "remote sentinel is a format this version of geode can't read",
   });
 });
@@ -279,6 +350,7 @@ test("syncOnce: a manifest format this build doesn't know halts the pass before 
 
   assert.deepEqual(outcome, {
     ok: false,
+    fault: "permanent",
     message: "remote manifest is a format this version of geode can't read",
     failures: [],
     snapshot: null,
@@ -424,6 +496,7 @@ test("syncOnce: a device pointed at a different vault's sentinel refuses (#183)"
 
   assert.deepEqual(outcome, {
     ok: false,
+    fault: "permanent",
     message: "this bucket belongs to a different vault than the one last synced here",
     failures: [],
     snapshot: null,
@@ -564,6 +637,7 @@ test("syncOnce: a failed bucket listing on a first sync is reported, never guess
 
   assert.deepEqual(outcome, {
     ok: false,
+    fault: "transient",
     message: "Storage rejected the list (500)",
     failures: [],
     snapshot: null,
@@ -614,6 +688,7 @@ test("syncOnce: a manifest overwritten by another device mid sync fails the pass
 
   assert.deepEqual(outcome, {
     ok: false,
+    fault: "raced",
     message: "another device synced at the same time; sync again",
     failures: [],
     snapshot: null,
@@ -669,6 +744,7 @@ test("syncOnce: retry adopts an identical orphaned upload with a HEAD, not anoth
 
   assert.deepEqual(first, {
     ok: false,
+    fault: "raced",
     message: "another device synced at the same time; sync again",
     failures: [],
     snapshot: null,

--- a/src/sync/sync.ts
+++ b/src/sync/sync.ts
@@ -1,5 +1,5 @@
 import { unwrapObject, wrapObject } from "../storage/envelope.ts";
-import type { ObjectMeta, PutCondition, StorageClient } from "../storage/storage.ts";
+import type { ObjectMeta, PutCondition, ResultStatus, StorageClient } from "../storage/storage.ts";
 import {
   byPath,
   decodeSnapshot,
@@ -34,10 +34,24 @@ export type SyncOutcome =
   | { ok: true; snapshot: Snapshot; changeCount: number }
   | {
       ok: false;
+      fault: SyncFault;
       message: string;
       failures: SyncFailure[];
       snapshot: Snapshot | null;
     };
+
+// SyncFault says how a failed pass should be treated by whatever decides when to try another one.
+// A message alone cannot answer that, and reading one to guess is how "(404)" ended up being
+// sniffed out of error text (#90), so the answer is carried rather than inferred.
+//
+// "transient" is anything a later attempt could plausibly get past on its own: a dropped
+// connection, a provider having a bad minute, a file that was briefly busy. "raced" is losing the
+// manifest compare-and-swap to another device, which is not this device failing at all; nothing is
+// lost by it, both sides' work survives, and the next pass reconciles them, so it must never count
+// towards giving up. "permanent" is everything retrying cannot fix, where trying again every few
+// minutes for a week is noise rather than resilience: credentials that are wrong, a bucket
+// belonging to a different vault, a manifest written in a format this build cannot read.
+export type SyncFault = "transient" | "raced" | "permanent";
 
 // adoptLiveStats returns manifest with each entry swapped for the live vault's entry at the same
 // path wherever the content hashes match, so state.json carries local size and mtime and the next
@@ -58,6 +72,26 @@ export function adoptLiveStats(manifest: Snapshot, live: Snapshot): Snapshot {
   }
 
   return { files };
+}
+
+// faultFor maps how a storage operation failed onto how the pass carrying it should be treated.
+// The two vocabularies stay separate because they answer different questions: ResultStatus says
+// what the provider did, SyncFault says whether trying again is worth anything.
+//
+// A lost precondition is the whole point of the compare-and-swap working, so it is raced rather
+// than failed. Auth and client are the provider telling us we are wrong rather than unlucky, and
+// no number of retries argues with that. Everything else, including 5xx and 429, is worth another
+// go. "ok" and "not_found" never reach here as failures (a 404 on the manifest is a first sync,
+// not an error) and fall through to transient, which is the harmless answer if one ever does.
+export function faultFor(status: ResultStatus): SyncFault {
+  if (status === "conflict") {
+    return "raced";
+  }
+  if (status === "auth" || status === "client") {
+    return "permanent";
+  }
+
+  return "transient";
 }
 
 // readRemoteManifest fetches and parses the remote manifest. A confirmed 404 means no manifest
@@ -82,10 +116,13 @@ export async function readRemoteManifest(
 ): Promise<
   | { ok: true; snapshot: Snapshot; firstSync: true }
   | { ok: true; snapshot: Snapshot; firstSync: false; etag: string }
-  | { ok: false; message: string }
+  | { ok: false; fault: SyncFault; message: string }
 > {
   const fetched = await storage.getObject(MANIFEST_KEY);
 
+  // Every refusal below this point is permanent: the bytes in the bucket are not something this
+  // build can read, and reading them again in two minutes will not change that. What they need is
+  // a newer geode, or a human, never a retry.
   if (fetched.ok && fetched.body !== null) {
     // The envelope is read before the JSON inside it, and its two unsupported reasons report the
     // same thing an unknown manifest version does: this bucket was written by a build that knows
@@ -96,10 +133,11 @@ export async function readRemoteManifest(
     const opened = unwrapObject(fetched.body);
     if (!opened.ok) {
       if (opened.reason === "corrupt") {
-        return { ok: false, message: "remote manifest is corrupt" };
+        return { ok: false, fault: "permanent", message: "remote manifest is corrupt" };
       }
       return {
         ok: false,
+        fault: "permanent",
         message: "remote manifest is a format this version of geode can't read",
       };
     }
@@ -108,32 +146,39 @@ export async function readRemoteManifest(
       if (decoded.reason === "unsupportedVersion") {
         return {
           ok: false,
+          fault: "permanent",
           message: "remote manifest is a format this version of geode can't read",
         };
       }
       if (decoded.reason === "unsafePath") {
-        return { ok: false, message: "remote manifest contains a path unsafe to write" };
+        return {
+          ok: false,
+          fault: "permanent",
+          message: "remote manifest contains a path unsafe to write",
+        };
       }
       if (decoded.reason === "caseCollision") {
         return {
           ok: false,
+          fault: "permanent",
           message: "remote manifest contains two paths that differ only by case",
         };
       }
       if (decoded.reason === "duplicatePath") {
         return {
           ok: false,
+          fault: "permanent",
           message: "remote manifest names the same path twice",
         };
       }
-      return { ok: false, message: "remote manifest is corrupt" };
+      return { ok: false, fault: "permanent", message: "remote manifest is corrupt" };
     }
     // Every S3 compatible server returns an ETag on a successful read; without one (a stripping
     // proxy, a broken provider) the manifest upload can't be made conditional, and uploading it
     // unconditionally is exactly the concurrent clobber #83 fixed, so refuse rather than sync
     // unsafely.
     if (fetched.etag === null) {
-      return { ok: false, message: "remote manifest has no etag" };
+      return { ok: false, fault: "permanent", message: "remote manifest has no etag" };
     }
     return { ok: true, snapshot: decoded.snapshot, firstSync: false, etag: fetched.etag };
   }
@@ -141,7 +186,7 @@ export async function readRemoteManifest(
   if (fetched.status === "not_found") {
     return { ok: true, snapshot: { files: [] }, firstSync: true };
   }
-  return { ok: false, message: fetched.message };
+  return { ok: false, fault: faultFor(fetched.status), message: fetched.message };
 }
 
 // readSentinel fetches and parses the remote sentinel (#183). A confirmed 404 is reported as
@@ -150,17 +195,20 @@ export async function readRemoteManifest(
 // "this bucket has never had one" from "something is wrong reading it" apart.
 export async function readSentinel(
   storage: StorageClient,
-): Promise<{ ok: true; sentinel: Sentinel | null } | { ok: false; message: string }> {
+): Promise<
+  { ok: true; sentinel: Sentinel | null } | { ok: false; fault: SyncFault; message: string }
+> {
   const fetched = await storage.getObject(SENTINEL_KEY);
 
   if (fetched.ok && fetched.body !== null) {
     const opened = unwrapObject(fetched.body);
     if (!opened.ok) {
       if (opened.reason === "corrupt") {
-        return { ok: false, message: "remote sentinel is corrupt" };
+        return { ok: false, fault: "permanent", message: "remote sentinel is corrupt" };
       }
       return {
         ok: false,
+        fault: "permanent",
         message: "remote sentinel is a format this version of geode can't read",
       };
     }
@@ -169,10 +217,11 @@ export async function readSentinel(
       if (decoded.reason === "unsupportedVersion") {
         return {
           ok: false,
+          fault: "permanent",
           message: "remote sentinel is a format this version of geode can't read",
         };
       }
-      return { ok: false, message: "remote sentinel is corrupt" };
+      return { ok: false, fault: "permanent", message: "remote sentinel is corrupt" };
     }
     return { ok: true, sentinel: decoded.sentinel };
   }
@@ -180,7 +229,7 @@ export async function readSentinel(
   if (fetched.status === "not_found") {
     return { ok: true, sentinel: null };
   }
-  return { ok: false, message: fetched.message };
+  return { ok: false, fault: faultFor(fetched.status), message: fetched.message };
 }
 
 // revertFailedPaths returns snapshot with every failed action's path restored to the ancestor's
@@ -234,10 +283,22 @@ export async function syncOnce(
     readSentinel(storage),
   ]);
   if (!remote.ok) {
-    return { ok: false, message: remote.message, failures: [], snapshot: null };
+    return {
+      ok: false,
+      fault: remote.fault,
+      message: remote.message,
+      failures: [],
+      snapshot: null,
+    };
   }
   if (!sentinelResult.ok) {
-    return { ok: false, message: sentinelResult.message, failures: [], snapshot: null };
+    return {
+      ok: false,
+      fault: sentinelResult.fault,
+      message: sentinelResult.message,
+      failures: [],
+      snapshot: null,
+    };
   }
   const identity = resolveVaultIdentity(
     remote.firstSync,
@@ -246,7 +307,13 @@ export async function syncOnce(
     newVaultId,
   );
   if (!identity.ok) {
-    return { ok: false, message: identity.message, failures: [], snapshot: null };
+    return {
+      ok: false,
+      fault: "permanent",
+      message: identity.message,
+      failures: [],
+      snapshot: null,
+    };
   }
 
   // No remote manifest means no prior sync ever completed against this bucket, so previous (the
@@ -286,7 +353,13 @@ export async function syncOnce(
   if (remote.firstSync) {
     const listed = await storage.listObjects(BLOB_PREFIX);
     if (!listed.ok) {
-      return { ok: false, message: listed.message, failures: [], snapshot: null };
+      return {
+        ok: false,
+        fault: faultFor(listed.status),
+        message: listed.message,
+        failures: [],
+        snapshot: null,
+      };
     }
     for (const key of unexplainedBlobs(listed.objects, local)) {
       strandedFailures.push({ path: key, message: "in the bucket but not in the local vault" });
@@ -368,6 +441,7 @@ export async function syncOnce(
       if (uploaded.status === "conflict") {
         return {
           ok: false,
+          fault: "raced",
           message: "another device synced at the same time; sync again",
           failures: executed.failures,
           snapshot: null,
@@ -375,6 +449,7 @@ export async function syncOnce(
       }
       return {
         ok: false,
+        fault: faultFor(uploaded.status),
         message: uploaded.message,
         failures: executed.failures,
         snapshot: null,
@@ -398,6 +473,7 @@ export async function syncOnce(
     if (!sentinelUploaded.ok) {
       return {
         ok: false,
+        fault: faultFor(sentinelUploaded.status),
         message: "could not write the vault sentinel; sync again",
         failures: executed.failures,
         snapshot: null,
@@ -411,9 +487,16 @@ export async function syncOnce(
   // otherwise, for a path a stranded blob doesn't have, so there is nothing for revertFailedPaths
   // to revert; it is folded in here purely so the pass reports itself failed and names what it
   // could not explain, rather than returning ok on a first sync that left content unreferenced.
+  //
+  // Transient, because a per file failure is overwhelmingly an I/O error or a mid sync drift, both
+  // of which the next pass resolves on its own, and because the rest of the pass succeeded: the
+  // manifest went up, so a file that keeps failing costs a retry rather than the whole vault. A
+  // stranded blob is the one member of this set retrying cannot fix, but it only ever arises on a
+  // first sync, which is never automatic, so nothing is backing off over it either way.
   if (executed.failed.length > 0 || strandedFailures.length > 0) {
     return {
       ok: false,
+      fault: "transient",
       message: `${executed.failed.length + strandedFailures.length} file(s) failed to sync`,
       failures: [...executed.failures, ...strandedFailures],
       snapshot: revertFailedPaths(final, ancestor, executed.failed),


### PR DESCRIPTION
Resolves [#93](https://github.com/8thpark/geode/issues/93)

## Problem

- A failed pass reported a message and nothing else, so nothing above `syncOnce` could tell a rotated access key from a dropped connection
- Every failure was therefore treated as worth another go, and a `403` was retried on a timer indefinitely rather than halting and saying why
- Losing the manifest race to another device counted as a failure too, so an ordinary two device vault escalated its own backoff over passes where nothing went wrong and nothing was lost

## Changes

A failed pass now says how it failed, and the scheduler acts on that rather than on a message it would have had to read:

| Fault           | Covers                                                                       | What happens next                   |
| --------------- | ---------------------------------------------------------------------------- | ----------------------------------- |
| **`transient`** | Dropped connection, timeout, `5xx`, `429`, a single file that would not move  | Retries, doubling to a 30 minute cap |
| **`raced`**     | Losing the manifest compare-and-swap to another device                       | Retries in 10 seconds, never counts as a failure |
| **`permanent`** | Rejected credentials, unusable configuration, a bucket belonging to another vault, a manifest a newer Geode wrote | Halts automatic sync until settings are saved or a sync is asked for by hand |

- Carries the classification storage already produces through `syncOnce`, so most of this is one mapping function rather than new judgement
- Replaces the retry delay derived from the failure counter with a timestamp written where the failure is recorded, which is what lets three different delays exist without three code paths
- Hands the failure counter back its single job, counting how many in a row, which is what the escalation notice in #182 will want
- Documents the revised failure behaviour in `docs/syncing.md`

## Why

- A message is not a classification, and reading one to guess is how `(404)` came to be sniffed out of error text in #90; the answer is now carried rather than inferred
- Retrying a rejected access key every few minutes for a week is not resilience, it is a machine that has stopped listening, and stopping while saying why is the honest response
- Two devices syncing at overlapping times is ordinary once sync runs on a timer rather than a click, so treating it as a failure meant a vault got slower the more it was used, which is precisely backwards

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR carries typed sync-failure classifications into the scheduler so terminal failures halt, transient failures back off, and manifest races retry quickly without increasing the failure streak.
- Adds transient, raced, and permanent sync fault classifications.
- Stores explicit retry timestamps and resets failure streaks after races.
- Adds scheduler and sync regression coverage and updates syncing documentation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/schedule/schedule.ts | Adds explicit retry timestamps and correctly resets the transient-failure streak when a manifest race occurs. |
| src/sync/sync.ts | Propagates storage and validation failures as transient, raced, or permanent sync faults. |
| src/main.ts | Maps sync fault classifications into scheduler outcomes. |
| src/schedule/schedule.test.ts | Covers retry timing, terminal stops, race retries, and failure-streak reset behavior. |
| src/sync/sync.test.ts | Covers storage-status classification and propagation through failed sync outcomes. |
| docs/syncing.md | Documents the revised retry, race, and terminal-failure behavior. |

<sub>Reviews (2): Last reviewed commit: ["Address comment"](https://github.com/8thpark/geode/commit/f8f183d15d241e9e6d118c3fe3c94a9ad8a91ec6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50736177)</sub>

**Context used:**

- Knowledge Base — [Sync flow](https://app.greptile.com/8thpark/-/custom-context/knowledge-base/8thpark/geode/-/docs/sync-flow.md)
- Knowledge Base — [Plugin entrypoint (src/main.ts)](https://app.greptile.com/8thpark/-/custom-context/knowledge-base/8thpark/geode/-/docs/plugin-entrypoint.md)

<!-- /greptile_comment -->