### PR TITLE
[#205] Sync → Keep a permanent halt through a network reconnect

### DIFF
--- a/docs/technical_plugin.md
+++ b/docs/technical_plugin.md
@@ -90,7 +90,10 @@ A manual pass ignores a pause and clears any halt. The escape hatch has to work 
 especially the one where the automatic path has given up.
 
 Coming back online ends a backoff early, but is not treated as proof anything works, only as reason
-enough to stop waiting out a backoff whose premise has visibly expired. Nothing gates on
+enough to stop waiting out a backoff whose premise has visibly expired. It pulls a waiting retry
+forward and stops there: the failure streak keeps its size, so a flapping interface cannot reset the
+delay to the base over and over, and a halt survives untouched, since wrong credentials and a bucket
+belonging to another vault are exactly as wrong after a reconnect. Nothing gates on
 `navigator.onLine`, which reports being on a network rather than being able to reach anything:
 trusting it would turn one wrong answer into a sync that silently never runs.
 

--- a/docs/technical_sync.md
+++ b/docs/technical_sync.md
@@ -349,6 +349,11 @@ guess, which is how a bare "(404)" once ended up being sniffed out of error text
 - **Permanent** is everything retrying cannot fix: credentials that are wrong, a bucket belonging to
   a different vault, a manifest written in a format this build cannot read.
 
+A permanent failure halts automatic sync, and only two things lift that halt: syncing manually, and
+saving settings. Both are someone acting on the problem it is about. A network reconnect is neither.
+It says an interface came back, never that the provider is reachable or the credentials are good, so
+it brings a waiting retry forward and leaves the halt exactly where it is.
+
 A raced pass resets the failure streak rather than merely holding it. It reached the provider, read
 the manifest, moved the files, and lost only the final compare and swap, which proves the network is
 up and the credentials are good. Carrying an earlier failure past that point would let an unlucky

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import {
   noteFocus,
   notePassFinished,
   notePassStarted,
+  noteReconnected,
   noteResumed,
   noteVaultChange,
   PAUSE_KEY,
@@ -237,7 +238,7 @@ export default class GeodePlugin extends Plugin {
       // Reconnecting only ends a backoff whose premise has visibly expired, and is never proof
       // anything works. Nothing gates on navigator.onLine, which reports far less than it seems.
       this.registerDomEvent(window, "online", () => {
-        this.schedule = noteResumed(this.schedule);
+        this.schedule = noteReconnected(this.schedule, Date.now());
       });
 
       this.registerInterval(window.setInterval(() => this.tick(), TICK_MS));

--- a/src/schedule/schedule.test.ts
+++ b/src/schedule/schedule.test.ts
@@ -13,6 +13,7 @@ import {
   noteFocus,
   notePassFinished,
   notePassStarted,
+  noteReconnected,
   noteResumed,
   noteVaultChange,
   POLL_INTERVAL_MS,
@@ -238,6 +239,37 @@ test("notePassFinished: a race breaks a failure streak, since it proves the roun
   state = notePassFinished(state, "retry", 3_000);
   assert.equal(state.failures, 1);
   assert.equal(state.retryAfter, 3_000 + BACKOFF_BASE_MS);
+});
+
+test("noteReconnected: ends a backoff early, keeping the streak that sized it", () => {
+  let state = notePassFinished(notePassFinished(DEFAULT_STATE, "retry", 100), "retry", 200);
+  assert.equal(state.retryAfter, 200 + BACKOFF_BASE_MS * 2);
+
+  state = noteReconnected(state, 300);
+  assert.deepEqual(due(state, 300), { due: true, trigger: "retry" });
+  // The streak survives, so a reconnect that fixed nothing cannot flap the retry delay back down to
+  // the base every time an interface returns.
+  assert.equal(state.failures, 2);
+
+  state = notePassFinished(state, "retry", 300);
+  assert.equal(state.retryAfter, 300 + BACKOFF_BASE_MS * 4);
+});
+
+test("noteReconnected: with nothing waiting, there is nothing to bring forward", () => {
+  // A retry already due is not pushed back to the moment the network returned, and a state with no
+  // retry pending is not handed one it never earned.
+  const overdue = notePassFinished(DEFAULT_STATE, "retry", 100);
+  assert.deepEqual(noteReconnected(overdue, overdue.retryAfter + 1), overdue);
+  assert.deepEqual(noteReconnected(DEFAULT_STATE, 100), DEFAULT_STATE);
+});
+
+test("noteReconnected: a halt survives, since a network returning fixes nothing it stopped for", () => {
+  // Rejected credentials and a bucket belonging to another vault are exactly as wrong after a
+  // reconnect, so resuming here would re-fail on every flap for as long as the vault is open.
+  const halted = notePassFinished(DEFAULT_STATE, "stop", 100);
+
+  assert.deepEqual(noteReconnected(halted, 200), halted);
+  assert.deepEqual(due(noteReconnected(halted, 200), 100 + BACKOFF_MAX_MS * 10), { due: false });
 });
 
 test("noteResumed: clears a halt and any pending retry, and nothing else does", () => {

--- a/src/schedule/schedule.ts
+++ b/src/schedule/schedule.ts
@@ -188,6 +188,20 @@ export function notePassStarted(state: State): State {
   return { ...state, syncing: true, pendingSince: 0, lastEventAt: 0 };
 }
 
+// noteReconnected pulls a waiting retry forward to now, the network being the one premise a backoff
+// waits out. The failure streak survives, since a reconnect proves nothing works, and so does a
+// halt, since an interface returning is not a fixed credential.
+export function noteReconnected(state: State, now: number): State {
+  if (state.stopped) {
+    return state;
+  }
+  if (state.retryAfter === 0 || state.retryAfter <= now) {
+    return state;
+  }
+
+  return { ...state, retryAfter: now };
+}
+
 // noteResumed clears a halt and any backoff; nothing else clears stopped, which is the point of it.
 export function noteResumed(state: State): State {
   return { ...state, failures: 0, retryAfter: 0, stopped: false };


### PR DESCRIPTION
Resolves [#205](https://github.com/8thpark/geode/issues/205)

## Problem

- A failure retrying cannot fix halts automatic sync until someone fixes the underlying problem, but the browser `online` event cleared that halt outright
- Any network reconnect therefore resumed automatic sync and re-failed on rejected credentials, a bucket belonging to another vault, or a provider ignoring conditional writes
- That contradicts the guarantee stated in `docs/technical_sync.md`, and defeats the reason the halt exists

## Why

- A halt is a statement that something is wrong and nothing has fixed it; a reconnect says an interface came back, never that the provider is reachable or the credentials are good
- Silence has to mean everything is fine, so a vault that has stopped syncing should stay stopped and visible rather than quietly re-failing every time the network flaps

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR preserves permanent synchronization halts across browser network reconnects while still advancing a pending retry whose backoff has not expired.

- Adds `noteReconnected` as a targeted scheduler transition that preserves halt and failure-streak state.
- Wires browser `online` events to the new transition instead of fully resuming synchronization.
- Adds scheduler tests covering pending, expired, absent, and permanently halted retries.
- Updates technical documentation to distinguish reconnects from deliberate manual or settings-driven resumes.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or security issues identified.

The reconnect handler now performs the documented narrow scheduler transition, and existing scheduling guards prevent it from duplicating, suppressing, or improperly starting synchronization passes.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/schedule/schedule.ts | Adds a focused reconnect transition that advances only future retries while preserving permanent halts and failure counts. |
| src/main.ts | Routes browser reconnect events through the new scheduler transition without adding lifecycle or concurrency regressions. |
| src/schedule/schedule.test.ts | Covers reconnect behavior for waiting, already-due, absent, and halted retries, including preservation of exponential-backoff state. |
| docs/technical_sync.md | Documents that only manual synchronization and settings changes clear permanent halts. |
| docs/technical_plugin.md | Clarifies that reconnects advance waiting retries without resetting their failure streak or clearing halts. |

<sub>Reviews (1): Last reviewed commit: ["Keep a permanent halt through a network ..."](https://github.com/8thpark/geode/commit/4225e5b97763fcb6f46dc8bfdfb03cc8446c7cc7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51100981)</sub>

**Context used:**

- Knowledge Base — [Plugin entrypoint (src/main.ts)](https://app.greptile.com/8thpark/-/custom-context/knowledge-base/8thpark/geode/-/docs/plugin-entrypoint.md)

<!-- /greptile_comment -->