### PR TITLE
[#193] Onboarding → Walk a new bucket through its first sync

### DIFF
--- a/docs/technical_plugin.md
+++ b/docs/technical_plugin.md
@@ -12,6 +12,7 @@ of Geode testable without a running app.
 - [The Layering Rule](#the-layering-rule)
 - [The Adapters](#the-adapters)
 - [What The Plugin Owns](#what-the-plugin-owns)
+- [The First Sync Dialog](#the-first-sync-dialog)
 - [Guards](#guards)
 - [Writing Files Safely](#writing-files-safely)
 - [Deleting Files](#deleting-files)
@@ -67,6 +68,42 @@ bytes already on disk, so without this a pull can land on a path whose editor st
 content and the next autosave silently overwrites the pulled bytes with content sync never saw. The
 residual race is only whatever someone types between that flush and the read, rather than however
 long has passed since Obsidian's debounce last fired.
+
+### The First Sync Dialog
+
+Saving a connection is the moment someone has said what they want and nothing has happened yet.
+Because the first pass is never started for you (see [Sync](technical_sync.md)), that moment would
+otherwise end in silence, so saving opens a dialog that reads the bucket, says what a first sync
+would do, and offers to run it.
+
+It reads before it asks. The manifest and the sentinel answer whether a vault already lives there,
+and the vault's own file list answers what is on this device. Nothing is written, and no file is
+hashed: the counts come from comparing paths, which is why the merge case says "where a file
+differs" rather than claiming to know that any file does.
+
+| The bucket says       | This vault is | The dialog offers                                     |
+| --------------------- | ------------- | ----------------------------------------------------- |
+| No vault here yet     | Anything      | Upload everything, and this vault becomes the original |
+| A vault already lives here | Empty    | Download everything, nothing local is touched         |
+| A vault already lives here | Not empty | A merge, with upload, download, and overlap counts   |
+| Something to go and fix | Anything    | The reason, and a way back to settings                 |
+| Nothing, it can't be read | Anything  | The error, and another go                             |
+
+Once a pass finishes the same dialog reports what moved and, for the first and only time, explains
+how Geode behaves from then on: automatic syncing, the status bar icon, and the log view. Said
+before a sync has ever run, that is noise; said the moment one has landed, it is the answer to
+"what now". A failed pass keeps someone in the dialog with the message, the logs, and a retry,
+rather than handing them back a status bar icon that can only say something went wrong.
+
+There is deliberately no "overwrite the bucket" or "discard local and fetch" option. Plugins that
+offer that pair are where their users lose notes, and a destructive choice presented during setup is
+the one moment nobody has the context to answer it. Merging with conflict copies is the only path,
+which is the same promise the rest of sync makes.
+
+The dialog is offered while, and only while, a first sync is still ahead of this device: a usable
+connection with no completed pass behind it. That is also what gates the **Set up sync** command, so
+dismissing the dialog is never a dead end and a vault that is already set up is never offered a
+setup step.
 
 ### Guards
 

--- a/docs/technical_settings.md
+++ b/docs/technical_settings.md
@@ -107,3 +107,7 @@ under concurrency, which is exactly what green-lighting it on the HEAD alone wou
 
 Saving is gated on the result, so a draft that failed its test cannot be saved and left to fail at
 sync time instead.
+
+Saving a connection this device has never synced through closes the settings window and opens the
+first sync dialog, since a working connection and no sync yet is a half finished setup rather than a
+finished one; see [Plugin](technical_plugin.md#the-first-sync-dialog).

--- a/docs/technical_sync.md
+++ b/docs/technical_sync.md
@@ -56,6 +56,10 @@ in the table above takes over.
 The same applies if you point Geode at a different bucket: until a sync completes against the new
 one, automatic sync waits. Automatic sync also stays off while storage is not fully configured.
 
+You are not left to find that first pass yourself. Saving a connection opens a dialog that reads the
+bucket, tells you what a first sync would upload, download, or merge, and runs it when you say so;
+see [the first sync dialog](technical_plugin.md#the-first-sync-dialog).
+
 ### Pausing
 
 Two commands in the palette, **Pause automatic sync** and **Resume automatic sync**.

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,8 @@ import { DEVICE_ID_KEY, deviceIdFrom, deviceSuffixFrom } from "./device/device";
 import { createLogSink } from "./log/adapter";
 import { createLogBus, createLogger, type LogBus, type Logger, type LogSink } from "./log/log";
 import { GeodeLogView, LOG_VIEW_TYPE } from "./log/view";
+import { type Actions, GeodeOnboardingModal } from "./onboarding/modal";
+import { type RemoteRead, readRemote, type SyncReport } from "./onboarding/onboarding";
 import {
   armed,
   DEFAULT_STATE,
@@ -60,6 +62,10 @@ type AppWithSetting = App & {
     openTabById: (id: string) => void;
   };
 };
+
+// PassOutcome pairs what the scheduler needs from a pass with what a UI watching one needs, since
+// neither answer contains the other: "stop" is not a message, and a message is not a policy.
+type PassOutcome = { report: SyncReport; result: PassResult };
 
 // SyncStatus is the state the status bar item reflects.
 type SyncStatus = "idle" | "syncing" | "error" | "paused";
@@ -178,6 +184,21 @@ export default class GeodePlugin extends Plugin {
       name: "Sync",
       callback: () => void this.syncNow("manual"),
     });
+    // Offered only while there is a first sync left to run, so the palette never lists a setup
+    // step for a vault that is already set up.
+    this.addCommand({
+      id: "setup",
+      name: "Set up sync",
+      checkCallback: (checking) => {
+        if (!this.canOfferOnboarding()) {
+          return false;
+        }
+        if (!checking) {
+          this.offerOnboarding();
+        }
+        return true;
+      },
+    });
     // Two commands rather than one toggle, so the palette only ever offers the one that would do
     // something, and its name says what that is without the user having to know the current state.
     this.addCommand({
@@ -272,6 +293,74 @@ export default class GeodePlugin extends Plugin {
     app.setting.openTabById(this.manifest.id);
   }
 
+  // canOfferOnboarding reports whether a first sync is still ahead of this device: a usable
+  // connection it has never completed a pass through.
+  private canOfferOnboarding(): boolean {
+    if (this.syncedBefore || !hasConnectionConfig(this.settings)) {
+      return false;
+    }
+
+    return prefixError(this.settings.prefix) === "";
+  }
+
+  // offerOnboarding opens the first sync dialog, closing the settings window first so the status
+  // bar and the log view it points at are not left underneath a modal.
+  private offerOnboarding(): void {
+    if (!this.canOfferOnboarding()) {
+      return;
+    }
+    (this.app as AppWithSetting).setting.close();
+    new GeodeOnboardingModal(this.app, this.onboardingActions()).open();
+  }
+
+  // onboardingActions returns what the first sync dialog needs from the plugin.
+  private onboardingActions(): Actions {
+    return {
+      localPaths: async () => {
+        const files = await createObsidianReader(this.app.vault).listFiles();
+        const paths: string[] = [];
+        for (const file of files) {
+          paths.push(file.path);
+        }
+        return paths;
+      },
+      openLogs: () => void this.openLogView(),
+      openSettings: () => this.openSettingsTab(),
+      readRemote: () => this.readRemoteForPreview(),
+      sync: () => this.syncNow("manual"),
+    };
+  }
+
+  // readRemoteForPreview builds the storage client the preview reads through, reporting anything
+  // that stops it being built as the dialog's own blocked state rather than as a failed pass.
+  private async readRemoteForPreview(): Promise<RemoteRead> {
+    const secretAccessKey = this.app.secretStorage.getSecret(this.settings.secretId);
+    if (secretAccessKey === null || secretAccessKey === "") {
+      return {
+        kind: "blocked",
+        message: `no secret access key found for ID "${this.settings.secretId}"`,
+      };
+    }
+    const dir = this.manifest.dir;
+    if (dir === undefined) {
+      return { kind: "blocked", message: "no plugin data directory available" };
+    }
+
+    const store = createObsidianStore(this.app.vault.adapter, `${dir}/state.json`, this.settings);
+    let localVaultId: string | undefined;
+    try {
+      const snapshot = await store.read();
+      localVaultId = snapshot.vaultId;
+    } catch (err) {
+      this.logger.error(`onboarding: could not read sync state: ${err}`);
+    }
+
+    return readRemote(
+      createS3Client(this.settings, secretAccessKey, obsidianTransport),
+      localVaultId,
+    );
+  }
+
   // restingStatus returns the status bar state to fall back to once nothing is happening, which is
   // "paused" rather than "idle" on a device where automatic sync is switched off. Silence means
   // everything is fine only if a device that has stopped syncing says so.
@@ -321,14 +410,14 @@ export default class GeodePlugin extends Plugin {
 
   // syncNow runs one pass, refusing to start a second while one is running. A manual pass ignores
   // a pause and clears any halt, since the escape hatch has to work in every state.
-  async syncNow(trigger: Trigger = "manual"): Promise<void> {
+  async syncNow(trigger: Trigger = "manual"): Promise<SyncReport> {
     if (this.schedule.syncing) {
-      return;
+      return { ok: false, message: "a sync is already running" };
     }
     if (!hasConnectionConfig(this.settings)) {
       this.logger.warn("sync: storage isn't configured yet");
       this.setSyncStatus("error", "storage isn't configured yet");
-      return;
+      return { ok: false, message: "storage isn't configured yet" };
     }
     // The storage client already refuses an unusable prefix; checking here is what makes the
     // refusal legible, rather than reporting it as a failed conditional write probe.
@@ -336,13 +425,13 @@ export default class GeodePlugin extends Plugin {
     if (badPrefix !== "") {
       this.logger.warn(`sync: ${badPrefix}`);
       this.setSyncStatus("error", badPrefix);
-      return;
+      return { ok: false, message: badPrefix };
     }
     const dir = this.manifest.dir;
     if (dir === undefined) {
       this.logger.error("sync: no plugin data directory available");
       this.setSyncStatus("error", "no plugin data directory available");
-      return;
+      return { ok: false, message: "no plugin data directory available" };
     }
 
     if (trigger === "manual") {
@@ -350,9 +439,12 @@ export default class GeodePlugin extends Plugin {
     }
     this.schedule = notePassStarted(this.schedule);
     this.setSyncStatus("syncing", "");
-    let result: PassResult = "retry";
+    let outcome: PassOutcome = {
+      report: { ok: false, message: "unexpected error" },
+      result: "retry",
+    };
     try {
-      result = await this.runSync(dir, trigger);
+      outcome = await this.runSync(dir, trigger);
     } catch (err) {
       let message = "unexpected error";
       if (err instanceof Error) {
@@ -360,19 +452,23 @@ export default class GeodePlugin extends Plugin {
       }
       this.logger.error(`sync: ${message}`);
       this.setSyncStatus("error", message);
+      outcome = { report: { ok: false, message }, result: "retry" };
     } finally {
-      this.schedule = notePassFinished(this.schedule, result, Date.now());
+      this.schedule = notePassFinished(this.schedule, outcome.result, Date.now());
     }
+
+    return outcome.report;
   }
 
   // runSync does the work of syncNow, split out so the guard and status bar bookkeeping stay
   // readable, and returns what the scheduler backs off from.
-  private async runSync(dir: string, trigger: Trigger): Promise<PassResult> {
+  private async runSync(dir: string, trigger: Trigger): Promise<PassOutcome> {
     const secretAccessKey = this.app.secretStorage.getSecret(this.settings.secretId);
     if (secretAccessKey === null || secretAccessKey === "") {
+      const message = "secret access key not found; open settings to reconfigure";
       this.logger.error(`sync: secret access key not found for ID "${this.settings.secretId}"`);
-      this.setSyncStatus("error", "secret access key not found; open settings to reconfigure");
-      return "stop";
+      this.setSyncStatus("error", message);
+      return { report: { ok: false, message }, result: "stop" };
     }
 
     const storage = createS3Client(this.settings, secretAccessKey, obsidianTransport);
@@ -382,7 +478,7 @@ export default class GeodePlugin extends Plugin {
       if (!probe.ok) {
         this.logger.error(`sync: conditional write check failed: ${probe.message}`);
         this.setSyncStatus("error", probe.message);
-        return "stop";
+        return { report: { ok: false, message: probe.message }, result: "stop" };
       }
       this.conditionalWritesVerified = true;
       this.logger.info("sync: conditional write support verified");
@@ -422,7 +518,10 @@ export default class GeodePlugin extends Plugin {
       this.logger.error(`sync: ${outcome.message}`);
       this.setSyncStatus("error", outcome.message);
 
-      return passResultFor(outcome.fault);
+      return {
+        report: { ok: false, message: outcome.message },
+        result: passResultFor(outcome.fault),
+      };
     }
 
     await stateStore.write(outcome.snapshot);
@@ -434,7 +533,7 @@ export default class GeodePlugin extends Plugin {
     }
     this.setSyncStatus(this.restingStatus(), "");
 
-    return "ok";
+    return { report: { ok: true, changeCount: outcome.changeCount }, result: "ok" };
   }
 
   // loadDeviceId returns this device's identity, minting one on first run and treating an unusable
@@ -489,5 +588,8 @@ export default class GeodePlugin extends Plugin {
     this.schedule = noteResumed(this.schedule);
     await this.loadSyncedBefore();
     this.logger.info("settings saved");
+    // Saving a connection is the moment someone has said what they want and nothing has happened
+    // yet, which is the only moment the first sync dialog has anything to offer.
+    this.offerOnboarding();
   }
 }

--- a/src/onboarding/modal.ts
+++ b/src/onboarding/modal.ts
@@ -1,0 +1,212 @@
+import { type App, ButtonComponent, Modal } from "obsidian";
+import {
+  type Counts,
+  copyFor,
+  DONE_STEPS,
+  doneLead,
+  type Preview,
+  previewFor,
+  type RemoteRead,
+  type SyncReport,
+} from "./onboarding.ts";
+
+// Actions is everything the dialog needs from the plugin, and the whole of what it knows about
+// geode: two reads to build a preview from, one pass to run, and two places to send someone.
+export type Actions = {
+  localPaths: () => Promise<string[]>;
+  openLogs: () => void;
+  openSettings: () => void;
+  readRemote: () => Promise<RemoteRead>;
+  sync: () => Promise<SyncReport>;
+};
+
+// Control is what a rendered button does to the dialog around it.
+type Control = {
+  check: () => void;
+  close: () => void;
+  sync: () => void;
+};
+
+// Stage is where the dialog has got to, and is the only state it holds.
+type Stage =
+  | { kind: "checking" }
+  | { kind: "preview"; preview: Preview }
+  | { kind: "syncing" }
+  | { kind: "done"; changeCount: number }
+  | { kind: "failed"; message: string };
+
+// renderCount draws one labelled number of the counts row.
+function renderCount(row: HTMLElement, label: string, value: number): void {
+  const cell = row.createDiv({ cls: "geode-onboarding-count" });
+  cell.createDiv({ cls: "geode-onboarding-count-value", text: String(value) });
+  cell.createDiv({ cls: "geode-onboarding-count-label", text: label });
+}
+
+// renderCounts draws the three numbers a merge is worth knowing before agreeing to it.
+function renderCounts(el: HTMLElement, counts: Counts): void {
+  const row = el.createDiv({ cls: "geode-onboarding-counts" });
+  renderCount(row, "Upload", counts.upload);
+  renderCount(row, "Download", counts.download);
+  renderCount(row, "On both sides", counts.shared);
+}
+
+// renderDone draws the finished state, the one place the dialog explains how geode behaves from
+// here on.
+function renderDone(el: HTMLElement, changeCount: number, control: Control): void {
+  el.createEl("p", { text: doneLead(changeCount) });
+
+  const list = el.createEl("ul", { cls: "geode-onboarding-steps" });
+  for (const step of DONE_STEPS) {
+    list.createEl("li", { text: step });
+  }
+
+  const buttons = el.createDiv({ cls: "geode-onboarding-buttons" });
+  new ButtonComponent(buttons)
+    .setButtonText("Done")
+    .setCta()
+    .onClick(() => control.close());
+}
+
+// renderFailed draws a failed pass, keeping someone in the dialog rather than returning them to a
+// status bar icon that can only say that something went wrong.
+function renderFailed(el: HTMLElement, message: string, actions: Actions, control: Control): void {
+  el.createEl("p", { cls: "geode-onboarding-error", text: `Sync failed: ${message}` });
+
+  const buttons = el.createDiv({ cls: "geode-onboarding-buttons" });
+  new ButtonComponent(buttons).setButtonText("View logs").onClick(() => {
+    control.close();
+    actions.openLogs();
+  });
+  new ButtonComponent(buttons)
+    .setButtonText("Try again")
+    .setCta()
+    .onClick(() => control.sync());
+}
+
+// renderPreview draws what a first sync would do, and the buttons that answer it.
+function renderPreview(
+  el: HTMLElement,
+  preview: Preview,
+  actions: Actions,
+  control: Control,
+): void {
+  const copy = copyFor(preview);
+  el.createEl("p", { text: copy.lead });
+
+  if (preview.kind === "merge") {
+    renderCounts(el, preview.counts);
+  }
+  for (const line of copy.caution) {
+    el.createEl("p", { cls: "geode-onboarding-caution", text: line });
+  }
+
+  const buttons = el.createDiv({ cls: "geode-onboarding-buttons" });
+  if (preview.kind === "blocked") {
+    new ButtonComponent(buttons).setButtonText("Close").onClick(() => control.close());
+    new ButtonComponent(buttons)
+      .setButtonText("Open settings")
+      .setCta()
+      .onClick(() => {
+        control.close();
+        actions.openSettings();
+      });
+    return;
+  }
+  if (preview.kind === "unreachable") {
+    new ButtonComponent(buttons).setButtonText("Close").onClick(() => control.close());
+    new ButtonComponent(buttons)
+      .setButtonText("Try again")
+      .setCta()
+      .onClick(() => control.check());
+    return;
+  }
+
+  new ButtonComponent(buttons).setButtonText("Not now").onClick(() => control.close());
+  new ButtonComponent(buttons)
+    .setButtonText("Sync now")
+    .setCta()
+    .onClick(() => control.sync());
+}
+
+// renderStage draws the dialog for stage, always as a full redraw of what the stage holds rather
+// than a DOM mutation, the same posture the log view takes.
+function renderStage(el: HTMLElement, stage: Stage, actions: Actions, control: Control): void {
+  el.empty();
+  el.addClass("geode-onboarding");
+
+  if (stage.kind === "checking") {
+    el.createEl("p", { text: "Checking the bucket..." });
+    return;
+  }
+  if (stage.kind === "preview") {
+    renderPreview(el, stage.preview, actions, control);
+    return;
+  }
+  if (stage.kind === "syncing") {
+    el.createEl("p", {
+      text: "Syncing. This can take a while on a large vault, and it carries on if you close this.",
+    });
+    return;
+  }
+  if (stage.kind === "done") {
+    renderDone(el, stage.changeCount, control);
+    return;
+  }
+
+  renderFailed(el, stage.message, actions, control);
+}
+
+// GeodeOnboardingModal walks someone through the one pass geode will never start for them; see
+// docs/technical_plugin.md for why the first sync is asked for rather than assumed.
+export class GeodeOnboardingModal extends Modal {
+  private actions: Actions;
+  private stage: Stage = { kind: "checking" };
+
+  constructor(app: App, actions: Actions) {
+    super(app);
+    this.actions = actions;
+  }
+
+  onOpen(): void {
+    this.titleEl.setText("Set up sync");
+    this.check();
+  }
+
+  onClose(): void {
+    this.contentEl.empty();
+  }
+
+  // check builds the preview, and is also what the unreachable state's retry runs.
+  private check(): void {
+    this.setStage({ kind: "checking" });
+    void this.checkAsync();
+  }
+
+  private async checkAsync(): Promise<void> {
+    const [paths, remote] = await Promise.all([
+      this.actions.localPaths(),
+      this.actions.readRemote(),
+    ]);
+    this.setStage({ kind: "preview", preview: previewFor(paths, remote) });
+  }
+
+  private async run(): Promise<void> {
+    this.setStage({ kind: "syncing" });
+    const report = await this.actions.sync();
+    if (!report.ok) {
+      this.setStage({ kind: "failed", message: report.message });
+      return;
+    }
+
+    this.setStage({ kind: "done", changeCount: report.changeCount });
+  }
+
+  private setStage(stage: Stage): void {
+    this.stage = stage;
+    renderStage(this.contentEl, this.stage, this.actions, {
+      check: () => this.check(),
+      close: () => this.close(),
+      sync: () => void this.run(),
+    });
+  }
+}

--- a/src/onboarding/modal.ts
+++ b/src/onboarding/modal.ts
@@ -5,9 +5,13 @@ import {
   DONE_STEPS,
   doneLead,
   type Preview,
-  previewFor,
   type RemoteRead,
+  type Stage,
   type SyncReport,
+  stageForCheck,
+  stageForFailedCheck,
+  stageForFailedSync,
+  stageForSync,
 } from "./onboarding.ts";
 
 // Actions is everything the dialog needs from the plugin, and the whole of what it knows about
@@ -26,14 +30,6 @@ type Control = {
   close: () => void;
   sync: () => void;
 };
-
-// Stage is where the dialog has got to, and is the only state it holds.
-type Stage =
-  | { kind: "checking" }
-  | { kind: "preview"; preview: Preview }
-  | { kind: "syncing" }
-  | { kind: "done"; changeCount: number }
-  | { kind: "failed"; message: string };
 
 // renderCount draws one labelled number of the counts row.
 function renderCount(row: HTMLElement, label: string, value: number): void {
@@ -182,23 +178,27 @@ export class GeodeOnboardingModal extends Modal {
     void this.checkAsync();
   }
 
+  // Both steps report failure as a value, so a rejection here is something neither expected. It
+  // still has to land somewhere the dialog offers a way out of, or setup stops at "Checking...".
   private async checkAsync(): Promise<void> {
-    const [paths, remote] = await Promise.all([
-      this.actions.localPaths(),
-      this.actions.readRemote(),
-    ]);
-    this.setStage({ kind: "preview", preview: previewFor(paths, remote) });
+    try {
+      const [paths, remote] = await Promise.all([
+        this.actions.localPaths(),
+        this.actions.readRemote(),
+      ]);
+      this.setStage(stageForCheck(paths, remote));
+    } catch (err) {
+      this.setStage(stageForFailedCheck(err));
+    }
   }
 
   private async run(): Promise<void> {
     this.setStage({ kind: "syncing" });
-    const report = await this.actions.sync();
-    if (!report.ok) {
-      this.setStage({ kind: "failed", message: report.message });
-      return;
+    try {
+      this.setStage(stageForSync(await this.actions.sync()));
+    } catch (err) {
+      this.setStage(stageForFailedSync(err));
     }
-
-    this.setStage({ kind: "done", changeCount: report.changeCount });
   }
 
   private setStage(stage: Stage): void {

--- a/src/onboarding/onboarding.test.ts
+++ b/src/onboarding/onboarding.test.ts
@@ -1,0 +1,206 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { fakeStorage, wrapped } from "../sync/fake.ts";
+import { encodeSentinel, MANIFEST_KEY, SENTINEL_KEY } from "../sync/plan.ts";
+import { encodeSnapshot, type Snapshot } from "../vault/vault.ts";
+import {
+  type Counts,
+  copyFor,
+  countsFor,
+  doneLead,
+  type Preview,
+  previewFor,
+  type RemoteRead,
+  readRemote,
+} from "./onboarding.ts";
+
+// VAULT_ID is the identity a seeded bucket claims; nothing depends on the value beyond two tests
+// needing to disagree about it.
+const VAULT_ID = "vault-a";
+
+// file returns a manifest entry at path, with the fields a preview never looks at left at their
+// zero values.
+function file(path: string) {
+  return { path, hash: "h", size: 1, mtime: 2, blob: "h" };
+}
+
+// seeded returns a storage client holding a manifest and sentinel for paths, the shape a bucket
+// has once one device has synced to it.
+function seeded(paths: string[]): ReturnType<typeof fakeStorage> {
+  const snapshot: Snapshot = { files: paths.map(file) };
+
+  return fakeStorage({
+    [MANIFEST_KEY]: wrapped(encodeSnapshot(snapshot)),
+    [SENTINEL_KEY]: wrapped(encodeSentinel({ vaultId: VAULT_ID, createdAt: 0 })),
+  });
+}
+
+test("countsFor: splits two path lists by which side holds them", () => {
+  const cases: { name: string; local: string[]; remote: string[]; want: Counts }[] = [
+    {
+      name: "two empty sides count nothing",
+      local: [],
+      remote: [],
+      want: { download: 0, shared: 0, upload: 0 },
+    },
+    {
+      name: "a path only on disk is an upload",
+      local: ["a.md", "b.md"],
+      remote: [],
+      want: { download: 0, shared: 0, upload: 2 },
+    },
+    {
+      name: "a path only in the bucket is a download",
+      local: [],
+      remote: ["a.md", "b.md"],
+      want: { download: 2, shared: 0, upload: 0 },
+    },
+    {
+      name: "a path on both sides counts once, as shared",
+      local: ["a.md", "b.md"],
+      remote: ["b.md", "c.md"],
+      want: { download: 1, shared: 1, upload: 1 },
+    },
+    {
+      name: "case matters, since two casings are two keys in the bucket",
+      local: ["A.md"],
+      remote: ["a.md"],
+      want: { download: 1, shared: 0, upload: 1 },
+    },
+  ];
+
+  for (const c of cases) {
+    assert.deepEqual(countsFor(c.local, c.remote), c.want, c.name);
+  }
+});
+
+test("previewFor: each read of the bucket decides what the dialog offers", () => {
+  const cases: { name: string; local: string[]; remote: RemoteRead; want: Preview }[] = [
+    {
+      name: "a fresh bucket is a push of everything local",
+      local: ["a.md", "b.md"],
+      remote: { kind: "fresh" },
+      want: { kind: "push", upload: 2 },
+    },
+    {
+      name: "a fresh bucket and an empty vault is still a push, claiming the bucket",
+      local: [],
+      remote: { kind: "fresh" },
+      want: { kind: "push", upload: 0 },
+    },
+    {
+      name: "an empty vault against a synced bucket is a clean pull",
+      local: [],
+      remote: { kind: "vault", paths: ["a.md"] },
+      want: { kind: "pull", download: 1 },
+    },
+    {
+      name: "files on both sides is the merge, the one case worth a warning",
+      local: ["a.md", "b.md"],
+      remote: { kind: "vault", paths: ["b.md", "c.md"] },
+      want: { kind: "merge", counts: { download: 1, shared: 1, upload: 1 } },
+    },
+    {
+      name: "a permanent refusal is carried through as something to go and fix",
+      local: ["a.md"],
+      remote: { kind: "blocked", message: "belongs to a different vault" },
+      want: { kind: "blocked", message: "belongs to a different vault" },
+    },
+    {
+      name: "a transient failure is carried through as something to try again",
+      local: ["a.md"],
+      remote: { kind: "unreachable", message: "network error" },
+      want: { kind: "unreachable", message: "network error" },
+    },
+  ];
+
+  for (const c of cases) {
+    assert.deepEqual(previewFor(c.local, c.remote), c.want, c.name);
+  }
+});
+
+test("copyFor: says what will happen, and cautions only where there is something to lose", () => {
+  const push = copyFor({ kind: "push", upload: 1 });
+  assert.match(push.lead, /^This bucket is empty\. 1 file will be uploaded/);
+  assert.deepEqual(push.caution, []);
+
+  const empty = copyFor({ kind: "push", upload: 0 });
+  assert.match(empty.lead, /and so is this vault/);
+  assert.deepEqual(empty.caution, []);
+
+  const pull = copyFor({ kind: "pull", download: 3 });
+  assert.match(pull.lead, /3 files will be downloaded/);
+  assert.match(pull.lead, /nothing here is overwritten/);
+  assert.deepEqual(pull.caution, []);
+
+  const merge = copyFor({ kind: "merge", counts: { download: 1, shared: 2, upload: 1 } });
+  assert.match(merge.lead, /Nothing is deleted/);
+  assert.deepEqual(merge.caution, [
+    "Back up this vault first if the 2 files on both sides matter.",
+  ]);
+
+  const clean = copyFor({ kind: "merge", counts: { download: 1, shared: 0, upload: 1 } });
+  assert.deepEqual(clean.caution, [], "nothing overlaps, so there is nothing to back up for");
+
+  const blocked = copyFor({ kind: "blocked", message: "it belongs to another vault" });
+  assert.equal(blocked.lead, "Geode won't sync here: it belongs to another vault.");
+  assert.equal(blocked.caution.length, 1);
+
+  const unreachable = copyFor({ kind: "unreachable", message: "network error" });
+  assert.equal(unreachable.lead, "Could not read the bucket: network error.");
+  assert.deepEqual(unreachable.caution, []);
+});
+
+test("doneLead: reports what the pass moved, without making a count read as a plural", () => {
+  assert.match(doneLead(0), /Nothing needed moving/);
+  assert.equal(doneLead(1), "Synced. 1 change applied.");
+  assert.equal(doneLead(2), "Synced. 2 changes applied.");
+});
+
+test("readRemote: a bucket with no manifest is fresh", async () => {
+  const { storage } = fakeStorage();
+
+  assert.deepEqual(await readRemote(storage, undefined), { kind: "fresh" });
+});
+
+test("readRemote: a synced bucket reports the paths its manifest names", async () => {
+  const { storage } = seeded(["a.md", "notes/b.md"]);
+
+  assert.deepEqual(await readRemote(storage, undefined), {
+    kind: "vault",
+    paths: ["a.md", "notes/b.md"],
+  });
+});
+
+test("readRemote: a bucket owned by another vault is blocked before anything is offered", async () => {
+  const { storage } = seeded(["a.md"]);
+
+  const read = await readRemote(storage, "vault-b");
+  assert.equal(read.kind, "blocked");
+});
+
+test("readRemote: content this build cannot read is blocked, not something to retry", async () => {
+  const { storage } = fakeStorage({ [MANIFEST_KEY]: "not a geode object" });
+
+  const read = await readRemote(storage, undefined);
+  assert.equal(read.kind, "blocked");
+});
+
+test("readRemote: a failed read is unreachable, so the dialog offers another go", async () => {
+  const { storage } = fakeStorage();
+  const failing = {
+    ...storage,
+    getObject: async () => ({
+      ok: false as const,
+      status: "network" as const,
+      message: "network error",
+      body: null,
+      etag: null,
+    }),
+  };
+
+  assert.deepEqual(await readRemote(failing, undefined), {
+    kind: "unreachable",
+    message: "network error",
+  });
+});

--- a/src/onboarding/onboarding.test.ts
+++ b/src/onboarding/onboarding.test.ts
@@ -12,6 +12,10 @@ import {
   previewFor,
   type RemoteRead,
   readRemote,
+  stageForCheck,
+  stageForFailedCheck,
+  stageForFailedSync,
+  stageForSync,
 } from "./onboarding.ts";
 
 // VAULT_ID is the identity a seeded bucket claims; nothing depends on the value beyond two tests
@@ -155,6 +159,45 @@ test("doneLead: reports what the pass moved, without making a count read as a pl
   assert.match(doneLead(0), /Nothing needed moving/);
   assert.equal(doneLead(1), "Synced. 1 change applied.");
   assert.equal(doneLead(2), "Synced. 2 changes applied.");
+});
+
+test("stageForCheck: a completed read moves the dialog on to what it would do", () => {
+  assert.deepEqual(stageForCheck(["a.md"], { kind: "fresh" }), {
+    kind: "preview",
+    preview: { kind: "push", upload: 1 },
+  });
+});
+
+test("stageForFailedCheck: a thrown read still lands somewhere with a way out", () => {
+  const cases: { name: string; err: unknown; want: string }[] = [
+    { name: "an error is shown as what it says", err: new Error("disk gone"), want: "disk gone" },
+    { name: "an empty message is no message at all", err: new Error(""), want: "unexpected error" },
+    { name: "a thrown string carries nothing to show", err: "nope", want: "unexpected error" },
+  ];
+
+  for (const c of cases) {
+    assert.deepEqual(
+      stageForFailedCheck(c.err),
+      { kind: "preview", preview: { kind: "unreachable", message: c.want } },
+      c.name,
+    );
+  }
+});
+
+test("stageForSync: a reported pass ends the dialog on what it did, or on what went wrong", () => {
+  assert.deepEqual(stageForSync({ ok: true, changeCount: 3 }), { kind: "done", changeCount: 3 });
+  assert.deepEqual(stageForSync({ ok: false, message: "bucket gone" }), {
+    kind: "failed",
+    message: "bucket gone",
+  });
+});
+
+test("stageForFailedSync: a pass that throws past its report is still a failed pass", () => {
+  assert.deepEqual(stageForFailedSync(new Error("boom")), { kind: "failed", message: "boom" });
+  assert.deepEqual(stageForFailedSync(undefined), {
+    kind: "failed",
+    message: "unexpected error",
+  });
 });
 
 test("readRemote: a bucket with no manifest is fresh", async () => {

--- a/src/onboarding/onboarding.ts
+++ b/src/onboarding/onboarding.ts
@@ -36,6 +36,14 @@ export type RemoteRead =
   | { kind: "blocked"; message: string }
   | { kind: "unreachable"; message: string };
 
+// Stage is where the dialog has got to, and is the only state it holds.
+export type Stage =
+  | { kind: "checking" }
+  | { kind: "preview"; preview: Preview }
+  | { kind: "syncing" }
+  | { kind: "done"; changeCount: number }
+  | { kind: "failed"; message: string };
+
 // SyncReport is what one pass tells a caller that has to say more about it than the status bar's
 // icon can.
 export type SyncReport = { ok: true; changeCount: number } | { ok: false; message: string };
@@ -193,6 +201,32 @@ export async function readRemote(
   return { kind: "vault", paths };
 }
 
+// stageForCheck returns where the dialog lands once it knows what both sides hold.
+export function stageForCheck(localPaths: string[], remote: RemoteRead): Stage {
+  return { kind: "preview", preview: previewFor(localPaths, remote) };
+}
+
+// stageForFailedCheck returns where the dialog lands when a preview read throws instead of
+// returning a result, which is another way of not knowing and so is offered the same retry.
+export function stageForFailedCheck(err: unknown): Stage {
+  return { kind: "preview", preview: { kind: "unreachable", message: messageFrom(err) } };
+}
+
+// stageForFailedSync returns where the dialog lands when a pass throws past the report it was
+// supposed to return.
+export function stageForFailedSync(err: unknown): Stage {
+  return { kind: "failed", message: messageFrom(err) };
+}
+
+// stageForSync returns where the dialog lands once a pass has reported.
+export function stageForSync(report: SyncReport): Stage {
+  if (!report.ok) {
+    return { kind: "failed", message: report.message };
+  }
+
+  return { kind: "done", changeCount: report.changeCount };
+}
+
 // files renders a file count with its noun, since a dialog read once should not make anyone parse
 // "file(s)".
 function files(count: number): string {
@@ -201,6 +235,16 @@ function files(count: number): string {
   }
 
   return `${count} files`;
+}
+
+// messageFrom returns what a thrown value can be shown as, since nothing stops a rejection
+// carrying something that is not an Error.
+function messageFrom(err: unknown): string {
+  if (err instanceof Error && err.message !== "") {
+    return err.message;
+  }
+
+  return "unexpected error";
 }
 
 // refusal maps a failed read onto the two things the dialog can offer: something to go and fix, or

--- a/src/onboarding/onboarding.ts
+++ b/src/onboarding/onboarding.ts
@@ -1,0 +1,214 @@
+import type { StorageClient } from "../storage/storage.ts";
+import { resolveVaultIdentity } from "../sync/plan.ts";
+import { readRemoteManifest, readSentinel, type SyncFault } from "../sync/sync.ts";
+
+// DONE_STEPS is what a user needs to know once a first sync has landed, and is the only place
+// geode explains how it behaves; said before a sync has run it would be noise.
+export const DONE_STEPS = [
+  "Geode now syncs on its own: edits go up a few seconds after you stop typing, and it checks " +
+    "for remote changes every 5 minutes.",
+  "The cloud icon in the status bar is the whole status. Click it to sync right now.",
+  'Run "Geode: Logs" from the command palette to see everything it has done.',
+];
+
+// Copy is what the dialog says about a preview: one lead paragraph, then any cautions that follow
+// the counts.
+export type Copy = { caution: string[]; lead: string };
+
+// Counts is how a first sync would split the two sides, counted by path alone: no file is hashed,
+// so shared means a path exists on both sides, never that the two copies differ.
+export type Counts = { download: number; shared: number; upload: number };
+
+// Preview is what a first sync against this bucket would do, and is everything the dialog needs to
+// decide what to say; see docs/technical_plugin.md.
+export type Preview =
+  | { kind: "push"; upload: number }
+  | { kind: "pull"; download: number }
+  | { kind: "merge"; counts: Counts }
+  | { kind: "blocked"; message: string }
+  | { kind: "unreachable"; message: string };
+
+// RemoteRead is what the bucket said when the preview asked, kept apart from the judgement made
+// about it so every branch of previewFor stays a pure table case.
+export type RemoteRead =
+  | { kind: "fresh" }
+  | { kind: "vault"; paths: string[] }
+  | { kind: "blocked"; message: string }
+  | { kind: "unreachable"; message: string };
+
+// SyncReport is what one pass tells a caller that has to say more about it than the status bar's
+// icon can.
+export type SyncReport = { ok: true; changeCount: number } | { ok: false; message: string };
+
+// copyFor returns what the dialog says about preview, kept here rather than in the modal so the
+// wording of every branch is pinned by a test.
+export function copyFor(preview: Preview): Copy {
+  if (preview.kind === "push") {
+    if (preview.upload === 0) {
+      return {
+        caution: [],
+        lead:
+          "This bucket is empty, and so is this vault. Syncing now claims the bucket, so the " +
+          "next device you connect syncs into it.",
+      };
+    }
+    return {
+      caution: [],
+      lead:
+        `This bucket is empty. ${files(preview.upload)} will be uploaded, and this vault ` +
+        "becomes the copy every other device syncs from.",
+    };
+  }
+
+  if (preview.kind === "pull") {
+    return {
+      caution: [],
+      lead:
+        `This bucket already holds a vault. ${files(preview.download)} will be downloaded into ` +
+        "this empty vault, and nothing here is overwritten.",
+    };
+  }
+
+  if (preview.kind === "merge") {
+    const caution: string[] = [];
+    if (preview.counts.shared > 0) {
+      caution.push(
+        `Back up this vault first if the ${files(preview.counts.shared)} on both sides matter.`,
+      );
+    }
+    return {
+      caution,
+      lead:
+        "Both sides have files, so geode will merge them. Nothing is deleted: where a file " +
+        "differs on both sides the remote copy takes the name, and yours is kept beside it as a " +
+        "conflict copy.",
+    };
+  }
+
+  if (preview.kind === "blocked") {
+    return {
+      caution: ["Nothing has been written to the bucket. Fix this in settings, then try again."],
+      lead: `Geode won't sync here: ${preview.message}.`,
+    };
+  }
+
+  return { caution: [], lead: `Could not read the bucket: ${preview.message}.` };
+}
+
+// countsFor splits two path lists into what a first sync would upload, download, and find waiting
+// on both sides.
+export function countsFor(localPaths: string[], remotePaths: string[]): Counts {
+  const local = new Set(localPaths);
+  const remote = new Set(remotePaths);
+
+  let shared = 0;
+  let upload = 0;
+  for (const path of local) {
+    if (remote.has(path)) {
+      shared += 1;
+      continue;
+    }
+    upload += 1;
+  }
+
+  let download = 0;
+  for (const path of remote) {
+    if (local.has(path)) {
+      continue;
+    }
+    download += 1;
+  }
+
+  return { download, shared, upload };
+}
+
+// doneLead returns the one line summary of a completed first sync.
+export function doneLead(changeCount: number): string {
+  if (changeCount === 0) {
+    return "Synced. Nothing needed moving, and this bucket now belongs to this vault.";
+  }
+  if (changeCount === 1) {
+    return "Synced. 1 change applied.";
+  }
+
+  return `Synced. ${changeCount} changes applied.`;
+}
+
+// previewFor turns what the bucket said, and what is on disk, into what a first sync would do.
+export function previewFor(localPaths: string[], remote: RemoteRead): Preview {
+  if (remote.kind === "fresh") {
+    return { kind: "push", upload: localPaths.length };
+  }
+  if (remote.kind === "vault") {
+    if (localPaths.length === 0) {
+      return { kind: "pull", download: remote.paths.length };
+    }
+    return { kind: "merge", counts: countsFor(localPaths, remote.paths) };
+  }
+  if (remote.kind === "blocked") {
+    return { kind: "blocked", message: remote.message };
+  }
+
+  return { kind: "unreachable", message: remote.message };
+}
+
+// readRemote asks the bucket the two questions a preview is built from, reading only: a preview
+// that wrote anything would be the very first sync it exists to ask permission for.
+export async function readRemote(
+  storage: StorageClient,
+  localVaultId: string | undefined,
+): Promise<RemoteRead> {
+  const [manifest, sentinel] = await Promise.all([
+    readRemoteManifest(storage),
+    readSentinel(storage),
+  ]);
+  if (!manifest.ok) {
+    return refusal(manifest.fault, manifest.message);
+  }
+  if (!sentinel.ok) {
+    return refusal(sentinel.fault, sentinel.message);
+  }
+
+  // The minted ID is discarded, since all the preview asks is whether this pass would be refused
+  // for pointing a vault at a bucket that already belongs to a different one.
+  const identity = resolveVaultIdentity(
+    manifest.firstSync,
+    sentinel.sentinel,
+    localVaultId,
+    () => "",
+  );
+  if (!identity.ok) {
+    return { kind: "blocked", message: identity.message };
+  }
+
+  if (manifest.firstSync) {
+    return { kind: "fresh" };
+  }
+
+  const paths: string[] = [];
+  for (const entry of manifest.snapshot.files) {
+    paths.push(entry.path);
+  }
+
+  return { kind: "vault", paths };
+}
+
+// files renders a file count with its noun, since a dialog read once should not make anyone parse
+// "file(s)".
+function files(count: number): string {
+  if (count === 1) {
+    return "1 file";
+  }
+
+  return `${count} files`;
+}
+
+// refusal maps a failed read onto the two things the dialog can offer: something to go and fix, or
+// something to try again.
+function refusal(fault: SyncFault, message: string): RemoteRead {
+  if (fault === "permanent") {
+    return { kind: "blocked", message };
+  }
+
+  return { kind: "unreachable", message };
+}

--- a/styles.css
+++ b/styles.css
@@ -183,3 +183,61 @@
     transform: rotate(360deg);
   }
 }
+
+.geode-onboarding p {
+  margin: 0 0 1em;
+}
+
+.geode-onboarding-counts {
+  display: flex;
+  gap: 0.5em;
+  margin-bottom: 1em;
+}
+
+.geode-onboarding-count {
+  flex: 1;
+  padding: 0.75em 0.5em;
+  border-radius: var(--radius-m, 8px);
+  background: var(--background-secondary);
+  text-align: center;
+}
+
+.geode-onboarding-count-value {
+  font-size: 1.5em;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.geode-onboarding-count-label {
+  color: var(--text-muted);
+  font-size: var(--font-ui-smaller);
+}
+
+.geode-onboarding-caution {
+  color: var(--text-warning);
+}
+
+.geode-onboarding-error {
+  color: var(--text-error);
+}
+
+.geode-onboarding-steps {
+  margin: 0 0 1em;
+  padding-left: 1.25em;
+  color: var(--text-muted);
+}
+
+.geode-onboarding-steps li {
+  margin-bottom: 0.35em;
+}
+
+.geode-onboarding-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5em;
+  justify-content: flex-end;
+}
+
+.geode-onboarding-buttons button {
+  cursor: pointer;
+}


### PR DESCRIPTION
Resolves [#193](https://github.com/8thpark/geode/issues/193)

## Problem

Saving a working connection ended in silence. Geode never starts the first sync itself, so setup finished with a green "Connected" line, no sign that a manual pass was owed, and no warning that pointing a vault at a bucket which already holds one merges the two.

## Why

The first pass is the one with no ancestor to fall back on; a misconfigured bucket, an unrelated vault, or an unexpected merge all land there, and all are tedious to unpick afterwards. Reading the bucket first turns it into a decision with numbers attached.

There is deliberately no "overwrite remote" or "discard local" option. That pair is where other sync plugins lose notes, and setup is the moment someone has the least context to answer it; merging with conflict copies stays the only path.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a first-sync onboarding dialog that previews local and remote contents, guides users through the initial synchronization, and reports its outcome.
- Adds pure preview, count, copy, and stage-transition helpers with unit coverage.
- Connects onboarding to saved settings and a command-palette setup action.
- Documents first-sync behavior and adds dialog styling.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/onboarding/modal.ts | Implements the Obsidian modal UI, preview controls, synchronization progress, and rejection handling. |
| src/onboarding/onboarding.ts | Adds pure remote-preview, count, copy, and stage-transition behavior. |
| src/main.ts | Wires onboarding eligibility, preview dependencies, and synchronization reports into the plugin lifecycle. |
| src/onboarding/onboarding.test.ts | Covers preview classification, user-facing copy, transition helpers, and remote-read outcomes. |
| styles.css | Adds layout and visual treatment for onboarding counts, cautions, errors, and controls. |
| docs/technical_plugin.md | Documents the first-sync dialog, its safety posture, and when it is offered. |

<sub>Reviews (2): Last reviewed commit: ["Address comments"](https://github.com/8thpark/geode/commit/89ec8f5e7fdd59ed9787fdd04f3c062304ef0c85) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51107652)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/8thpark/geode/blob/main/AGENTS.md))

<!-- /greptile_comment -->