### PR TITLE
Security → Bump js-yaml past the omap DoS advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1825,9 +1825,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Resolves [Dependabot #5](https://github.com/8thpark/geode/security/dependabot/5)

## Problem

- `js-yaml` 4.3.0 resolves `!!omap` sequences with a linear scan per entry, so parsing cost grows quadratically and a small document can stall the event loop
- Flagged as high severity (7.5, availability only) under `GHSA-5p4m-2wfm-xmqj`, the 3.x/4.x twin of `CVE-2026-59870` that was never backported from the 5.x line

## Changes

- Bump `js-yaml` from `4.3.0` to `4.3.1` in `package-lock.json`

## Why

- Exposure is limited; `js-yaml` is a development only transitive dependency of `secretlint`, no project source imports it, and it never reaches the shipped plugin bundle

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the transitive development dependency `js-yaml` from 4.3.0 to 4.3.1 to address the `!!omap` denial-of-service advisory.

- Updates the locked package version, registry URL, and integrity hash.
- Preserves the existing dependency graph and development-only classification.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable issues identified.

The lockfile update stays within the transitive consumers’ declared js-yaml ranges, preserves development-only usage, and remains compatible with the repository’s Node runtime.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| package-lock.json | The js-yaml patch update is internally consistent, remains within all requesting dependency ranges, and introduces no identified installation or runtime regression. |

<sub>Reviews (1): Last reviewed commit: ["Bump dep"](https://github.com/8thpark/geode/commit/d4feabb877d9f05f52b7d7f48fd44169d14fc8b0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51122990)</sub>

<!-- /greptile_comment -->