### PR TITLE
[#77] Sync → Halt a pass that would destroy a large share of the vault

### DIFF
--- a/docs/technical_plugin.md
+++ b/docs/technical_plugin.md
@@ -13,6 +13,7 @@ of Geode testable without a running app.
 - [The Adapters](#the-adapters)
 - [What The Plugin Owns](#what-the-plugin-owns)
 - [The First Sync Dialog](#the-first-sync-dialog)
+- [The Mass Change Dialog](#the-mass-change-dialog)
 - [Guards](#guards)
 - [Writing Files Safely](#writing-files-safely)
 - [Deleting Files](#deleting-files)
@@ -104,6 +105,28 @@ The dialog is offered while, and only while, a first sync is still ahead of this
 connection with no completed pass behind it. That is also what gates the **Set up sync** command, so
 dismissing the dialog is never a dead end and a vault that is already set up is never offered a
 setup step.
+
+### The Mass Change Dialog
+
+When a pass is refused by the [mass change guard](technical_sync.md#the-mass-change-guard), the
+plugin opens the only other dialog Geode has. It is the same shape as the first sync one, and for
+the same reason: something irreversible is about to happen, and the only person who can say whether
+it is right is not the one who planned it.
+
+Four things have to be on the screen, because a bare count cannot be answered:
+
+1. What the pass would do, per side, in files rather than actions
+2. Which part of it is recoverable, since a deleted file goes to the trash and a replaced one does
+   not, and nobody would guess that
+3. The files themselves, collapsed, first twenty and a count of the rest; seeing "all my daily
+   notes" rather than "the folder I deleted on my phone" is what makes the question answerable
+4. That nothing has changed yet and automatic sync stays off until it is answered, or someone
+   cancels, notices sync is dead an hour later, and reports it as a bug
+
+Cancel is the emphasised button and dismissing the dialog any other way counts as a cancel, so the
+pass only runs when someone reached for the button that says so. Confirming runs a fresh manual
+pass, which is also what lifts the halt, so the escape hatch and the answer are the same mechanism
+rather than two that can disagree.
 
 ### Guards
 

--- a/docs/technical_plugin.md
+++ b/docs/technical_plugin.md
@@ -128,6 +128,12 @@ pass only runs when someone reached for the button that says so. Confirming runs
 pass, which is also what lifts the halt, so the escape hatch and the answer are the same mechanism
 rather than two that can disagree.
 
+The answer carries the plan it was given back with it, and the fresh pass checks that it is still
+planning exactly that (see [the guard](technical_sync.md#the-mass-change-guard)). When it is not,
+the dialog opens again, and says so: a second identical looking prompt with no explanation reads as
+a bug, and someone who has already clicked through one is exactly the person who will click through
+the next without reading it.
+
 ### Guards
 
 Three pieces of state the plugin holds, each preventing a specific failure.

--- a/docs/technical_sync.md
+++ b/docs/technical_sync.md
@@ -15,6 +15,7 @@ for the promise that no edit is ever lost.
 - [The Scheduler](#the-scheduler)
 - [What A Pass Does](#what-a-pass-does)
 - [Planning](#planning)
+- [The Mass Change Guard](#the-mass-change-guard)
 - [Executing](#executing)
 - [Conflicts](#conflicts)
 - [Vault Identity](#vault-identity)
@@ -59,6 +60,9 @@ one, automatic sync waits. Automatic sync also stays off while storage is not fu
 You are not left to find that first pass yourself. Saving a connection opens a dialog that reads the
 bucket, tells you what a first sync would upload, download, or merge, and runs it when you say so;
 see [the first sync dialog](technical_plugin.md#the-first-sync-dialog).
+
+**A sync that would destroy a large share of the vault is also always something you ask for**, first
+pass or hundredth; see [the mass change guard](#the-mass-change-guard).
 
 ### Pausing
 
@@ -132,16 +136,17 @@ One pass, in order:
 3. Read the remote manifest, and its ETag
 4. Resolve vault identity, refusing if this bucket is not the one this device synced before
 5. Plan the reconciliation from three snapshots
-6. Execute every action, collecting per file failures rather than stopping at the first
-7. Upload a manifest describing what the bucket now holds, conditional on that ETag still being
+6. Stop and ask if the plan would destroy a large share of the vault, unless it already has
+7. Execute every action, collecting per file failures rather than stopping at the first
+8. Upload a manifest describing what the bucket now holds, conditional on that ETag still being
    current, or on the manifest still being absent for a first sync
-8. Return the new snapshot for the caller to persist as `state.json`
+9. Return the new snapshot for the caller to persist as `state.json`
 
 The caller owns persistence. The previous snapshot is passed in and the new one handed back rather
 than read or written internally, so a pass stays pure over its inputs and tests can drive it with
 their own store.
 
-A pass that planned nothing and found a manifest already describing exactly that skips step 7.
+A pass that planned nothing and found a manifest already describing exactly that skips step 8.
 Writing it anyway is not merely a wasted request: every manifest upload is a compare and swap, so a
 device with nothing to say is a device that can lose a race it had no reason to enter and report
 "another device synced at the same time" over a vault nobody touched. Under manual sync that costs
@@ -174,6 +179,52 @@ Every pushed entry is recorded at the hash of the bytes that actually reached th
 pre-push snapshot hash and not at the owning action's success. A conflict's copy push can succeed
 while the same action's restore fails, and the copy still has to reach the manifest or it sits in
 the bucket forever, invisible to every other device.
+
+### The Mass Change Guard
+
+Between planning and executing sits the last point at which refusing costs nothing. A plan is
+counted before a byte moves, and a pass that would destroy a large share of the vault stops and asks
+instead of running.
+
+Destroying means one of three things, and nothing else counts:
+
+| Action                                       | Destructive? | Why                                     |
+| -------------------------------------------- | ------------ | --------------------------------------- |
+| A file deleted locally                       | Yes          | Goes to the trash, but it does go       |
+| A file here replaced by the remote version    | Yes          | The version in the vault is not kept    |
+| A file deleted from the bucket               | Yes          | The manifest stops listing it           |
+| A file added on either side                  | No           | Nothing is being replaced               |
+| A conflict copy                              | No           | Both versions survive, under two names  |
+
+The threshold is a share of the tracked files, clamped at both ends:
+
+```
+halt if destructive > clamp(tracked * 0.2, 10, 50)
+```
+
+Three bands fall out of that. Under 50 tracked files the floor of 10 binds, so deleting a handful of
+notes never prompts. Between 50 and 250 the share binds. Above 250 the ceiling of 50 binds, because
+a fifth of a ten thousand file vault is two thousand files and nobody should lose two thousand files
+without being asked.
+
+Neither end works alone. A share on its own waves through thousands in a large vault; a count on its
+own can never fire in a vault smaller than the count itself, which is exactly where a new user is.
+The floor is there because a guard people learn to dismiss guards nothing.
+
+Tracked is the ancestor's file count, so a first sync has a tracked count of zero. That is safe by
+construction rather than by special case: every action in a bootstrap is an addition, and a device
+pulling a vault into an empty folder is adding too, so neither can reach the floor.
+
+Halting executes nothing. No file is written, no manifest goes up, no sentinel is written, and
+`state.json` does not advance, so cancelling leaves a pass that can simply be planned again. The
+confirmation runs a fresh pass rather than resuming the halted one: the plan is rebuilt from a
+re-read of the bucket, which is both simpler than holding an ETag open across a human's attention
+span and safer, since the compare and swap is never left waiting on someone finding their reading
+glasses.
+
+Under automatic sync the halt is a full stop rather than a prompt on a timer. The scheduler treats
+it exactly like a permanent failure, so an unanswered dialog is asked once, not once every five
+minutes.
 
 ### Executing
 
@@ -342,6 +393,7 @@ successful pass reconciles both. What changes is how soon that next pass is atte
 | Secret access key missing                      | Stops automatic sync until you fix it |
 | Provider does not support conditional writes   | Stops automatic sync until you fix it |
 | Bucket was written by a newer version of Geode | Stops automatic sync; update Geode    |
+| The pass would destroy a large share of the vault | Stops automatic sync until you answer |
 
 A failed pass carries how it should be treated rather than leaving a caller to read the message and
 guess, which is how a bare "(404)" once ended up being sniffed out of error text.
@@ -352,6 +404,8 @@ guess, which is how a bare "(404)" once ended up being sniffed out of error text
   failing at all. Nothing is lost, both sides' work survives, and the next pass reconciles them.
 - **Permanent** is everything retrying cannot fix: credentials that are wrong, a bucket belonging to
   a different vault, a manifest written in a format this build cannot read.
+- **Blocked** is not a failure at all: the pass was refused by the mass change guard and is waiting
+  on an answer. Nothing ran, so there is no progress to keep and nothing to retry.
 
 A permanent failure halts automatic sync, and only two things lift that halt: syncing manually, and
 saving settings. Both are someone acting on the problem it is about. A network reconnect is neither.

--- a/docs/technical_sync.md
+++ b/docs/technical_sync.md
@@ -222,6 +222,17 @@ re-read of the bucket, which is both simpler than holding an ETag open across a 
 span and safer, since the compare and swap is never left waiting on someone finding their reading
 glasses.
 
+An answer covers the plan it was given and no other. The confirmation carries the destructive set
+that was on the screen, and the fresh pass runs only if what it now plans is exactly that set, path
+for path and fate for fate. Anything else is a plan nobody has seen, so it is asked again rather
+than executed under an old yes. That matters because the vault and the bucket both keep moving
+between the dialog opening and someone answering it: without the binding, a "yes" to 12 deletions
+could be spent on 400.
+
+The comparison is by set rather than by order, since planning follows snapshot order and a re-read
+of the bucket is under no obligation to repeat it. A fresh plan that no longer trips the guard at
+all simply runs, confirmed or not; there is nothing left to ask about.
+
 Under automatic sync the halt is a full stop rather than a prompt on a timer. The scheduler treats
 it exactly like a permanent failure, so an unanswered dialog is asked once, not once every five
 minutes.

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,6 +32,7 @@ import {
 import { GeodeSettingTab } from "./settings/tab";
 import { obsidianTransport } from "./storage/obsidian";
 import { createS3Client, probeConditionalWrites } from "./storage/storage";
+import { GeodeMassChangeModal } from "./sync/modal";
 import { type SyncFault, syncOnce } from "./sync/sync";
 import {
   createObsidianLocalWriter,
@@ -410,7 +411,7 @@ export default class GeodePlugin extends Plugin {
 
   // syncNow runs one pass, refusing to start a second while one is running. A manual pass ignores
   // a pause and clears any halt, since the escape hatch has to work in every state.
-  async syncNow(trigger: Trigger = "manual"): Promise<SyncReport> {
+  async syncNow(trigger: Trigger = "manual", allowMassChange = false): Promise<SyncReport> {
     if (this.schedule.syncing) {
       return { ok: false, message: "a sync is already running" };
     }
@@ -444,7 +445,7 @@ export default class GeodePlugin extends Plugin {
       result: "retry",
     };
     try {
-      outcome = await this.runSync(dir, trigger);
+      outcome = await this.runSync(dir, trigger, allowMassChange);
     } catch (err) {
       let message = "unexpected error";
       if (err instanceof Error) {
@@ -462,7 +463,11 @@ export default class GeodePlugin extends Plugin {
 
   // runSync does the work of syncNow, split out so the guard and status bar bookkeeping stay
   // readable, and returns what the scheduler backs off from.
-  private async runSync(dir: string, trigger: Trigger): Promise<PassOutcome> {
+  private async runSync(
+    dir: string,
+    trigger: Trigger,
+    allowMassChange: boolean,
+  ): Promise<PassOutcome> {
     const secretAccessKey = this.app.secretStorage.getSecret(this.settings.secretId);
     if (secretAccessKey === null || secretAccessKey === "") {
       const message = "secret access key not found; open settings to reconfigure";
@@ -505,7 +510,17 @@ export default class GeodePlugin extends Plugin {
       Date.now(),
       () => crypto.randomUUID(),
       this.deviceId,
+      allowMassChange,
     );
+    if (!outcome.ok && outcome.fault === "blocked") {
+      this.logger.warn(`sync: ${outcome.message}`);
+      this.setSyncStatus("error", outcome.message);
+      new GeodeMassChangeModal(this.app, outcome.change, () => {
+        void this.syncNow("manual", true);
+      }).open();
+
+      return { report: { ok: false, message: outcome.message }, result: "stop" };
+    }
     if (!outcome.ok) {
       // A failed pass can still have made progress worth keeping: completed work is recorded so
       // it is never replanned, while each failed file stays pending.

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,6 +32,7 @@ import {
 import { GeodeSettingTab } from "./settings/tab";
 import { obsidianTransport } from "./storage/obsidian";
 import { createS3Client, probeConditionalWrites } from "./storage/storage";
+import type { MassChange } from "./sync/guard";
 import { GeodeMassChangeModal } from "./sync/modal";
 import { type SyncFault, syncOnce } from "./sync/sync";
 import {
@@ -411,7 +412,10 @@ export default class GeodePlugin extends Plugin {
 
   // syncNow runs one pass, refusing to start a second while one is running. A manual pass ignores
   // a pause and clears any halt, since the escape hatch has to work in every state.
-  async syncNow(trigger: Trigger = "manual", allowMassChange = false): Promise<SyncReport> {
+  async syncNow(
+    trigger: Trigger = "manual",
+    confirmed: MassChange | null = null,
+  ): Promise<SyncReport> {
     if (this.schedule.syncing) {
       return { ok: false, message: "a sync is already running" };
     }
@@ -445,7 +449,7 @@ export default class GeodePlugin extends Plugin {
       result: "retry",
     };
     try {
-      outcome = await this.runSync(dir, trigger, allowMassChange);
+      outcome = await this.runSync(dir, trigger, confirmed);
     } catch (err) {
       let message = "unexpected error";
       if (err instanceof Error) {
@@ -466,7 +470,7 @@ export default class GeodePlugin extends Plugin {
   private async runSync(
     dir: string,
     trigger: Trigger,
-    allowMassChange: boolean,
+    confirmed: MassChange | null,
   ): Promise<PassOutcome> {
     const secretAccessKey = this.app.secretStorage.getSecret(this.settings.secretId);
     if (secretAccessKey === null || secretAccessKey === "") {
@@ -510,13 +514,13 @@ export default class GeodePlugin extends Plugin {
       Date.now(),
       () => crypto.randomUUID(),
       this.deviceId,
-      allowMassChange,
+      confirmed,
     );
     if (!outcome.ok && outcome.fault === "blocked") {
       this.logger.warn(`sync: ${outcome.message}`);
       this.setSyncStatus("error", outcome.message);
-      new GeodeMassChangeModal(this.app, outcome.change, () => {
-        void this.syncNow("manual", true);
+      new GeodeMassChangeModal(this.app, outcome.change, outcome.restated, (confirmed) => {
+        void this.syncNow("manual", confirmed);
       }).open();
 
       return { report: { ok: false, message: outcome.message }, result: "stop" };

--- a/src/sync/guard.test.ts
+++ b/src/sync/guard.test.ts
@@ -6,6 +6,7 @@ import {
   DESTRUCTIVE_FLOOR,
   destructiveLabel,
   type MassChange,
+  massChangeApproved,
   massChangeCopy,
   massChangeFor,
   massChangeHalts,
@@ -143,6 +144,7 @@ test("massChangeHalts: a wiped remote trips in a vault of any size above the flo
 test("massChangeCopy: names every side the pass would touch", () => {
   const copy = massChangeCopy(
     change({ localDeletes: 214, localOverwrites: 37, remoteDeletes: 3, tracked: 900 }),
+    false,
   );
 
   assert.equal(
@@ -154,7 +156,7 @@ test("massChangeCopy: names every side the pass would touch", () => {
 });
 
 test("massChangeCopy: a single side reads as one clause", () => {
-  const copy = massChangeCopy(change({ localDeletes: 1, tracked: 4 }));
+  const copy = massChangeCopy(change({ localDeletes: 1, tracked: 4 }), false);
 
   assert.equal(
     copy.lead,
@@ -164,7 +166,7 @@ test("massChangeCopy: a single side reads as one clause", () => {
 });
 
 test("massChangeCopy: two sides read as one clause joined by and", () => {
-  const copy = massChangeCopy(change({ localDeletes: 2, remoteDeletes: 4, tracked: 40 }));
+  const copy = massChangeCopy(change({ localDeletes: 2, remoteDeletes: 4, tracked: 40 }), false);
 
   assert.equal(
     copy.lead,
@@ -174,10 +176,10 @@ test("massChangeCopy: two sides read as one clause joined by and", () => {
 });
 
 test("massChangeCopy: the note says what is recoverable, per side", () => {
-  const both = massChangeCopy(change({ localDeletes: 2, localOverwrites: 2, tracked: 20 }));
-  const overwrites = massChangeCopy(change({ localOverwrites: 2, tracked: 20 }));
-  const deleted = massChangeCopy(change({ localDeletes: 2, tracked: 20 }));
-  const remote = massChangeCopy(change({ remoteDeletes: 2, tracked: 20 }));
+  const both = massChangeCopy(change({ localDeletes: 2, localOverwrites: 2, tracked: 20 }), false);
+  const overwrites = massChangeCopy(change({ localOverwrites: 2, tracked: 20 }), false);
+  const deleted = massChangeCopy(change({ localDeletes: 2, tracked: 20 }), false);
+  const remote = massChangeCopy(change({ remoteDeletes: 2, tracked: 20 }), false);
 
   assert.equal(
     both.note,
@@ -198,11 +200,79 @@ test("massChangeCopy: the note says what is recoverable, per side", () => {
 });
 
 test("massChangeCopy: the halt is stated, since a cancelled prompt stops automatic sync", () => {
-  const copy = massChangeCopy(change({ localDeletes: 11, tracked: 20 }));
+  const copy = massChangeCopy(change({ localDeletes: 11, tracked: 20 }), false);
 
   assert.equal(
     copy.halted,
     "Nothing has changed yet, and automatic sync stays off until you answer this.",
+  );
+});
+
+test("massChangeApproved: an answer covers the plan it was shown, whatever order it comes back in", () => {
+  const shown = change({
+    localDeletes: 0,
+    paths: [
+      { kind: "localDelete", path: "a.md" },
+      { kind: "localOverwrite", path: "b.md" },
+      { kind: "remoteDelete", path: "c.md" },
+    ],
+  });
+  const reordered = change({
+    paths: [
+      { kind: "remoteDelete", path: "c.md" },
+      { kind: "localDelete", path: "a.md" },
+      { kind: "localOverwrite", path: "b.md" },
+    ],
+  });
+
+  assert.equal(massChangeApproved(shown, reordered), true);
+});
+
+test("massChangeApproved: nothing is approved without an answer", () => {
+  assert.equal(massChangeApproved(null, change({ localDeletes: 11, tracked: 20 })), false);
+});
+
+test("massChangeApproved: a plan that is not the one shown is not covered by the answer", () => {
+  const shown = change({
+    paths: [
+      { kind: "localDelete", path: "a.md" },
+      { kind: "localDelete", path: "b.md" },
+    ],
+  });
+  // One path swapped, one path added, and one path facing a different fate: each is a plan nobody
+  // has actually seen, so none of them may run on the answer given to the one above.
+  const swapped = change({
+    paths: [
+      { kind: "localDelete", path: "a.md" },
+      { kind: "localDelete", path: "c.md" },
+    ],
+  });
+  const extra = change({
+    paths: [
+      { kind: "localDelete", path: "a.md" },
+      { kind: "localDelete", path: "b.md" },
+      { kind: "localDelete", path: "c.md" },
+    ],
+  });
+  const rekinded = change({
+    paths: [
+      { kind: "localDelete", path: "a.md" },
+      { kind: "localOverwrite", path: "b.md" },
+    ],
+  });
+
+  assert.equal(massChangeApproved(shown, swapped), false);
+  assert.equal(massChangeApproved(shown, extra), false);
+  assert.equal(massChangeApproved(shown, rekinded), false);
+});
+
+test("massChangeCopy: a second asking says so, since the same dialog twice reads as a bug", () => {
+  const copy = massChangeCopy(change({ localDeletes: 12, tracked: 20 }), true);
+
+  assert.equal(
+    copy.lead,
+    "Something changed since you confirmed, so this is not the sync you agreed to. It would now " +
+      "delete 12 files from this vault.",
   );
 });
 

--- a/src/sync/guard.test.ts
+++ b/src/sync/guard.test.ts
@@ -1,0 +1,223 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { empty, file, snapshot } from "./fake.ts";
+import {
+  DESTRUCTIVE_CEILING,
+  DESTRUCTIVE_FLOOR,
+  destructiveLabel,
+  type MassChange,
+  massChangeCopy,
+  massChangeFor,
+  massChangeHalts,
+  massChangeThreshold,
+} from "./guard.ts";
+import type { SyncAction } from "./plan.ts";
+
+// change builds a MassChange from counts alone, for the cases that never look at paths beyond
+// how many there are.
+function change(counts: Partial<MassChange>): MassChange {
+  const built: MassChange = {
+    localDeletes: 0,
+    localOverwrites: 0,
+    paths: [],
+    remoteDeletes: 0,
+    tracked: 0,
+    ...counts,
+  };
+  const total = built.localDeletes + built.localOverwrites + built.remoteDeletes;
+  if (built.paths.length === 0) {
+    for (let i = 0; i < total; i++) {
+      built.paths.push({ kind: "localDelete", path: `note-${i}.md` });
+    }
+  }
+
+  return built;
+}
+
+// deletes builds count pullDelete actions, the plan a wiped remote produces.
+function deletes(count: number): SyncAction[] {
+  const actions: SyncAction[] = [];
+  for (let i = 0; i < count; i++) {
+    actions.push({ kind: "pullDelete", path: `note-${i}.md` });
+  }
+
+  return actions;
+}
+
+test("massChangeFor: a local delete, a local overwrite, and a remote delete all count", () => {
+  const local = snapshot(file("here.md", "h1"));
+  const actions: SyncAction[] = [
+    { kind: "pullDelete", path: "gone.md" },
+    { kind: "pull", path: "here.md" },
+    { kind: "pushDelete", path: "remote.md" },
+  ];
+
+  assert.deepEqual(massChangeFor(actions, local, 3), {
+    localDeletes: 1,
+    localOverwrites: 1,
+    paths: [
+      { kind: "localDelete", path: "gone.md" },
+      { kind: "localOverwrite", path: "here.md" },
+      { kind: "remoteDelete", path: "remote.md" },
+    ],
+    remoteDeletes: 1,
+    tracked: 3,
+  });
+});
+
+test("massChangeFor: a pull onto a path with no local file is an addition, not an overwrite", () => {
+  const actions: SyncAction[] = [{ kind: "pull", path: "new.md" }];
+
+  assert.deepEqual(massChangeFor(actions, empty, 0).paths, []);
+});
+
+test("massChangeFor: pushes and conflict copies destroy nothing", () => {
+  const local = snapshot(file("a.md", "h1"), file("b.md", "h2"));
+  const actions: SyncAction[] = [
+    { kind: "push", path: "a.md" },
+    { kind: "conflict", path: "b.md", deletedSide: "none" },
+    { kind: "conflict", path: "c.md", deletedSide: "local" },
+    { kind: "conflict", path: "d.md", deletedSide: "remote" },
+  ];
+
+  assert.deepEqual(massChangeFor(actions, local, 2).paths, []);
+});
+
+test("massChangeThreshold: a share of the vault between the floor and the ceiling", () => {
+  const cases: { tracked: number; want: number }[] = [
+    { tracked: 0, want: DESTRUCTIVE_FLOOR },
+    { tracked: 10, want: DESTRUCTIVE_FLOOR },
+    { tracked: 49, want: DESTRUCTIVE_FLOOR },
+    { tracked: 50, want: DESTRUCTIVE_FLOOR },
+    { tracked: 100, want: 20 },
+    { tracked: 250, want: DESTRUCTIVE_CEILING },
+    { tracked: 1_000, want: DESTRUCTIVE_CEILING },
+    { tracked: 100_000, want: DESTRUCTIVE_CEILING },
+  ];
+
+  for (const c of cases) {
+    assert.equal(massChangeThreshold(c.tracked), c.want, `tracked ${c.tracked}`);
+  }
+});
+
+test("massChangeHalts: the share decides in a vault small enough for it to bite first", () => {
+  assert.equal(massChangeHalts(change({ localDeletes: 20, tracked: 100 })), false);
+  assert.equal(massChangeHalts(change({ localDeletes: 21, tracked: 100 })), true);
+});
+
+test("massChangeHalts: the ceiling decides once a share of the vault is the larger number", () => {
+  assert.equal(massChangeHalts(change({ localDeletes: 50, tracked: 10_000 })), false);
+  assert.equal(massChangeHalts(change({ localDeletes: 51, tracked: 10_000 })), true);
+});
+
+test("massChangeHalts: the floor spares a handful of files in a small vault", () => {
+  assert.equal(massChangeHalts(change({ localDeletes: 10, tracked: 20 })), false);
+  assert.equal(massChangeHalts(change({ localDeletes: 11, tracked: 20 })), true);
+});
+
+test("massChangeHalts: a first sync uploading a whole vault never trips", () => {
+  const local = snapshot(...manyFiles(5_000));
+  const actions: SyncAction[] = [];
+  for (const entry of local.files) {
+    actions.push({ kind: "push", path: entry.path });
+  }
+
+  assert.equal(massChangeHalts(massChangeFor(actions, local, 0)), false);
+});
+
+test("massChangeHalts: a new device pulling a whole vault into an empty one never trips", () => {
+  const actions: SyncAction[] = [];
+  for (let i = 0; i < 5_000; i++) {
+    actions.push({ kind: "pull", path: `note-${i}.md` });
+  }
+
+  assert.equal(massChangeHalts(massChangeFor(actions, empty, 0)), false);
+});
+
+test("massChangeHalts: a wiped remote trips in a vault of any size above the floor", () => {
+  const local = snapshot(...manyFiles(11));
+
+  assert.equal(massChangeHalts(massChangeFor(deletes(11), local, 11)), true);
+});
+
+test("massChangeCopy: names every side the pass would touch", () => {
+  const copy = massChangeCopy(
+    change({ localDeletes: 214, localOverwrites: 37, remoteDeletes: 3, tracked: 900 }),
+  );
+
+  assert.equal(
+    copy.lead,
+    "Syncing now would delete 214 files from this vault, replace 37 files here with the version " +
+      "from your bucket, and remove 3 files from your bucket. That is more of this vault than " +
+      "Geode will change without asking.",
+  );
+});
+
+test("massChangeCopy: a single side reads as one clause", () => {
+  const copy = massChangeCopy(change({ localDeletes: 1, tracked: 4 }));
+
+  assert.equal(
+    copy.lead,
+    "Syncing now would delete 1 file from this vault. That is more of this vault than Geode will " +
+      "change without asking.",
+  );
+});
+
+test("massChangeCopy: two sides read as one clause joined by and", () => {
+  const copy = massChangeCopy(change({ localDeletes: 2, remoteDeletes: 4, tracked: 40 }));
+
+  assert.equal(
+    copy.lead,
+    "Syncing now would delete 2 files from this vault and remove 4 files from your bucket. That " +
+      "is more of this vault than Geode will change without asking.",
+  );
+});
+
+test("massChangeCopy: the note says what is recoverable, per side", () => {
+  const both = massChangeCopy(change({ localDeletes: 2, localOverwrites: 2, tracked: 20 }));
+  const overwrites = massChangeCopy(change({ localOverwrites: 2, tracked: 20 }));
+  const deleted = massChangeCopy(change({ localDeletes: 2, tracked: 20 }));
+  const remote = massChangeCopy(change({ remoteDeletes: 2, tracked: 20 }));
+
+  assert.equal(
+    both.note,
+    "Deleted files go to your trash, but replaced files do not: the version in this vault is lost.",
+  );
+  assert.equal(
+    overwrites.note,
+    "A replaced file does not go to your trash: the version in this vault is lost.",
+  );
+  assert.equal(
+    deleted.note,
+    "Deleted files go to your trash, so this is recoverable if it turns out to be wrong.",
+  );
+  assert.equal(
+    remote.note,
+    "Nothing in this vault is touched; this only changes what your bucket holds.",
+  );
+});
+
+test("massChangeCopy: the halt is stated, since a cancelled prompt stops automatic sync", () => {
+  const copy = massChangeCopy(change({ localDeletes: 11, tracked: 20 }));
+
+  assert.equal(
+    copy.halted,
+    "Nothing has changed yet, and automatic sync stays off until you answer this.",
+  );
+});
+
+test("destructiveLabel: every kind has a verb", () => {
+  assert.equal(destructiveLabel("localDelete"), "delete");
+  assert.equal(destructiveLabel("localOverwrite"), "replace");
+  assert.equal(destructiveLabel("remoteDelete"), "remove from bucket");
+});
+
+// manyFiles builds count file states, for the size cases that only care about how many there are.
+function manyFiles(count: number) {
+  const files = [];
+  for (let i = 0; i < count; i++) {
+    files.push(file(`note-${i}.md`, `h${i}`));
+  }
+
+  return files;
+}

--- a/src/sync/guard.ts
+++ b/src/sync/guard.ts
@@ -46,9 +46,34 @@ export function destructiveLabel(kind: DestructiveKind): string {
   return "remove from bucket";
 }
 
+// massChangeApproved reports whether a fresh plan is the one that was confirmed. Nothing is taken
+// on trust from the answer alone: what ran has to be what was on the screen.
+export function massChangeApproved(confirmed: MassChange | null, change: MassChange): boolean {
+  if (confirmed === null) {
+    return false;
+  }
+  if (confirmed.paths.length !== change.paths.length) {
+    return false;
+  }
+
+  // Keyed rather than compared in order: planSync's output follows snapshot order, which a
+  // re-read of the bucket is under no obligation to repeat.
+  const keys = new Set<string>();
+  for (const entry of confirmed.paths) {
+    keys.add(`${entry.kind}:${entry.path}`);
+  }
+  for (const entry of change.paths) {
+    if (!keys.has(`${entry.kind}:${entry.path}`)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 // massChangeCopy returns what the dialog says about a halted pass, kept here rather than in the
-// modal so the wording of every branch is pinned by a test.
-export function massChangeCopy(change: MassChange): MassChangeCopy {
+// modal so the wording of every branch is pinned by a test. restated marks a second asking.
+export function massChangeCopy(change: MassChange, restated: boolean): MassChangeCopy {
   const parts: string[] = [];
   if (change.localDeletes > 0) {
     parts.push(`delete ${files(change.localDeletes)} from this vault`);
@@ -60,9 +85,14 @@ export function massChangeCopy(change: MassChange): MassChangeCopy {
     parts.push(`remove ${files(change.remoteDeletes)} from your bucket`);
   }
 
-  const lead =
+  let lead =
     `Syncing now would ${phrase(parts)}. That is more of this vault than Geode will ` +
     "change without asking.";
+  if (restated) {
+    lead =
+      "Something changed since you confirmed, so this is not the sync you agreed to. It would " +
+      `now ${phrase(parts)}.`;
+  }
 
   return {
     halted: "Nothing has changed yet, and automatic sync stays off until you answer this.",

--- a/src/sync/guard.ts
+++ b/src/sync/guard.ts
@@ -1,0 +1,168 @@
+import { byPath, type Snapshot } from "../vault/vault.ts";
+import type { SyncAction } from "./plan.ts";
+
+// DESTRUCTIVE_CEILING is the most files one pass may destroy without asking, whatever the size of
+// the vault: past this the ratio alone would wave through thousands.
+export const DESTRUCTIVE_CEILING = 50;
+
+// DESTRUCTIVE_FLOOR is the point below which a pass never asks, since a prompt over a handful of
+// deleted notes is noise, and a guard people learn to dismiss guards nothing.
+export const DESTRUCTIVE_FLOOR = 10;
+
+// DESTRUCTIVE_RATIO is the share of tracked files one pass may destroy before it stops to ask; see
+// docs/technical_sync.md for why a share alone is not enough.
+export const DESTRUCTIVE_RATIO = 0.2;
+
+// DestructiveKind is what a pass would do to one file that cannot simply be undone by syncing
+// again.
+export type DestructiveKind = "localDelete" | "localOverwrite" | "remoteDelete";
+
+// DestructivePath is one file a pass would destroy, and what would happen to it.
+export type DestructivePath = { kind: DestructiveKind; path: string };
+
+// MassChange is how much of a vault one pass would destroy, counted per side so a prompt can say
+// what it would do rather than only how much.
+export type MassChange = {
+  localDeletes: number;
+  localOverwrites: number;
+  paths: DestructivePath[];
+  remoteDeletes: number;
+  tracked: number;
+};
+
+// MassChangeCopy is what the confirmation dialog says: what the pass would do, what of it can be
+// undone, and what happens while nobody answers.
+export type MassChangeCopy = { halted: string; lead: string; note: string };
+
+// destructiveLabel returns the verb shown beside a path in the confirmation dialog.
+export function destructiveLabel(kind: DestructiveKind): string {
+  if (kind === "localDelete") {
+    return "delete";
+  }
+  if (kind === "localOverwrite") {
+    return "replace";
+  }
+
+  return "remove from bucket";
+}
+
+// massChangeCopy returns what the dialog says about a halted pass, kept here rather than in the
+// modal so the wording of every branch is pinned by a test.
+export function massChangeCopy(change: MassChange): MassChangeCopy {
+  const parts: string[] = [];
+  if (change.localDeletes > 0) {
+    parts.push(`delete ${files(change.localDeletes)} from this vault`);
+  }
+  if (change.localOverwrites > 0) {
+    parts.push(`replace ${files(change.localOverwrites)} here with the version from your bucket`);
+  }
+  if (change.remoteDeletes > 0) {
+    parts.push(`remove ${files(change.remoteDeletes)} from your bucket`);
+  }
+
+  const lead =
+    `Syncing now would ${phrase(parts)}. That is more of this vault than Geode will ` +
+    "change without asking.";
+
+  return {
+    halted: "Nothing has changed yet, and automatic sync stays off until you answer this.",
+    lead,
+    note: note(change),
+  };
+}
+
+// massChangeFor counts what a plan would destroy: a delete on either side, or a pull landing on a
+// file that already exists here. A conflict copy and a plain addition destroy nothing.
+export function massChangeFor(actions: SyncAction[], local: Snapshot, tracked: number): MassChange {
+  const localByPath = byPath(local.files);
+  const change: MassChange = {
+    localDeletes: 0,
+    localOverwrites: 0,
+    paths: [],
+    remoteDeletes: 0,
+    tracked,
+  };
+
+  for (const action of actions) {
+    if (action.kind === "pullDelete") {
+      change.localDeletes += 1;
+      change.paths.push({ kind: "localDelete", path: action.path });
+      continue;
+    }
+    if (action.kind === "pull" && localByPath.has(action.path)) {
+      change.localOverwrites += 1;
+      change.paths.push({ kind: "localOverwrite", path: action.path });
+      continue;
+    }
+    if (action.kind === "pushDelete") {
+      change.remoteDeletes += 1;
+      change.paths.push({ kind: "remoteDelete", path: action.path });
+    }
+  }
+
+  return change;
+}
+
+// massChangeHalts reports whether a pass must stop and ask before it touches anything.
+export function massChangeHalts(change: MassChange): boolean {
+  return change.paths.length > massChangeThreshold(change.tracked);
+}
+
+// massChangeThreshold returns how many files a pass may destroy unasked in a vault of this size:
+// a share of it, never fewer than the floor, never more than the ceiling.
+export function massChangeThreshold(tracked: number): number {
+  const share = Math.floor(tracked * DESTRUCTIVE_RATIO);
+  if (share < DESTRUCTIVE_FLOOR) {
+    return DESTRUCTIVE_FLOOR;
+  }
+  if (share > DESTRUCTIVE_CEILING) {
+    return DESTRUCTIVE_CEILING;
+  }
+
+  return share;
+}
+
+// files renders a file count with its noun, since a dialog read once should not make anyone parse
+// "file(s)".
+function files(count: number): string {
+  if (count === 1) {
+    return "1 file";
+  }
+
+  return `${count} files`;
+}
+
+// note returns the line about what can be undone, which is the part nobody can guess: a deleted
+// file is in the trash, an overwritten one is simply gone.
+function note(change: MassChange): string {
+  if (change.localOverwrites > 0 && change.localDeletes > 0) {
+    return (
+      "Deleted files go to your trash, but replaced files do not: the version in this vault is " +
+      "lost."
+    );
+  }
+  if (change.localOverwrites > 0) {
+    return "A replaced file does not go to your trash: the version in this vault is lost.";
+  }
+  if (change.localDeletes > 0) {
+    return "Deleted files go to your trash, so this is recoverable if it turns out to be wrong.";
+  }
+
+  return "Nothing in this vault is touched; this only changes what your bucket holds.";
+}
+
+// phrase joins what a pass would do into one readable clause, since the dialog reads it as a
+// sentence rather than a list.
+function phrase(parts: string[]): string {
+  if (parts.length === 0) {
+    return "destroy nothing";
+  }
+  if (parts.length === 1) {
+    return parts[0];
+  }
+  if (parts.length === 2) {
+    return `${parts[0]} and ${parts[1]}`;
+  }
+
+  return `${parts.slice(0, -1).join(", ")}, and ${parts[parts.length - 1]}`;
+}

--- a/src/sync/modal.ts
+++ b/src/sync/modal.ts
@@ -1,0 +1,94 @@
+import { type App, ButtonComponent, Modal } from "obsidian";
+import { destructiveLabel, type MassChange, massChangeCopy } from "./guard.ts";
+
+// PATH_LIMIT is how many files the dialog lists before summarising the rest: enough to recognise
+// which corner of the vault this is, short of a scroll nobody reads.
+const PATH_LIMIT = 20;
+
+// Control is what a rendered button does to the dialog around it.
+type Control = {
+  cancel: () => void;
+  confirm: () => void;
+};
+
+// render draws what the pass would destroy and the two answers to it, always as a full redraw of
+// the dialog rather than a DOM mutation, the same posture the log view takes.
+function render(el: HTMLElement, change: MassChange, control: Control): void {
+  el.empty();
+  el.addClass("geode-mass-change");
+
+  const copy = massChangeCopy(change);
+  el.createEl("p", { text: copy.lead });
+  el.createEl("p", { cls: "geode-mass-change-note", text: copy.note });
+  renderPaths(el, change);
+  el.createEl("p", { text: copy.halted });
+
+  const buttons = el.createDiv({ cls: "geode-mass-change-buttons" });
+  // Cancel is the emphasised answer: someone reading a dialog they did not expect should land on
+  // the button that changes nothing.
+  new ButtonComponent(buttons)
+    .setButtonText("Cancel")
+    .setCta()
+    .onClick(() => control.cancel());
+  new ButtonComponent(buttons)
+    .setButtonText("Sync anyway")
+    .setWarning()
+    .onClick(() => control.confirm());
+}
+
+// renderPaths draws the files themselves, collapsed: a count says how big the change is, and only
+// the names say whether it is the right one.
+function renderPaths(el: HTMLElement, change: MassChange): void {
+  if (change.paths.length === 0) {
+    return;
+  }
+
+  const details = el.createEl("details", { cls: "geode-mass-change-paths" });
+  details.createEl("summary", { text: "Show the files" });
+  const list = details.createEl("ul");
+  for (const entry of change.paths.slice(0, PATH_LIMIT)) {
+    const item = list.createEl("li");
+    item.createSpan({ cls: "geode-mass-change-verb", text: destructiveLabel(entry.kind) });
+    item.createSpan({ text: entry.path });
+  }
+  if (change.paths.length > PATH_LIMIT) {
+    details.createEl("p", {
+      cls: "geode-mass-change-more",
+      text: `and ${change.paths.length - PATH_LIMIT} more`,
+    });
+  }
+}
+
+// GeodeMassChangeModal asks before a pass destroys a large share of a vault; see
+// docs/technical_sync.md for what counts as large and why the answer is never assumed.
+export class GeodeMassChangeModal extends Modal {
+  private change: MassChange;
+  private confirm: () => void;
+  private confirmed = false;
+
+  constructor(app: App, change: MassChange, confirm: () => void) {
+    super(app);
+    this.change = change;
+    this.confirm = confirm;
+  }
+
+  onOpen(): void {
+    this.titleEl.setText("This sync would change a lot of files");
+    render(this.contentEl, this.change, {
+      cancel: () => this.close(),
+      confirm: () => {
+        this.confirmed = true;
+        this.close();
+      },
+    });
+  }
+
+  // Dismissing the dialog any other way is a cancel, so the pass only runs when someone actually
+  // reached for the button that says so.
+  onClose(): void {
+    this.contentEl.empty();
+    if (this.confirmed) {
+      this.confirm();
+    }
+  }
+}

--- a/src/sync/modal.ts
+++ b/src/sync/modal.ts
@@ -13,11 +13,11 @@ type Control = {
 
 // render draws what the pass would destroy and the two answers to it, always as a full redraw of
 // the dialog rather than a DOM mutation, the same posture the log view takes.
-function render(el: HTMLElement, change: MassChange, control: Control): void {
+function render(el: HTMLElement, change: MassChange, restated: boolean, control: Control): void {
   el.empty();
   el.addClass("geode-mass-change");
 
-  const copy = massChangeCopy(change);
+  const copy = massChangeCopy(change, restated);
   el.createEl("p", { text: copy.lead });
   el.createEl("p", { cls: "geode-mass-change-note", text: copy.note });
   renderPaths(el, change);
@@ -63,18 +63,28 @@ function renderPaths(el: HTMLElement, change: MassChange): void {
 // docs/technical_sync.md for what counts as large and why the answer is never assumed.
 export class GeodeMassChangeModal extends Modal {
   private change: MassChange;
-  private confirm: () => void;
+  private confirm: (change: MassChange) => void;
   private confirmed = false;
+  private restated: boolean;
 
-  constructor(app: App, change: MassChange, confirm: () => void) {
+  constructor(
+    app: App,
+    change: MassChange,
+    restated: boolean,
+    confirm: (change: MassChange) => void,
+  ) {
     super(app);
     this.change = change;
     this.confirm = confirm;
+    this.restated = restated;
   }
 
   onOpen(): void {
     this.titleEl.setText("This sync would change a lot of files");
-    render(this.contentEl, this.change, {
+    if (this.restated) {
+      this.titleEl.setText("This sync changed since you confirmed it");
+    }
+    render(this.contentEl, this.change, this.restated, {
       cancel: () => this.close(),
       confirm: () => {
         this.confirmed = true;
@@ -88,7 +98,9 @@ export class GeodeMassChangeModal extends Modal {
   onClose(): void {
     this.contentEl.empty();
     if (this.confirmed) {
-      this.confirm();
+      // The plan that was on the screen travels with the answer, so the pass it authorises is the
+      // one it described and no other.
+      this.confirm(this.change);
     }
   }
 }

--- a/src/sync/sync.test.ts
+++ b/src/sync/sync.test.ts
@@ -13,12 +13,14 @@ import {
   unwrapped,
   wrapped,
 } from "./fake.ts";
+import { massChangeFor } from "./guard.ts";
 import {
   blobKeyFor,
   conflictCopyPath,
   encodeSentinel,
   MANIFEST_KEY,
   SENTINEL_KEY,
+  type SyncAction,
 } from "./plan.ts";
 import {
   adoptLiveStats,
@@ -36,6 +38,17 @@ import {
 // content actually lives under.
 async function hashOf(text: string): Promise<string> {
   return hashBytes(new TextEncoder().encode(text));
+}
+
+// deletesOf returns the plan a wiped remote produces for entries, for building the answer a
+// confirmation dialog would have been given.
+function deletesOf(entries: FileState[]): SyncAction[] {
+  const actions: SyncAction[] = [];
+  for (const entry of entries) {
+    actions.push({ kind: "pullDelete", path: entry.path });
+  }
+
+  return actions;
 }
 
 // vaultOf builds a vault of count files as both snapshot entries and the live content behind them,
@@ -587,6 +600,7 @@ test("syncOnce: a remote that lost most of a vault halts before deleting anythin
     assert.equal(outcome.change.localDeletes, 12);
     assert.equal(outcome.change.tracked, 12);
     assert.equal(outcome.change.paths.length, 12);
+    assert.equal(outcome.restated, false);
   }
   assert.equal(outcome.snapshot, null);
   assert.equal(files.size, 12);
@@ -594,7 +608,7 @@ test("syncOnce: a remote that lost most of a vault halts before deleting anythin
   assert.equal(objects.size, 1);
 });
 
-test("syncOnce: the same pass runs in full once it has been confirmed", async () => {
+test("syncOnce: the confirmed pass runs in full when it is still the plan that was confirmed", async () => {
   const vault = await vaultOf(12);
   const reader = fakeReader(vault.content);
   const { writer, files } = fakeLocalWriter();
@@ -602,6 +616,7 @@ test("syncOnce: the same pass runs in full once it has been confirmed", async ()
     files.set(path, vault.content[path]);
   }
   const { storage } = fakeStorage({ [MANIFEST_KEY]: wrapped(encodeSnapshot(empty)) });
+  const confirmed = massChangeFor(deletesOf(vault.entries), snapshot(...vault.entries), 12);
 
   const outcome = await syncOnce(
     snapshot(...vault.entries),
@@ -611,11 +626,45 @@ test("syncOnce: the same pass runs in full once it has been confirmed", async ()
     1,
     () => "vault-1",
     "",
-    true,
+    confirmed,
   );
 
   assert.equal(outcome.ok, true);
   assert.equal(files.size, 0);
+});
+
+test("syncOnce: a confirmation is spent on the plan it was given and no other", async () => {
+  // The vault moved on between the dialog and the answer, so what would run is not what was on
+  // the screen. The pass is asked again rather than executing an unseen plan under an old yes.
+  const vault = await vaultOf(12);
+  const reader = fakeReader(vault.content);
+  const { writer, files } = fakeLocalWriter();
+  for (const path of Object.keys(vault.content)) {
+    files.set(path, vault.content[path]);
+  }
+  const { storage, objects } = fakeStorage({ [MANIFEST_KEY]: wrapped(encodeSnapshot(empty)) });
+  const stale = await vaultOf(12);
+  stale.entries[0] = { ...stale.entries[0], path: "somewhere-else.md" };
+  const confirmed = massChangeFor(deletesOf(stale.entries), snapshot(...stale.entries), 12);
+
+  const outcome = await syncOnce(
+    snapshot(...vault.entries),
+    reader,
+    writer,
+    storage,
+    1,
+    () => "vault-1",
+    "",
+    confirmed,
+  );
+
+  assert.ok(!outcome.ok);
+  assert.equal(outcome.fault, "blocked");
+  if (outcome.fault === "blocked") {
+    assert.equal(outcome.restated, true);
+  }
+  assert.equal(files.size, 12);
+  assert.equal(objects.size, 1);
 });
 
 test("syncOnce: a first sync pushing a whole vault is never mistaken for a mass deletion", async () => {

--- a/src/sync/sync.test.ts
+++ b/src/sync/sync.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import type { ResultStatus } from "../storage/storage.ts";
-import { encodeSnapshot, hashBytes, type Snapshot } from "../vault/vault.ts";
+import { encodeSnapshot, type FileState, hashBytes, type Snapshot } from "../vault/vault.ts";
 import type { LocalWriter } from "./execute.ts";
 import {
   empty,
@@ -36,6 +36,24 @@ import {
 // content actually lives under.
 async function hashOf(text: string): Promise<string> {
   return hashBytes(new TextEncoder().encode(text));
+}
+
+// vaultOf builds a vault of count files as both snapshot entries and the live content behind them,
+// for the cases where what matters is how many files a pass would touch.
+async function vaultOf(
+  count: number,
+): Promise<{ content: Record<string, string>; entries: FileState[] }> {
+  const content: Record<string, string> = {};
+  const entries: FileState[] = [];
+  for (let i = 0; i < count; i++) {
+    const path = `note-${i}.md`;
+    const text = `note ${i}`;
+    const hash = await hashOf(text);
+    content[path] = text;
+    entries.push({ path, size: text.length, mtime: 1, hash, blob: hash });
+  }
+
+  return { content, entries };
 }
 
 test("faultFor: trying again is worth something, or it never will be, and a race is neither", () => {
@@ -548,6 +566,69 @@ test("syncOnce: a present but empty manifest still trusts the ancestor and pulls
 
   assert.equal(outcome.ok, true);
   assert.equal(files.has("a.md"), false);
+});
+
+test("syncOnce: a remote that lost most of a vault halts before deleting anything", async () => {
+  // A manifest that looks wiped plans as "delete every local file", which is the one pass that
+  // must never run unasked: it stops instead, leaving both sides exactly as they were.
+  const vault = await vaultOf(12);
+  const reader = fakeReader(vault.content);
+  const { writer, files } = fakeLocalWriter();
+  for (const path of Object.keys(vault.content)) {
+    files.set(path, vault.content[path]);
+  }
+  const { storage, objects } = fakeStorage({ [MANIFEST_KEY]: wrapped(encodeSnapshot(empty)) });
+
+  const outcome = await syncOnce(snapshot(...vault.entries), reader, writer, storage, 1);
+
+  assert.ok(!outcome.ok);
+  assert.equal(outcome.fault, "blocked");
+  if (outcome.fault === "blocked") {
+    assert.equal(outcome.change.localDeletes, 12);
+    assert.equal(outcome.change.tracked, 12);
+    assert.equal(outcome.change.paths.length, 12);
+  }
+  assert.equal(outcome.snapshot, null);
+  assert.equal(files.size, 12);
+  // Only the seeded manifest: no blob, no sentinel, and no manifest of its own went up.
+  assert.equal(objects.size, 1);
+});
+
+test("syncOnce: the same pass runs in full once it has been confirmed", async () => {
+  const vault = await vaultOf(12);
+  const reader = fakeReader(vault.content);
+  const { writer, files } = fakeLocalWriter();
+  for (const path of Object.keys(vault.content)) {
+    files.set(path, vault.content[path]);
+  }
+  const { storage } = fakeStorage({ [MANIFEST_KEY]: wrapped(encodeSnapshot(empty)) });
+
+  const outcome = await syncOnce(
+    snapshot(...vault.entries),
+    reader,
+    writer,
+    storage,
+    1,
+    () => "vault-1",
+    "",
+    true,
+  );
+
+  assert.equal(outcome.ok, true);
+  assert.equal(files.size, 0);
+});
+
+test("syncOnce: a first sync pushing a whole vault is never mistaken for a mass deletion", async () => {
+  // Every action here is an addition, so a bootstrap of any size must sail through the guard the
+  // wiped remote above trips.
+  const vault = await vaultOf(200);
+  const reader = fakeReader(vault.content);
+  const { writer } = fakeLocalWriter();
+  const { storage } = fakeStorage();
+
+  const outcome = await syncOnce(empty, reader, writer, storage, 1);
+
+  assert.equal(outcome.ok, true);
 });
 
 test("syncOnce: a missing manifest with unexplained blobs reports and proceeds, rather than deadlocking every future sync", async () => {

--- a/src/sync/sync.ts
+++ b/src/sync/sync.ts
@@ -10,6 +10,7 @@ import {
   takeSnapshot,
 } from "../vault/vault.ts";
 import { executeSyncPlan, type LocalWriter, type SyncFailure } from "./execute.ts";
+import { type MassChange, massChangeFor, massChangeHalts } from "./guard.ts";
 import {
   BLOB_PREFIX,
   decodeSentinel,
@@ -28,6 +29,16 @@ import {
 // worth keeping rather than always null.
 export type SyncOutcome =
   | { ok: true; snapshot: Snapshot; changeCount: number }
+  // A blocked pass executed nothing, so it has no progress to persist and nothing to retry: it is
+  // waiting on an answer only a person can give.
+  | {
+      ok: false;
+      fault: "blocked";
+      change: MassChange;
+      message: string;
+      failures: SyncFailure[];
+      snapshot: null;
+    }
   | {
       ok: false;
       fault: SyncFault;
@@ -220,6 +231,7 @@ export async function syncOnce(
   now: number,
   newVaultId: () => string = () => crypto.randomUUID(),
   deviceId = "",
+  allowMassChange = false,
 ): Promise<SyncOutcome> {
   const [remote, sentinelResult] = await Promise.all([
     readRemoteManifest(storage),
@@ -297,6 +309,21 @@ export async function syncOnce(
     manifestEtag = remote.etag;
   }
   const actions = planSync(ancestor, local, remoteView);
+
+  // The guard sits between planning and doing, the last point at which refusing costs nothing:
+  // one truncated listing or one bad manifest should never quietly gut a vault.
+  const change = massChangeFor(actions, local, ancestor.files.length);
+  if (!allowMassChange && massChangeHalts(change)) {
+    return {
+      ok: false,
+      fault: "blocked",
+      change,
+      message: `this sync would delete or replace ${change.paths.length} files; confirm it first`,
+      failures: [],
+      snapshot: null,
+    };
+  }
+
   const executed = await executeSyncPlan(
     actions,
     local,

--- a/src/sync/sync.ts
+++ b/src/sync/sync.ts
@@ -10,7 +10,7 @@ import {
   takeSnapshot,
 } from "../vault/vault.ts";
 import { executeSyncPlan, type LocalWriter, type SyncFailure } from "./execute.ts";
-import { type MassChange, massChangeFor, massChangeHalts } from "./guard.ts";
+import { type MassChange, massChangeApproved, massChangeFor, massChangeHalts } from "./guard.ts";
 import {
   BLOB_PREFIX,
   decodeSentinel,
@@ -30,11 +30,12 @@ import {
 export type SyncOutcome =
   | { ok: true; snapshot: Snapshot; changeCount: number }
   // A blocked pass executed nothing, so it has no progress to persist and nothing to retry: it is
-  // waiting on an answer only a person can give.
+  // waiting on an answer only a person can give. restated marks one asked a second time.
   | {
       ok: false;
       fault: "blocked";
       change: MassChange;
+      restated: boolean;
       message: string;
       failures: SyncFailure[];
       snapshot: null;
@@ -231,7 +232,7 @@ export async function syncOnce(
   now: number,
   newVaultId: () => string = () => crypto.randomUUID(),
   deviceId = "",
-  allowMassChange = false,
+  confirmed: MassChange | null = null,
 ): Promise<SyncOutcome> {
   const [remote, sentinelResult] = await Promise.all([
     readRemoteManifest(storage),
@@ -313,12 +314,22 @@ export async function syncOnce(
   // The guard sits between planning and doing, the last point at which refusing costs nothing:
   // one truncated listing or one bad manifest should never quietly gut a vault.
   const change = massChangeFor(actions, local, ancestor.files.length);
-  if (!allowMassChange && massChangeHalts(change)) {
+  const approved = massChangeApproved(confirmed, change);
+  if (massChangeHalts(change) && !approved) {
+    // An answer covers the plan it was given, never the next one: a confirmation that no longer
+    // describes what this pass would do is asked again rather than spent on it.
+    const restated = confirmed !== null;
+    let message = `this sync would delete or replace ${change.paths.length} files; confirm it first`;
+    if (restated) {
+      message = "this sync is no longer the one you confirmed; confirm it again";
+    }
+
     return {
       ok: false,
       fault: "blocked",
       change,
-      message: `this sync would delete or replace ${change.paths.length} files; confirm it first`,
+      restated,
+      message,
       failures: [],
       snapshot: null,
     };

--- a/styles.css
+++ b/styles.css
@@ -241,3 +241,55 @@
 .geode-onboarding-buttons button {
   cursor: pointer;
 }
+
+.geode-mass-change p {
+  margin: 0 0 1em;
+}
+
+.geode-mass-change-note {
+  color: var(--text-warning);
+}
+
+.geode-mass-change-paths {
+  margin: 0 0 1em;
+}
+
+.geode-mass-change-paths summary {
+  cursor: pointer;
+  color: var(--text-muted);
+}
+
+.geode-mass-change-paths ul {
+  margin: 0.5em 0 0;
+  padding-left: 1.25em;
+  max-height: 12em;
+  overflow-y: auto;
+  font-size: var(--font-ui-smaller);
+}
+
+.geode-mass-change-paths li {
+  margin-bottom: 0.2em;
+}
+
+.geode-mass-change-verb {
+  display: inline-block;
+  min-width: 8em;
+  color: var(--text-muted);
+}
+
+.geode-mass-change-more {
+  margin: 0.5em 0 0;
+  color: var(--text-muted);
+  font-size: var(--font-ui-smaller);
+}
+
+.geode-mass-change-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5em;
+  justify-content: flex-end;
+}
+
+.geode-mass-change-buttons button {
+  cursor: pointer;
+}


### PR DESCRIPTION
Resolves [#77](https://github.com/8thpark/geode/issues/77)

## Problem

- A single pass can plan an unlimited number of destructive actions and today it executes every one of them without asking
- The dangerous case is already reachable: a manifest that looks wiped plans as "delete everything here", and one bad read should never be able to quietly gut a vault
- Automatic sync removed the human who would have hesitated before clicking, so a pass wanting to delete two hundred files now starts on a timer

## Changes

- Added `src/sync/guard.ts`, which counts what a plan would destroy: local deletes, local overwrites, and remote deletes, with additions and conflict copies counting for nothing
- Added the halt between `planSync` and `executeSyncPlan`, returning a new `blocked` outcome carrying the counts and the paths, before anything is written on either side
- Added the confirmation dialog, listing what the pass would do, what of it is recoverable, and the first twenty files themselves
- Mapped the halt onto the scheduler's `stop`, so an automatic pass asks once rather than re-prompting every tick, and confirming runs a fresh pass that also lifts the halt
- Documented the guard and the dialog in `technical_sync.md` and `technical_plugin.md`

## Why

- The threshold is `clamp(tracked * 0.2, 10, 50)` rather than the issue's flat pair, because a share alone waves through thousands in a large vault and a count alone can never fire in a vault smaller than the count itself
- The floor of 10 is a deviation from the issue, and it is there because a guard that prompts over three deleted notes is one people learn to dismiss
- Confirming replans from a fresh read instead of resuming the halted pass, which avoids holding the manifest compare and swap open across a human's attention span
- The dialog leads on files and recoverability rather than a bare count, since a count alone gives nobody a way to answer the question
- Halting writes nothing at all, so cancelling leaves a pass that can simply be planned again

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a mass-change guard that halts destructive sync plans and requires confirmation bound to the freshly replanned destructive set.

- Counts local deletions, local overwrites, and remote deletions against a vault-size threshold.
- Presents affected paths and recoverability details in a confirmation dialog.
- Stops scheduled sync after a blocked pass and validates confirmation against a fresh plan.
- Adds unit coverage and documents the guard and plugin workflow.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the previously reported confirmation bypass is fixed by comparing the fresh destructive path-and-fate set with the set displayed for confirmation before execution.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/sync/guard.ts | Implements destructive-action counting, threshold evaluation, user-facing copy, and exact order-independent confirmation matching. |
| src/sync/sync.ts | Inserts the guard between planning and execution and returns a non-writing blocked outcome when confirmation is absent or stale. |
| src/main.ts | Maps blocked outcomes to scheduler stop behavior and carries the displayed plan into a fresh manual pass. |
| src/sync/modal.ts | Displays destructive counts and paths and invokes confirmation only through the explicit warning action. |
| src/sync/guard.test.ts | Covers thresholds, destructive classification, confirmation binding, dialog copy, and path labels. |
| src/sync/sync.test.ts | Verifies blocked passes perform no writes and stale confirmations cannot authorize changed destructive plans. |

<sub>Reviews (2): Last reviewed commit: ["Address comment"](https://github.com/8thpark/geode/commit/bbdfb4cac304494a267da5a104afff9e2ed0a8c0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51128198)</sub>

**Context used:**

- Knowledge Base — [Sync flow](https://app.greptile.com/8thpark/-/custom-context/knowledge-base/8thpark/geode/-/docs/sync-flow.md)
- Knowledge Base — [Plugin entrypoint (src/main.ts)](https://app.greptile.com/8thpark/-/custom-context/knowledge-base/8thpark/geode/-/docs/plugin-entrypoint.md)

<!-- /greptile_comment -->