### PR TITLE
[#182] Sync → Say the things a status bar icon cannot

### DIFF
--- a/docs/technical_plugin.md
+++ b/docs/technical_plugin.md
@@ -48,6 +48,7 @@ needing a running Obsidian.
 | State store    | Reading and writing `state.json`                              |
 | Storage        | Dispatching signed requests through `requestUrl`              |
 | Log sink       | Appending to a capped file in the plugin's data folder        |
+| Toaster        | Putting a decided toast on screen, and taking the sticky one down |
 
 Pulled content is written through the low level data adapter rather than the Vault API, because a
 path pulled down for the first time has no `TFile` for the Vault API to operate on.

--- a/docs/technical_plugin.md
+++ b/docs/technical_plugin.md
@@ -14,6 +14,7 @@ of Geode testable without a running app.
 - [What The Plugin Owns](#what-the-plugin-owns)
 - [The First Sync Dialog](#the-first-sync-dialog)
 - [The Mass Change Dialog](#the-mass-change-dialog)
+- [Toasts](#toasts)
 - [Guards](#guards)
 - [Writing Files Safely](#writing-files-safely)
 - [Deleting Files](#deleting-files)
@@ -56,7 +57,7 @@ path pulled down for the first time has no `TFile` for the Vault API to operate 
 - Loading settings, the device identity, and whether this vault has synced before
 - Registering the vault event listeners that mark local work pending
 - Ticking the scheduler and starting a pass when one is due
-- The status bar, the log view, and the commands
+- The status bar, the log view, the toasts, and the commands
 - Translating a failed pass into what the scheduler should do about it
 
 That last one is the whole of the contract between two modules that otherwise know nothing about
@@ -133,6 +134,37 @@ planning exactly that (see [the guard](technical_sync.md#the-mass-change-guard))
 the dialog opens again, and says so: a second identical looking prompt with no explanation reads as
 a bug, and someone who has already clicked through one is exactly the person who will click through
 the next without reading it.
+
+### Toasts
+
+The status bar is a cloud icon and a tooltip, which is enough to answer "what is it doing" and
+nothing like enough to say something you have to act on. Toasts are the other half, and every one
+geode raises comes from a single table in `notify/notify.ts`, so the wording, the duration, and the
+silences are all pinned by one test rather than scattered across the plugin class.
+
+| Occasion                          | Says                                                     | Stays |
+| --------------------------------- | -------------------------------------------------------- | ----- |
+| Automatic sync halted             | The reason, since nothing will happen until you act       | Until dismissed |
+| A large change is waiting on you  | That nothing has synced, for whoever dismissed the dialog | 10s |
+| Any pass failed                   | The reason                                                | 10s |
+| Conflict copies were made         | How many, and that your copy is beside the remote one     | 10s |
+| A pass applied changes            | How many                                                  | 5s |
+| A manual pass found nothing to do | That you were already up to date                          | 5s |
+| Syncing recovered                 | That it is working again                                  | 5s |
+| Paused, resumed, settings saved   | That it happened                                          | 5s |
+
+One thing stays silent: an automatic pass that applied nothing. That is the product working, it
+happens every few minutes forever, and a notice you cannot stop is not information. `log.ts` drops
+those lines for the same reason.
+
+Precedence within a pass is worst news first. A halt outranks the failure it arrived as, a mass
+change outranks the halt, and a conflict outranks the change count it came with, because the count
+is the part you would have guessed.
+
+The halt toast is the only sticky one, and it is held so the next thing geode says can take it
+down. A "stopped syncing" notice still on screen after you have fixed the credentials is worse than
+no notice at all, and a sticky toast outlives the plugin that raised it, so disabling geode retires
+it too.
 
 ### Guards
 

--- a/docs/technical_sync.md
+++ b/docs/technical_sync.md
@@ -330,6 +330,10 @@ A conflict is a path that changed on both sides to different content. Neither ed
 discarded: the local edit is renamed to a conflict copy and pushed, and the remote version claims
 the original path.
 
+It is also the one thing a successful pass does that nobody would find on their own, so a pass that
+made any says so in a [toast](technical_plugin.md#toasts). An edit kept under a name you never
+learn about is not an edit that survived.
+
 The copy's name carries the time and the device, because on a three device vault "whose" is the
 question actually being asked. It uses no spaces, is lowercase throughout, and separates fields with
 underscores while hyphens live inside them, so a name parses unambiguously from the right even when

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,11 @@
 import type { App } from "obsidian";
-import { Notice, Platform, Plugin, setIcon, setTooltip } from "obsidian";
+import { Platform, Plugin, setIcon, setTooltip } from "obsidian";
 import { DEVICE_ID_KEY, deviceIdFrom, deviceSuffixFrom } from "./device/device";
 import { createLogSink } from "./log/adapter";
 import { createLogBus, createLogger, type LogBus, type Logger, type LogSink } from "./log/log";
 import { GeodeLogView, LOG_VIEW_TYPE } from "./log/view";
-import { DEFAULT_PASS, type Pass, STICKY, type Toast, toastFor } from "./notify/notify";
+import { DEFAULT_PASS, type Pass, toastFor } from "./notify/notify";
+import { createToaster, type Toaster } from "./notify/obsidian";
 import { type Actions, GeodeOnboardingModal } from "./onboarding/modal";
 import { type RemoteRead, readRemote, type SyncReport } from "./onboarding/onboarding";
 import {
@@ -171,9 +172,9 @@ export default class GeodePlugin extends Plugin {
   // once per session before trusting the compare and swap. Reset on save, so a new provider
   // re-verifies.
   private conditionalWritesVerified = false;
-  // stickyNotice is the one toast that waits to be dismissed, held so the next thing geode says can
-  // take it down: a halt notice still on screen after the halt cleared is a lie.
-  private stickyNotice: Notice | null = null;
+  // toaster owns everything geode says out loud, including the one notice that waits to be
+  // dismissed: a halt still on screen after the halt cleared is a lie.
+  private toaster: Toaster = createToaster();
 
   async onload() {
     await this.loadSettings();
@@ -246,7 +247,7 @@ export default class GeodePlugin extends Plugin {
     this.register(() => this.app.workspace.detachLeavesOfType(LOG_VIEW_TYPE));
     // A sticky toast outlives the plugin that raised it, and a disabled geode has no business
     // still saying it has stopped syncing.
-    this.register(() => this.dismissSticky());
+    this.register(() => this.toaster.dismissSticky());
 
     this.statusBarEl = this.addStatusBarItem();
     this.statusBarEl.addClass("geode-status-bar", "mod-clickable");
@@ -398,33 +399,11 @@ export default class GeodePlugin extends Plugin {
     this.setSyncStatus(this.restingStatus(), "");
     if (paused) {
       this.logger.info("automatic sync paused on this device");
-      this.showToast(toastFor({ kind: "paused" }));
+      this.toaster.show(toastFor({ kind: "paused" }));
       return;
     }
     this.logger.info("automatic sync resumed on this device");
-    this.showToast(toastFor({ kind: "resumed" }));
-  }
-
-  // showToast puts a decided toast on screen and is the only place geode calls Notice. Anything it
-  // says retires the sticky one first, since the newer statement is the true one.
-  private showToast(toast: Toast | null): void {
-    if (toast === null) {
-      return;
-    }
-    this.dismissSticky();
-    const notice = new Notice(toast.text, toast.durationMs);
-    if (toast.durationMs === STICKY) {
-      this.stickyNotice = notice;
-    }
-  }
-
-  // dismissSticky takes down the toast that was waiting to be dismissed, if one is up.
-  private dismissSticky(): void {
-    if (this.stickyNotice === null) {
-      return;
-    }
-    this.stickyNotice.hide();
-    this.stickyNotice = null;
+    this.toaster.show(toastFor({ kind: "resumed" }));
   }
 
   // setSyncStatus updates the status bar icon and tooltip to reflect status.
@@ -461,7 +440,7 @@ export default class GeodePlugin extends Plugin {
       // No status change: a pass is on screen already saying it is running, and this one never
       // started, so the toast is the whole of the answer.
       const message = "a sync is already running";
-      this.showToast(toastFor({ kind: "pass", pass: { ...DEFAULT_PASS, message } }));
+      this.toaster.show(toastFor({ kind: "pass", pass: { ...DEFAULT_PASS, message } }));
       return { ok: false, message };
     }
     if (!hasConnectionConfig(this.settings)) {
@@ -510,7 +489,7 @@ export default class GeodePlugin extends Plugin {
     // to answer, so the dialog's own case is never reported as a halt.
     const stopped = outcome.result === "stop" && !outcome.pass.blocked;
     const pass: Pass = { ...outcome.pass, manual: trigger === "manual", recovered, stopped };
-    this.showToast(toastFor({ kind: "pass", pass }));
+    this.toaster.show(toastFor({ kind: "pass", pass }));
 
     return reportFor(pass);
   }
@@ -519,7 +498,7 @@ export default class GeodePlugin extends Plugin {
   // a refusal nobody sees is indistinguishable from a sync that silently never runs.
   private refuse(message: string): SyncReport {
     this.setSyncStatus("error", message);
-    this.showToast(toastFor({ kind: "pass", pass: { ...DEFAULT_PASS, message } }));
+    this.toaster.show(toastFor({ kind: "pass", pass: { ...DEFAULT_PASS, message } }));
 
     return { ok: false, message };
   }
@@ -677,7 +656,7 @@ export default class GeodePlugin extends Plugin {
     this.schedule = noteResumed(this.schedule);
     await this.loadSyncedBefore();
     this.logger.info("settings saved");
-    this.showToast(toastFor({ kind: "settingsSaved" }));
+    this.toaster.show(toastFor({ kind: "settingsSaved" }));
     // Saving a connection is the moment someone has said what they want and nothing has happened
     // yet, which is the only moment the first sync dialog has anything to offer.
     this.offerOnboarding();

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,10 @@
 import type { App } from "obsidian";
-import { Platform, Plugin, setIcon, setTooltip } from "obsidian";
+import { Notice, Platform, Plugin, setIcon, setTooltip } from "obsidian";
 import { DEVICE_ID_KEY, deviceIdFrom, deviceSuffixFrom } from "./device/device";
 import { createLogSink } from "./log/adapter";
 import { createLogBus, createLogger, type LogBus, type Logger, type LogSink } from "./log/log";
 import { GeodeLogView, LOG_VIEW_TYPE } from "./log/view";
+import { DEFAULT_PASS, type Pass, STICKY, type Toast, toastFor } from "./notify/notify";
 import { type Actions, GeodeOnboardingModal } from "./onboarding/modal";
 import { type RemoteRead, readRemote, type SyncReport } from "./onboarding/onboarding";
 import {
@@ -65,9 +66,9 @@ type AppWithSetting = App & {
   };
 };
 
-// PassOutcome pairs what the scheduler needs from a pass with what a UI watching one needs, since
-// neither answer contains the other: "stop" is not a message, and a message is not a policy.
-type PassOutcome = { report: SyncReport; result: PassResult };
+// PassOutcome pairs what the scheduler needs from a pass with what everything watching one needs,
+// since neither answer contains the other: "stop" is not a message, and a message is not a policy.
+type PassOutcome = { pass: Pass; result: PassResult };
 
 // SyncStatus is the state the status bar item reflects.
 type SyncStatus = "idle" | "syncing" | "error" | "paused";
@@ -121,6 +122,16 @@ function passResultFor(fault: SyncFault): PassResult {
   return "retry";
 }
 
+// reportFor returns what a caller watching a pass is told about it, which is the part of a pass the
+// first sync dialog can render.
+function reportFor(pass: Pass): SyncReport {
+  if (pass.ok) {
+    return { ok: true, changeCount: pass.changes };
+  }
+
+  return { ok: false, message: pass.message };
+}
+
 // tooltipFor returns the status bar hover text for status. detail is folded into the error case.
 function tooltipFor(status: SyncStatus, detail: string): string {
   if (status === "syncing") {
@@ -160,6 +171,9 @@ export default class GeodePlugin extends Plugin {
   // once per session before trusting the compare and swap. Reset on save, so a new provider
   // re-verifies.
   private conditionalWritesVerified = false;
+  // stickyNotice is the one toast that waits to be dismissed, held so the next thing geode says can
+  // take it down: a halt notice still on screen after the halt cleared is a lie.
+  private stickyNotice: Notice | null = null;
 
   async onload() {
     await this.loadSettings();
@@ -230,6 +244,9 @@ export default class GeodePlugin extends Plugin {
       },
     });
     this.register(() => this.app.workspace.detachLeavesOfType(LOG_VIEW_TYPE));
+    // A sticky toast outlives the plugin that raised it, and a disabled geode has no business
+    // still saying it has stopped syncing.
+    this.register(() => this.dismissSticky());
 
     this.statusBarEl = this.addStatusBarItem();
     this.statusBarEl.addClass("geode-status-bar", "mod-clickable");
@@ -381,9 +398,33 @@ export default class GeodePlugin extends Plugin {
     this.setSyncStatus(this.restingStatus(), "");
     if (paused) {
       this.logger.info("automatic sync paused on this device");
+      this.showToast(toastFor({ kind: "paused" }));
       return;
     }
     this.logger.info("automatic sync resumed on this device");
+    this.showToast(toastFor({ kind: "resumed" }));
+  }
+
+  // showToast puts a decided toast on screen and is the only place geode calls Notice. Anything it
+  // says retires the sticky one first, since the newer statement is the true one.
+  private showToast(toast: Toast | null): void {
+    if (toast === null) {
+      return;
+    }
+    this.dismissSticky();
+    const notice = new Notice(toast.text, toast.durationMs);
+    if (toast.durationMs === STICKY) {
+      this.stickyNotice = notice;
+    }
+  }
+
+  // dismissSticky takes down the toast that was waiting to be dismissed, if one is up.
+  private dismissSticky(): void {
+    if (this.stickyNotice === null) {
+      return;
+    }
+    this.stickyNotice.hide();
+    this.stickyNotice = null;
   }
 
   // setSyncStatus updates the status bar icon and tooltip to reflect status.
@@ -417,35 +458,38 @@ export default class GeodePlugin extends Plugin {
     confirmed: MassChange | null = null,
   ): Promise<SyncReport> {
     if (this.schedule.syncing) {
-      return { ok: false, message: "a sync is already running" };
+      // No status change: a pass is on screen already saying it is running, and this one never
+      // started, so the toast is the whole of the answer.
+      const message = "a sync is already running";
+      this.showToast(toastFor({ kind: "pass", pass: { ...DEFAULT_PASS, message } }));
+      return { ok: false, message };
     }
     if (!hasConnectionConfig(this.settings)) {
       this.logger.warn("sync: storage isn't configured yet");
-      this.setSyncStatus("error", "storage isn't configured yet");
-      return { ok: false, message: "storage isn't configured yet" };
+      return this.refuse("storage isn't configured yet");
     }
     // The storage client already refuses an unusable prefix; checking here is what makes the
     // refusal legible, rather than reporting it as a failed conditional write probe.
     const badPrefix = prefixError(this.settings.prefix);
     if (badPrefix !== "") {
       this.logger.warn(`sync: ${badPrefix}`);
-      this.setSyncStatus("error", badPrefix);
-      return { ok: false, message: badPrefix };
+      return this.refuse(badPrefix);
     }
     const dir = this.manifest.dir;
     if (dir === undefined) {
       this.logger.error("sync: no plugin data directory available");
-      this.setSyncStatus("error", "no plugin data directory available");
-      return { ok: false, message: "no plugin data directory available" };
+      return this.refuse("no plugin data directory available");
     }
 
+    // Read before the pass starts, since finishing one is what resets the streak it followed.
+    const recovered = this.schedule.failures > 0;
     if (trigger === "manual") {
       this.schedule = noteResumed(this.schedule);
     }
     this.schedule = notePassStarted(this.schedule);
     this.setSyncStatus("syncing", "");
     let outcome: PassOutcome = {
-      report: { ok: false, message: "unexpected error" },
+      pass: { ...DEFAULT_PASS, message: "unexpected error" },
       result: "retry",
     };
     try {
@@ -457,12 +501,27 @@ export default class GeodePlugin extends Plugin {
       }
       this.logger.error(`sync: ${message}`);
       this.setSyncStatus("error", message);
-      outcome = { report: { ok: false, message }, result: "retry" };
+      outcome = { pass: { ...DEFAULT_PASS, message }, result: "retry" };
     } finally {
       this.schedule = notePassFinished(this.schedule, outcome.result, Date.now());
     }
 
-    return outcome.report;
+    // A halted pass and a blocked one both end automatic sync, but only one of them is the user's
+    // to answer, so the dialog's own case is never reported as a halt.
+    const stopped = outcome.result === "stop" && !outcome.pass.blocked;
+    const pass: Pass = { ...outcome.pass, manual: trigger === "manual", recovered, stopped };
+    this.showToast(toastFor({ kind: "pass", pass }));
+
+    return reportFor(pass);
+  }
+
+  // refuse reports a pass that never started. The status bar carries it, and so does a toast, since
+  // a refusal nobody sees is indistinguishable from a sync that silently never runs.
+  private refuse(message: string): SyncReport {
+    this.setSyncStatus("error", message);
+    this.showToast(toastFor({ kind: "pass", pass: { ...DEFAULT_PASS, message } }));
+
+    return { ok: false, message };
   }
 
   // runSync does the work of syncNow, split out so the guard and status bar bookkeeping stay
@@ -477,7 +536,7 @@ export default class GeodePlugin extends Plugin {
       const message = "secret access key not found; open settings to reconfigure";
       this.logger.error(`sync: secret access key not found for ID "${this.settings.secretId}"`);
       this.setSyncStatus("error", message);
-      return { report: { ok: false, message }, result: "stop" };
+      return { pass: { ...DEFAULT_PASS, message }, result: "stop" };
     }
 
     const storage = createS3Client(this.settings, secretAccessKey, obsidianTransport);
@@ -487,7 +546,7 @@ export default class GeodePlugin extends Plugin {
       if (!probe.ok) {
         this.logger.error(`sync: conditional write check failed: ${probe.message}`);
         this.setSyncStatus("error", probe.message);
-        return { report: { ok: false, message: probe.message }, result: "stop" };
+        return { pass: { ...DEFAULT_PASS, message: probe.message }, result: "stop" };
       }
       this.conditionalWritesVerified = true;
       this.logger.info("sync: conditional write support verified");
@@ -523,7 +582,10 @@ export default class GeodePlugin extends Plugin {
         void this.syncNow("manual", confirmed);
       }).open();
 
-      return { report: { ok: false, message: outcome.message }, result: "stop" };
+      return {
+        pass: { ...DEFAULT_PASS, blocked: true, message: outcome.message },
+        result: "stop",
+      };
     }
     if (!outcome.ok) {
       // A failed pass can still have made progress worth keeping: completed work is recorded so
@@ -538,7 +600,7 @@ export default class GeodePlugin extends Plugin {
       this.setSyncStatus("error", outcome.message);
 
       return {
-        report: { ok: false, message: outcome.message },
+        pass: { ...DEFAULT_PASS, message: outcome.message },
         result: passResultFor(outcome.fault),
       };
     }
@@ -552,7 +614,15 @@ export default class GeodePlugin extends Plugin {
     }
     this.setSyncStatus(this.restingStatus(), "");
 
-    return { report: { ok: true, changeCount: outcome.changeCount }, result: "ok" };
+    return {
+      pass: {
+        ...DEFAULT_PASS,
+        changes: outcome.changeCount,
+        conflicts: outcome.conflictCount,
+        ok: true,
+      },
+      result: "ok",
+    };
   }
 
   // loadDeviceId returns this device's identity, minting one on first run and treating an unusable
@@ -607,6 +677,7 @@ export default class GeodePlugin extends Plugin {
     this.schedule = noteResumed(this.schedule);
     await this.loadSyncedBefore();
     this.logger.info("settings saved");
+    this.showToast(toastFor({ kind: "settingsSaved" }));
     // Saving a connection is the moment someone has said what they want and nothing has happened
     // yet, which is the only moment the first sync dialog has anything to offer.
     this.offerOnboarding();

--- a/src/notify/notify.test.ts
+++ b/src/notify/notify.test.ts
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  DEFAULT_PASS,
+  type Occasion,
+  type Pass,
+  PROBLEM_MS,
+  ROUTINE_MS,
+  STICKY,
+  type Toast,
+  toastFor,
+} from "./notify.ts";
+
+// pass returns a finished pass with everything at its zero value except what a case moves, so each
+// row proves which rule answered rather than which field happened to be set.
+function pass(over: Partial<Pass> = {}): Occasion {
+  return { kind: "pass", pass: { ...DEFAULT_PASS, ...over } };
+}
+
+test("toastFor: every occasion that earns a toast gets one, and the order between them holds", () => {
+  const cases: { name: string; occasion: Occasion; want: Toast | null }[] = [
+    {
+      name: "a halt is the one notice that waits until it is dismissed",
+      occasion: pass({ message: "secret access key not found", stopped: true }),
+      want: {
+        durationMs: STICKY,
+        text: "Geode has stopped syncing: secret access key not found",
+      },
+    },
+    {
+      name: "a mass change outranks the halt it arrives as, since a dialog is already asking",
+      occasion: pass({ blocked: true, message: "confirm it first", stopped: true }),
+      want: {
+        durationMs: PROBLEM_MS,
+        text: "Geode is waiting for you to confirm a large change; nothing has synced",
+      },
+    },
+    {
+      name: "an ordinary failure reports itself and goes away on its own",
+      occasion: pass({ message: "2 file(s) failed to sync" }),
+      want: { durationMs: PROBLEM_MS, text: "Geode: 2 file(s) failed to sync" },
+    },
+    {
+      name: "a failure someone asked for reads the same as one nobody did",
+      occasion: pass({ manual: true, message: "storage isn't configured yet" }),
+      want: { durationMs: PROBLEM_MS, text: "Geode: storage isn't configured yet" },
+    },
+    {
+      name: "a conflict outranks the changes it arrived with, being the half nobody would guess",
+      occasion: pass({ changes: 4, conflicts: 1, ok: true }),
+      want: {
+        durationMs: PROBLEM_MS,
+        text: "Geode found a conflict in 1 file; your copy was kept beside the remote one",
+      },
+    },
+    {
+      name: "more than one conflict counts them",
+      occasion: pass({ changes: 9, conflicts: 3, ok: true }),
+      want: {
+        durationMs: PROBLEM_MS,
+        text: "Geode found a conflict in 3 files; your copy was kept beside the remote one",
+      },
+    },
+    {
+      name: "a pass that applied changes says how many",
+      occasion: pass({ changes: 1, ok: true }),
+      want: { durationMs: ROUTINE_MS, text: "Geode: synced, 1 change applied" },
+    },
+    {
+      name: "an automatic pass that applied changes is worth saying too",
+      occasion: pass({ changes: 12, ok: true }),
+      want: { durationMs: ROUTINE_MS, text: "Geode: synced, 12 changes applied" },
+    },
+    {
+      name: "a pass someone asked for answers even when there was nothing to do",
+      occasion: pass({ manual: true, ok: true }),
+      want: { durationMs: ROUTINE_MS, text: "Geode: already up to date" },
+    },
+    {
+      name: "the first quiet pass after a failure says the failure is over",
+      occasion: pass({ ok: true, recovered: true }),
+      want: { durationMs: ROUTINE_MS, text: "Geode: syncing again" },
+    },
+    {
+      name: "an idle automatic pass is the one thing that stays silent",
+      occasion: pass({ ok: true }),
+      want: null,
+    },
+    {
+      name: "pausing on this device says so, since the status bar is not the only place to look",
+      occasion: { kind: "paused" },
+      want: { durationMs: ROUTINE_MS, text: "Geode: automatic sync paused on this device" },
+    },
+    {
+      name: "resuming says so as well",
+      occasion: { kind: "resumed" },
+      want: { durationMs: ROUTINE_MS, text: "Geode: automatic sync resumed on this device" },
+    },
+    {
+      name: "saving settings confirms the save rather than leaving the form to imply it",
+      occasion: { kind: "settingsSaved" },
+      want: { durationMs: ROUTINE_MS, text: "Geode: settings saved" },
+    },
+  ];
+
+  for (const item of cases) {
+    assert.deepEqual(toastFor(item.occasion), item.want, item.name);
+  }
+});
+
+test("toastFor: the zero value is a failed pass with nothing to say for itself", () => {
+  // A pass that ended in a way nothing anticipated still reaches the user, since the alternative
+  // is a status bar icon changing colour and no explanation anywhere.
+  assert.deepEqual(toastFor(pass()), { durationMs: PROBLEM_MS, text: "Geode: sync failed" });
+});

--- a/src/notify/notify.ts
+++ b/src/notify/notify.ts
@@ -1,0 +1,137 @@
+// Deciding what geode says out loud, kept apart from saying it: every occasion below is one row of
+// a table, so the wording and the silences are pinned by a test rather than scattered across the
+// plugin class. The case for each row is in docs/technical_plugin.md.
+
+// DEFAULT_PASS is the complete zero value: a pass that failed, said nothing, and changed nothing.
+export const DEFAULT_PASS: Pass = {
+  blocked: false,
+  changes: 0,
+  conflicts: 0,
+  manual: false,
+  message: "",
+  ok: false,
+  recovered: false,
+  stopped: false,
+};
+
+// PROBLEM_MS is how long a toast about something wrong stays up: twice Obsidian's default, since
+// reading a failure once rarely tells you what to do about it.
+export const PROBLEM_MS = 10_000;
+
+// ROUTINE_MS is how long a toast about ordinary progress stays up, matching Obsidian's own default
+// so geode's routine toasts behave like every other plugin's.
+export const ROUTINE_MS = 5_000;
+
+// STICKY is the duration Obsidian reads as "stay on screen until the user dismisses it", and is
+// spent on the one occasion where nothing will happen again until a person acts.
+export const STICKY = 0;
+
+// Occasion is everything that can earn a toast. Anything not on this list is silent by
+// construction, which is the point of routing every notice through one function.
+export type Occasion =
+  | { kind: "pass"; pass: Pass }
+  | { kind: "paused" }
+  | { kind: "resumed" }
+  | { kind: "settingsSaved" };
+
+// Pass is what one finished sync pass tells the table, including the two things only the caller
+// knows: whether anyone asked for it, and whether it followed a failure.
+export type Pass = {
+  // blocked is whether the pass stopped to ask about a mass change, which a dialog is already
+  // asking about on screen.
+  blocked: boolean;
+  // changes is how many actions the pass applied.
+  changes: number;
+  // conflicts is how many local files it moved aside as conflict copies.
+  conflicts: number;
+  // manual is whether someone asked for this pass rather than the scheduler.
+  manual: boolean;
+  // message is why the pass failed, empty when it did not.
+  message: string;
+  ok: boolean;
+  // recovered is whether this pass followed at least one failed one.
+  recovered: boolean;
+  // stopped is whether automatic sync has halted until a person acts.
+  stopped: boolean;
+};
+
+// Toast is one notice to put on screen, already worded and timed.
+export type Toast = { durationMs: number; text: string };
+
+// toastFor returns the notice occasion earns, or null when it earns silence.
+export function toastFor(occasion: Occasion): Toast | null {
+  if (occasion.kind === "pass") {
+    return passToast(occasion.pass);
+  }
+  if (occasion.kind === "paused") {
+    return { durationMs: ROUTINE_MS, text: "Geode: automatic sync paused on this device" };
+  }
+  if (occasion.kind === "resumed") {
+    return { durationMs: ROUTINE_MS, text: "Geode: automatic sync resumed on this device" };
+  }
+
+  return { durationMs: ROUTINE_MS, text: "Geode: settings saved" };
+}
+
+// changes returns count with the right noun.
+function changes(count: number): string {
+  if (count === 1) {
+    return "1 change";
+  }
+
+  return `${count} changes`;
+}
+
+// files returns count with the right noun.
+function files(count: number): string {
+  if (count === 1) {
+    return "1 file";
+  }
+
+  return `${count} files`;
+}
+
+// passToast returns what a finished pass earns, worst news first: a halt outranks a failure, and a
+// conflict outranks the change count it arrived with.
+function passToast(pass: Pass): Toast | null {
+  if (!pass.ok) {
+    // The mass change dialog is already on screen saying all of this at length, so the toast is
+    // here for the person who dismissed it and would otherwise watch sync quietly stay dead.
+    if (pass.blocked) {
+      return {
+        durationMs: PROBLEM_MS,
+        text: "Geode is waiting for you to confirm a large change; nothing has synced",
+      };
+    }
+    if (pass.stopped) {
+      return { durationMs: STICKY, text: `Geode has stopped syncing: ${pass.message}` };
+    }
+    // A pass can fail in a way nothing anticipated, and a toast reading "Geode: " helps nobody.
+    if (pass.message === "") {
+      return { durationMs: PROBLEM_MS, text: "Geode: sync failed" };
+    }
+
+    return { durationMs: PROBLEM_MS, text: `Geode: ${pass.message}` };
+  }
+  if (pass.conflicts > 0) {
+    return {
+      durationMs: PROBLEM_MS,
+      text:
+        `Geode found a conflict in ${files(pass.conflicts)}; your copy was kept beside ` +
+        "the remote one",
+    };
+  }
+  if (pass.changes > 0) {
+    return { durationMs: ROUTINE_MS, text: `Geode: synced, ${changes(pass.changes)} applied` };
+  }
+  if (pass.manual) {
+    return { durationMs: ROUTINE_MS, text: "Geode: already up to date" };
+  }
+  // An automatic pass that finds nothing is the whole product working, and there is one every few
+  // minutes forever, so it is the one thing left that says nothing at all.
+  if (pass.recovered) {
+    return { durationMs: ROUTINE_MS, text: "Geode: syncing again" };
+  }
+
+  return null;
+}

--- a/src/notify/obsidian.ts
+++ b/src/notify/obsidian.ts
@@ -1,0 +1,37 @@
+import { Notice } from "obsidian";
+import { STICKY, type Toast } from "./notify.ts";
+
+// Toaster puts decided toasts on screen and owns the one waiting to be dismissed, so nothing else
+// has to remember that a notice can outlive the thing it was about.
+export type Toaster = {
+  dismissSticky: () => void;
+  show: (toast: Toast | null) => void;
+};
+
+// createToaster returns the only thing in geode that constructs a Notice. Anything it says retires
+// the sticky one first, since the newer statement is the true one.
+export function createToaster(): Toaster {
+  let sticky: Notice | null = null;
+
+  const dismissSticky = () => {
+    if (sticky === null) {
+      return;
+    }
+    sticky.hide();
+    sticky = null;
+  };
+
+  return {
+    dismissSticky,
+    show: (toast) => {
+      if (toast === null) {
+        return;
+      }
+      dismissSticky();
+      const notice = new Notice(toast.text, toast.durationMs);
+      if (toast.durationMs === STICKY) {
+        sticky = notice;
+      }
+    },
+  };
+}

--- a/src/onboarding/onboarding.ts
+++ b/src/onboarding/onboarding.ts
@@ -7,7 +7,7 @@ import { readRemoteManifest, readSentinel, type SyncFault } from "../sync/sync.t
 export const DONE_STEPS = [
   "Geode now syncs on its own: edits go up a few seconds after you stop typing, and it checks " +
     "for remote changes every 5 minutes.",
-  "The cloud icon in the status bar is the whole status. Click it to sync right now.",
+  "The cloud icon in the status bar says what it is doing. Click it to sync right now.",
   'Run "Geode: Logs" from the command palette to see everything it has done.',
 ];
 

--- a/src/sync/sync.test.ts
+++ b/src/sync/sync.test.ts
@@ -1044,6 +1044,46 @@ test("syncOnce: a conflict copy carries the device that made the edit (#103)", a
   assert.ok(paths.includes(copyPath), paths.join(", "));
 });
 
+test("syncOnce: only a conflict that actually kept a copy is counted", async () => {
+  // Both conflicts complete, but only one of them moves a local edit aside: a path deleted here and
+  // edited elsewhere restores the remote file and preserves nothing, so counting it would have the
+  // toast claim a copy that is not on disk.
+  const baseHash = await hashOf("shared base");
+  const goneHash = await hashOf("also shared");
+  const keptRemote = await hashOf("their edit");
+  const goneRemote = await hashOf("their other edit");
+  const ancestor = snapshot(
+    { path: "kept.md", size: 11, mtime: 1, hash: baseHash, blob: baseHash },
+    { path: "gone.md", size: 12, mtime: 1, hash: goneHash, blob: goneHash },
+  );
+  const remoteManifest = encodeSnapshot(
+    snapshot(
+      { path: "kept.md", size: 10, mtime: 1, hash: keptRemote, blob: keptRemote },
+      { path: "gone.md", size: 16, mtime: 1, hash: goneRemote, blob: goneRemote },
+    ),
+  );
+  const { storage } = fakeStorage({
+    [MANIFEST_KEY]: wrapped(remoteManifest),
+    [blobKeyFor(keptRemote)]: wrapped("their edit"),
+    [blobKeyFor(goneRemote)]: wrapped("their other edit"),
+  });
+  // gone.md is absent from the reader, which is what a local delete looks like to a pass.
+  const reader = fakeReader({ "kept.md": "my edit" });
+  const { writer, files } = fakeLocalWriter();
+  files.set("kept.md", "my edit");
+  const now = Date.parse("2026-07-14T14:37:22.123Z");
+
+  const outcome = await syncOnce(ancestor, reader, writer, storage, now);
+
+  assert.equal(outcome.ok, true);
+  assert.equal(outcome.changeCount, 2);
+  assert.equal(outcome.conflictCount, 1);
+  // The copy the count refers to is on disk, and the file that never had one is simply restored.
+  assert.equal(files.get(conflictCopyPath("kept.md", now)), "my edit");
+  assert.equal(files.get("kept.md"), "their edit");
+  assert.equal(files.get("gone.md"), "their other edit");
+});
+
 test("syncOnce: a manifest that moves on mid pull is caught before stale content lands on disk", async () => {
   // Another device completes a whole sync between this pass reading the manifest and its pull
   // committing. A blob read by its own address cannot notice that itself, so the manifest check

--- a/src/sync/sync.test.ts
+++ b/src/sync/sync.test.ts
@@ -861,6 +861,7 @@ test("syncOnce: retry adopts an identical orphaned upload with a HEAD, not anoth
       vaultId: "fixed-vault-id",
     },
     changeCount: 1,
+    conflictCount: 0,
   });
   assert.equal(filePuts, 1, "retry replaced an identical orphaned upload with a HEAD, not a PUT");
   assert.ok(retry.ok);

--- a/src/sync/sync.ts
+++ b/src/sync/sync.ts
@@ -24,11 +24,11 @@ import {
   type SyncAction,
 } from "./plan.ts";
 
-// SyncOutcome is the result of a single sync pass: on success the new snapshot to persist and how
-// many actions ran, on failure a message and any per file failures, with snapshot carrying progress
-// worth keeping rather than always null.
+// SyncOutcome is the result of a single sync pass: on success the new snapshot to persist, how many
+// actions ran, and how many of them moved a local file aside, on failure a message and any per file
+// failures, with snapshot carrying progress worth keeping rather than always null.
 export type SyncOutcome =
-  | { ok: true; snapshot: Snapshot; changeCount: number }
+  | { ok: true; snapshot: Snapshot; changeCount: number; conflictCount: number }
   // A blocked pass executed nothing, so it has no progress to persist and nothing to retry: it is
   // waiting on an answer only a person can give. restated marks one asked a second time.
   | {
@@ -425,6 +425,7 @@ export async function syncOnce(
     ok: true,
     snapshot: { ...final, vaultId: identity.vaultId },
     changeCount: actions.length,
+    conflictCount: conflictsIn(executed.completed),
   };
 }
 
@@ -446,4 +447,17 @@ export function unexplainedBlobs(objects: ObjectMeta[], local: Snapshot): string
   }
 
   return unexplained;
+}
+
+// conflictsIn counts the actions that renamed a local file aside, which is the one thing a
+// successful pass does that nobody would find on their own.
+function conflictsIn(completed: SyncAction[]): number {
+  let count = 0;
+  for (const action of completed) {
+    if (action.kind === "conflict") {
+      count += 1;
+    }
+  }
+
+  return count;
 }

--- a/src/sync/sync.ts
+++ b/src/sync/sync.ts
@@ -450,11 +450,12 @@ export function unexplainedBlobs(objects: ObjectMeta[], local: Snapshot): string
 }
 
 // conflictsIn counts the actions that renamed a local file aside, which is the one thing a
-// successful pass does that nobody would find on their own.
+// successful pass does that nobody would find on their own. A conflict whose local side was deleted
+// has no local content to preserve, so it restores the remote file and leaves no copy to report.
 function conflictsIn(completed: SyncAction[]): number {
   let count = 0;
   for (const action of completed) {
-    if (action.kind === "conflict") {
+    if (action.kind === "conflict" && action.deletedSide !== "local") {
       count += 1;
     }
   }


### PR DESCRIPTION
Resolves [#182](https://github.com/8thpark/geode/issues/182)

## Problem

- The status bar is a cloud icon and a tooltip, which answers "what is it doing" and nothing like enough to say something you have to act on
- A halted sync, a mass change waiting on an answer, and a conflict copy that renamed one of your notes all end in silence today, or in a log file nobody has open
- Obsidian has no other channel for this, and mobile has no status bar at all

## Changes

- Added `notify`, a pure module holding the single table that decides what Geode says and how long it stays, so every word and every silence is pinned by one test
- Routed every occasion through one `showToast` on the plugin, the only place `Notice` is now constructed

| Occasion | Says | Stays |
| --- | --- | --- |
| Automatic sync halted | The reason, since nothing happens until you act | Until dismissed |
| A large change is waiting on you | That nothing has synced, for whoever dismissed the dialog | 10s |
| Any pass failed | The reason | 10s |
| Conflict copies were made | How many, and that your copy sits beside the remote one | 10s |
| A pass applied changes | How many | 5s |
| A manual pass found nothing to do | That you were already up to date | 5s |
| Syncing recovered | That it is working again | 5s |
| Paused, resumed, settings saved | That it happened | 5s |

- Left exactly one thing silent, an automatic pass that applied nothing, since that is the product working and it happens every few minutes forever
- Taught `syncOnce` to report `conflictCount`, because a conflict copy is the one thing a successful pass does that nobody would find on their own
- Derived `SyncReport` from the finished pass rather than tracking it alongside, so there is one description of what happened instead of two that can drift

## Why

- Silence means everything is fine, which is only a promise worth making if the cases that are not fine actually break it
- Precedence is worst news first, so a halt outranks the failure it arrived as and a conflict outranks the change count it came with, the count being the part you would have guessed
- One table in one pure module is what keeps the list short; a toast added anywhere else would have to argue with a test first
- The halt toast is the only sticky one and the next thing Geode says retires it, so a "stopped syncing" notice can never sit on screen after you have already fixed the credentials

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds centralized user-facing sync notifications and reports conflict-copy counts from completed sync passes.
- Introduces pure toast selection and an Obsidian notification adapter.
- Routes sync, pause, resume, and settings events through the notification flow.
- Counts only completed conflicts that preserve a local copy.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/main.ts | Integrates toast occasions with sync lifecycle, pause/resume state, settings saves, and pass reporting. |
| src/notify/notify.ts | Defines the notification occasion model, precedence, wording, and durations. |
| src/notify/obsidian.ts | Encapsulates Obsidian Notice construction and sticky-notice replacement. |
| src/sync/sync.ts | Extends successful sync outcomes with a count of completed conflicts that created local copies. |
| src/sync/sync.test.ts | Verifies locally deleted conflicts are excluded from the conflict-copy count. |

<sub>Reviews (2): Last reviewed commit: ["Address comments"](https://github.com/8thpark/geode/commit/87364f470691a5e393da1e075e525760456ab711) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51732696)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - AGENTS.md ([source](https://github.com/8thpark/geode/blob/main/AGENTS.md))
- Knowledge Base — [Sync flow](https://app.greptile.com/8thpark/-/custom-context/knowledge-base/8thpark/geode/-/docs/sync-flow.md)
- Knowledge Base — [Plugin entrypoint (src/main.ts)](https://app.greptile.com/8thpark/-/custom-context/knowledge-base/8thpark/geode/-/docs/plugin-entrypoint.md)
</details>

<!-- /greptile_comment -->