### PR TITLE
UI Tweaks and Logging Improvements

### DIFF
--- a/docs/technical_logging.md
+++ b/docs/technical_logging.md
@@ -58,6 +58,16 @@ perfectly ordinary idle poll comes to look like a hang.
 
 A pane rendering the persisted log, most recent first, updating live as entries arrive.
 
+Every row is a fixed width local timestamp, a three letter level, then the message:
+
+```
+26/08/18 08:21:36 ERR connection test failed
+26/08/18 08:21:36 INF testing connection
+```
+
+Both leading parts are the same width on every row, so the messages line up as a column and the
+level reads as colour and shape long before it is read as a word.
+
 It is always a straight render of what the sink holds: every change re-reads and redraws rather than
 mutating the DOM in place. Read only, with no way to write entries, only to display what the sink
 recorded.

--- a/docs/technical_settings.md
+++ b/docs/technical_settings.md
@@ -25,7 +25,7 @@ Settings persist to `data.json` in the plugin's own folder.
 | `provider`    | `r2`, `s3`, `custom`, or `minio`                              |
 | `accountId`   | Cloudflare account, which R2 derives endpoint and region from  |
 | `endpoint`    | The S3 compatible endpoint, for a MinIO or custom provider     |
-| `region`      | The region, for Amazon S3, a MinIO server, or a custom provider |
+| `region`      | The region, for Amazon S3 or a custom provider                 |
 | `bucket`      | The bucket name                                                |
 | `prefix`      | The folder inside the bucket the vault lives under             |
 | `accessKeyId` | The access key                                                 |
@@ -45,13 +45,14 @@ is the same S3 API for all four.
 | ------------------ | --------------------------------- | --------------------- |
 | `r2` Cloudflare R2 | Derived from `accountId`          | Always `auto`         |
 | `s3` Amazon S3     | Derived from `region`             | The `region` as typed |
-| `minio` MinIO      | Typed in full                     | The `region` as typed |
+| `minio` MinIO      | Typed in full                     | Always `us-east-1`    |
 | `custom`           | Typed in full                     | The `region` as typed |
 
-MinIO is a real provider for the self-hosted audience the project serves: pick it, type your server's
-endpoint, and the region it signs with (usually `us-east-1`). Custom only appears in development
-builds, where esbuild defines `NODE_ENV`. It exists as an escape hatch for any other S3 compatible
-endpoint, while the named providers cover the setups worth naming.
+MinIO is a real provider for the self-hosted audience the project serves: pick it, type your
+server's endpoint, and you're done. It asks for no region, because MinIO ignores the one it is sent
+unless the server sets `MINIO_REGION`; a server pinned to another region is a custom provider.
+Custom only appears in development builds, where esbuild defines `NODE_ENV`. It exists as an escape
+hatch for any other S3 compatible endpoint, while the named providers cover the setups worth naming.
 
 Amazon S3 puts the region straight into the endpoint host, so the region is the endpoint. A value
 carrying URL authority delimiters, `x@attacker.example:443#`, would otherwise send signed requests

--- a/src/log/log.test.ts
+++ b/src/log/log.test.ts
@@ -5,8 +5,11 @@ import {
   createLogger,
   createMemorySink,
   formatLogLine,
+  formatTime,
   type LogEntry,
+  type LogLevel,
   levelEnabled,
+  levelLabel,
   parseLogLine,
   trimLogLines,
 } from "./log.ts";
@@ -166,6 +169,46 @@ const levelEnabledCases: {
 for (const { level, minLevel, want } of levelEnabledCases) {
   test(`levelEnabled: ${level} at minimum ${minLevel}`, () => {
     assert.equal(levelEnabled(level, minLevel), want);
+  });
+}
+
+// Local time in, local time out: the cases build their Date from parts rather than an ISO string,
+// so they assert the same thing in every timezone the tests run in.
+const formatTimeCases: { name: string; at: Date; want: string }[] = [
+  {
+    name: "two digit parts are rendered as typed",
+    at: new Date(2026, 7, 18, 18, 21, 36),
+    want: "26/08/18 18:21:36",
+  },
+  {
+    name: "single digit parts are padded",
+    at: new Date(2026, 0, 2, 3, 4, 5),
+    want: "26/01/02 03:04:05",
+  },
+  {
+    name: "a year ending in a single digit keeps its leading zero",
+    at: new Date(2005, 10, 30, 23, 59, 59),
+    want: "05/11/30 23:59:59",
+  },
+];
+
+for (const { name, at, want } of formatTimeCases) {
+  test(`formatTime: ${name}`, () => {
+    assert.equal(formatTime(at.getTime()), want);
+  });
+}
+
+const levelLabelCases: { level: LogLevel; want: string }[] = [
+  { level: "debug", want: "DBG" },
+  { level: "info", want: "INF" },
+  { level: "warn", want: "WRN" },
+  { level: "error", want: "ERR" },
+];
+
+for (const { level, want } of levelLabelCases) {
+  test(`levelLabel: ${level}`, () => {
+    assert.equal(levelLabel(level), want);
+    assert.equal(want.length, 3);
   });
 }
 

--- a/src/log/log.ts
+++ b/src/log/log.ts
@@ -1,3 +1,12 @@
+// LEVEL_LABELS are the tags the log view shows, all three letters so every message starts in the
+// same column without the level needing a fixed width column of its own.
+const LEVEL_LABELS: Record<LogLevel, string> = {
+  debug: "DBG",
+  info: "INF",
+  warn: "WRN",
+  error: "ERR",
+};
+
 const LEVEL_ORDER: Record<LogLevel, number> = {
   debug: 0,
   info: 1,
@@ -129,9 +138,25 @@ export function formatLogLine(entry: LogEntry): string {
   return `${new Date(entry.time).toISOString()}\t${entry.level}\t${escapeMessage(entry.message)}`;
 }
 
+// formatTime renders a timestamp for the log view as "YY/MM/DD HH:MM:SS" in local time; every part
+// is fixed width, so rows line up and the clock, the part actually read, stays short.
+export function formatTime(time: number): string {
+  const at = new Date(time);
+  const year = pad2(at.getFullYear() % 100);
+  const date = `${year}/${pad2(at.getMonth() + 1)}/${pad2(at.getDate())}`;
+  const clock = `${pad2(at.getHours())}:${pad2(at.getMinutes())}:${pad2(at.getSeconds())}`;
+
+  return `${date} ${clock}`;
+}
+
 // levelEnabled reports whether a message at level should be logged when the minimum is minLevel.
 export function levelEnabled(level: LogLevel, minLevel: LogLevel): boolean {
   return LEVEL_ORDER[level] >= LEVEL_ORDER[minLevel];
+}
+
+// levelLabel returns the tag the log view shows for level.
+export function levelLabel(level: LogLevel): string {
+  return LEVEL_LABELS[level];
 }
 
 // parseLogLine reverses formatLogLine. A malformed line (a corrupt or truncated file) is dropped
@@ -235,4 +260,9 @@ function notify(listener: LogListener | undefined, entry: LogEntry): void {
   } catch (err) {
     console.error(`geode: log listener failed: ${err}`);
   }
+}
+
+// pad2 renders a date or clock part as two digits, so every timestamp is the same width.
+function pad2(value: number): string {
+  return String(value).padStart(2, "0");
 }

--- a/src/log/view.ts
+++ b/src/log/view.ts
@@ -1,5 +1,5 @@
 import { ItemView, type WorkspaceLeaf } from "obsidian";
-import type { LogBus, LogEntry, LogSink } from "./log.ts";
+import { formatTime, type LogBus, type LogEntry, type LogSink, levelLabel } from "./log.ts";
 import { nextRender, selectionOverlaps } from "./selection.ts";
 
 // LOG_VIEW_TYPE identifies geode's log pane to Obsidian's workspace leaf API.
@@ -24,8 +24,8 @@ function renderLogView(containerEl: HTMLElement, entries: LogEntry[]): void {
 // renderRow draws one entry into list, colour coded by level via a geode-log-row.is-<level> class.
 function renderRow(list: HTMLElement, entry: LogEntry): void {
   const row = list.createDiv({ cls: `geode-log-row is-${entry.level}` });
-  row.createSpan({ cls: "geode-log-time", text: new Date(entry.time).toLocaleString() });
-  row.createSpan({ cls: "geode-log-level", text: entry.level.toUpperCase() });
+  row.createSpan({ cls: "geode-log-time", text: formatTime(entry.time) });
+  row.createSpan({ cls: "geode-log-level", text: levelLabel(entry.level) });
   row.createSpan({ cls: "geode-log-message", text: entry.message });
 }
 

--- a/src/settings/settings.test.ts
+++ b/src/settings/settings.test.ts
@@ -547,19 +547,25 @@ for (const { name, input, want } of prefixErrorCases) {
 
 test("providerOptions: production excludes the custom provider", () => {
   assert.deepStrictEqual(providerOptions(false), {
+    minio: "MinIO",
     r2: "Cloudflare R2",
     s3: "Amazon S3",
-    minio: "MinIO",
   });
 });
 
 test("providerOptions: local development includes the custom provider", () => {
   assert.deepStrictEqual(providerOptions(true), {
+    minio: "MinIO",
     r2: "Cloudflare R2",
     s3: "Amazon S3",
-    minio: "MinIO",
     custom: "Custom",
   });
+});
+
+// The dropdown renders in insertion order, so the order itself is part of the contract.
+test("providerOptions: lists providers in the order they are offered", () => {
+  assert.deepStrictEqual(Object.keys(providerOptions(false)), ["minio", "r2", "s3"]);
+  assert.deepStrictEqual(Object.keys(providerOptions(true)), ["minio", "r2", "s3", "custom"]);
 });
 
 const settingsEqualCases: { name: string; a: GeodeSettings; b: GeodeSettings; want: boolean }[] = [

--- a/src/settings/settings.test.ts
+++ b/src/settings/settings.test.ts
@@ -13,6 +13,7 @@ import {
   hasConnectionConfig,
   isAwsRegion,
   isCurrentConnectionResult,
+  MINIO_REGION,
   normalizePrefix,
   normalizeSettings,
   prefixError,
@@ -396,6 +397,11 @@ const regionCases: { name: string; input: GeodeSettings; want: string }[] = [
     input: { ...DEFAULT_SETTINGS, provider: "custom", region: "  eu-west-2  " },
     want: "eu-west-2",
   },
+  {
+    name: "minio signs with its own region, ignoring a stale configured one",
+    input: { ...DEFAULT_SETTINGS, provider: "minio", region: "eu-west-2" },
+    want: MINIO_REGION,
+  },
 ];
 
 for (const { name, input, want } of regionCases) {
@@ -749,7 +755,6 @@ const hasConnectionConfigCases: { name: string; input: GeodeSettings; want: bool
     input: {
       ...DEFAULT_SETTINGS,
       provider: "minio",
-      region: "us-east-1",
       bucket: "b",
       accessKeyId: "a",
       secretId: "s",
@@ -757,24 +762,11 @@ const hasConnectionConfigCases: { name: string; input: GeodeSettings; want: bool
     want: false,
   },
   {
-    name: "minio missing region is incomplete",
+    name: "minio needs no region of its own",
     input: {
       ...DEFAULT_SETTINGS,
       provider: "minio",
       endpoint: "http://localhost:9000",
-      bucket: "b",
-      accessKeyId: "a",
-      secretId: "s",
-    },
-    want: false,
-  },
-  {
-    name: "minio with all fields is complete",
-    input: {
-      ...DEFAULT_SETTINGS,
-      provider: "minio",
-      endpoint: "http://localhost:9000",
-      region: "us-east-1",
       bucket: "b",
       accessKeyId: "a",
       secretId: "s",
@@ -787,20 +779,6 @@ const hasConnectionConfigCases: { name: string; input: GeodeSettings; want: bool
       ...DEFAULT_SETTINGS,
       provider: "minio",
       endpoint: "   ",
-      region: "us-east-1",
-      bucket: "b",
-      accessKeyId: "a",
-      secretId: "s",
-    },
-    want: false,
-  },
-  {
-    name: "minio with a whitespace only region is incomplete",
-    input: {
-      ...DEFAULT_SETTINGS,
-      provider: "minio",
-      endpoint: "http://localhost:9000",
-      region: "   ",
       bucket: "b",
       accessKeyId: "a",
       secretId: "s",

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -11,6 +11,10 @@ export const DEFAULT_SETTINGS: GeodeSettings = {
   secretId: "",
 };
 
+// MINIO_REGION is the region MinIO signs with out of the box; it ignores the value entirely unless
+// the server sets MINIO_REGION, so asking the user for one buys nothing.
+export const MINIO_REGION = "us-east-1";
+
 // ConnectionStatus is the current in-memory state of a Test Connection check.
 export type ConnectionStatus = "unknown" | "checking" | "ok" | "error";
 
@@ -21,6 +25,8 @@ export type GeodeSettings = {
   provider: Provider;
   accountId: string;
   endpoint: string;
+  // region is the signing region for Amazon S3 and a custom provider; R2 and MinIO supply their
+  // own, so the value is left untouched while one of those is selected.
   region: string;
   bucket: string;
   // prefix is the folder inside the bucket the vault lives under, stored exactly as typed and
@@ -115,7 +121,8 @@ export function hasConnectionConfig(settings: GeodeSettings): boolean {
     return isAwsRegion(regionFor(settings));
   }
 
-  // MinIO and a custom provider both take their endpoint as typed, with a region for signing.
+  // MinIO and a custom provider both take their endpoint as typed; only the custom one also needs
+  // a region, which regionFor supplies for MinIO.
   return normalizeEndpoint(settings.endpoint) !== "" && regionFor(settings) !== "";
 }
 
@@ -245,10 +252,14 @@ export function providerOr(v: unknown): Provider {
 }
 
 // regionFor returns the signing region for settings, trimmed at the point of use; R2 always signs
-// with "auto", so Amazon S3, MinIO, and a custom provider need one specified.
+// with "auto" and MinIO with its own default, so only Amazon S3 and a custom provider need one
+// specified. A MinIO server pinned to another region is a custom provider.
 export function regionFor(settings: GeodeSettings): string {
   if (settings.provider === "r2") {
     return "auto";
+  }
+  if (settings.provider === "minio") {
+    return MINIO_REGION;
   }
 
   return settings.region.trim();

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -225,14 +225,14 @@ export function prefixError(raw: string): string {
 export function providerOptions(localDev: boolean): Record<string, string> {
   if (localDev) {
     return {
+      minio: "MinIO",
       r2: "Cloudflare R2",
       s3: "Amazon S3",
-      minio: "MinIO",
       custom: "Custom",
     };
   }
 
-  return { r2: "Cloudflare R2", s3: "Amazon S3", minio: "MinIO" };
+  return { minio: "MinIO", r2: "Cloudflare R2", s3: "Amazon S3" };
 }
 
 // providerOr returns a known provider, defaulting unknown values to "r2".

--- a/src/settings/tab.ts
+++ b/src/settings/tab.ts
@@ -162,31 +162,33 @@ function renderActions(tab: GeodeSettingTab, containerEl: HTMLElement): void {
   tab.refreshActionsUI();
 }
 
-// renderEndpointAndRegion draws the endpoint and region fields an S3 compatible provider whose
-// endpoint is typed rather than derived needs, with copy tailored to that provider.
-function renderEndpointAndRegion(
+// renderEndpointField draws the endpoint field an S3 compatible provider whose endpoint is typed
+// rather than derived needs, with copy tailored to that provider.
+function renderEndpointField(
   tab: GeodeSettingTab,
   containerEl: HTMLElement,
-  endpointDesc: string,
-  endpointPlaceholder: string,
-  regionDesc: string,
+  desc: string,
+  placeholder: string,
 ): void {
   new Setting(containerEl)
     .setName("Endpoint")
-    .setDesc(endpointDesc)
+    .setDesc(desc)
     .addText((text) =>
       text
-        .setPlaceholder(endpointPlaceholder)
+        .setPlaceholder(placeholder)
         .setValue(tab.draft.endpoint)
         .onChange((value) => {
           tab.draft.endpoint = value;
           onFieldChanged(tab);
         }),
     );
+}
 
+// renderRegionField draws the signing region field, for the providers that can't derive one.
+function renderRegionField(tab: GeodeSettingTab, containerEl: HTMLElement, desc: string): void {
   new Setting(containerEl)
     .setName("Region")
-    .setDesc(regionDesc)
+    .setDesc(desc)
     .addText((text) =>
       text
         .setPlaceholder("us-east-1")
@@ -247,39 +249,28 @@ function renderProviderFields(tab: GeodeSettingTab, containerEl: HTMLElement): v
   }
 
   if (tab.draft.provider === "s3") {
-    new Setting(containerEl)
-      .setName("Region")
-      .setDesc("The AWS region your bucket lives in.")
-      .addText((text) =>
-        text
-          .setPlaceholder("us-east-1")
-          .setValue(tab.draft.region)
-          .onChange((value) => {
-            tab.draft.region = value;
-            onFieldChanged(tab);
-          }),
-      );
+    renderRegionField(tab, containerEl, "The AWS region your bucket lives in.");
     return;
   }
 
+  // MinIO signs with its own default region, so it asks for nothing but the endpoint.
   if (tab.draft.provider === "minio") {
-    renderEndpointAndRegion(
+    renderEndpointField(
       tab,
       containerEl,
       "Your MinIO server's S3 endpoint URL.",
       "https://minio.example.com",
-      "The region your MinIO bucket lives in.",
     );
     return;
   }
 
-  renderEndpointAndRegion(
+  renderEndpointField(
     tab,
     containerEl,
     "The S3 compatible endpoint URL for your storage.",
     "https://s3.example.com",
-    "The region your bucket lives in.",
   );
+  renderRegionField(tab, containerEl, "The region your bucket lives in.");
 }
 
 // renderSecretRow draws the secret access key control; SecretComponent can't force a new entry

--- a/src/storage/storage.itest.ts
+++ b/src/storage/storage.itest.ts
@@ -11,7 +11,6 @@ const liveSettings: GeodeSettings = {
   ...DEFAULT_SETTINGS,
   provider: "minio",
   endpoint: "http://localhost:4568",
-  region: "us-east-1",
   bucket: "geode-test",
   accessKeyId: "geodedev",
 };

--- a/src/storage/storage.test.ts
+++ b/src/storage/storage.test.ts
@@ -174,24 +174,11 @@ const missingFieldCases: {
     settings: {
       ...DEFAULT_SETTINGS,
       provider: "minio",
-      region: "us-east-1",
       bucket: "my-vault",
       accessKeyId: "AKIA123",
     },
     secretAccessKey: "shh",
     want: "Fill in endpoint first",
-  },
-  {
-    name: "missing region for minio",
-    settings: {
-      ...DEFAULT_SETTINGS,
-      provider: "minio",
-      endpoint: "http://localhost:9000",
-      bucket: "my-vault",
-      accessKeyId: "AKIA123",
-    },
-    secretAccessKey: "shh",
-    want: "Fill in region first",
   },
   {
     name: "whitespace only endpoint for minio",
@@ -199,25 +186,11 @@ const missingFieldCases: {
       ...DEFAULT_SETTINGS,
       provider: "minio",
       endpoint: "   ",
-      region: "us-east-1",
       bucket: "my-vault",
       accessKeyId: "AKIA123",
     },
     secretAccessKey: "shh",
     want: "Fill in endpoint first",
-  },
-  {
-    name: "whitespace only region for minio",
-    settings: {
-      ...DEFAULT_SETTINGS,
-      provider: "minio",
-      endpoint: "http://localhost:9000",
-      region: "   ",
-      bucket: "my-vault",
-      accessKeyId: "AKIA123",
-    },
-    secretAccessKey: "shh",
-    want: "Fill in region first",
   },
 ];
 

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -279,9 +279,9 @@ function conditionHeaders(condition: PutCondition | undefined): Record<string, s
   return { "If-Match": condition.etag };
 }
 
-// missingFieldFor returns the name of the first field testConnection needs but doesn't have, or
-// "" when everything required is present; R2 derives endpoint and region from the account ID and
-// Amazon S3 from the region, so only MinIO and a custom provider need both explicitly.
+// missingFieldFor returns the name of the first field testConnection needs but doesn't have, or ""
+// when everything required is present; only a custom provider needs both an endpoint and a region,
+// since every other provider derives at least one of them.
 function missingFieldFor(settings: GeodeSettings, secretAccessKey: string): string {
   if (bucketFor(settings) === "") {
     return "bucket";

--- a/src/sync/sync.itest.ts
+++ b/src/sync/sync.itest.ts
@@ -31,7 +31,6 @@ const liveSettings: GeodeSettings = {
   ...DEFAULT_SETTINGS,
   provider: "minio",
   endpoint: "http://localhost:4568",
-  region: "us-east-1",
   // This file owns the bucket outright, since a first sync refuses over blobs it cannot explain
   // and a shared bucket's leftovers would eventually trip that.
   bucket: "geode-sync-test",

--- a/styles.css
+++ b/styles.css
@@ -117,7 +117,7 @@
 
 .geode-log-row {
   display: flex;
-  gap: 0.75em;
+  gap: 0.6em;
   align-items: baseline;
   padding: 0.35em 0.5em;
   border-radius: var(--radius-s, 4px);
@@ -133,9 +133,9 @@
   color: var(--text-faint);
 }
 
+/* Every level tag is three letters, so a single space column keeps messages aligned. */
 .geode-log-level {
   flex-shrink: 0;
-  width: 4em;
   font-weight: 700;
 }
 


### PR DESCRIPTION
Resolves #155 

WIP

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR streamlines MinIO setup, revises log timestamps and level labels, and updates the corresponding UI, documentation, and tests.
- Makes MinIO the first provider option and defaults its signing region to us-east-1.
- Removes the MinIO region input while retaining endpoint configuration.
- Formats log rows with fixed-shape local timestamps and three-letter level labels.
- Updates storage and sync integration fixtures for regionless MinIO settings.

<h3>Confidence Score: 4/5</h3>

The MinIO region regression needs to be fixed before merging because existing non-default-region production installations can no longer authenticate.

Real sync and connection testing now ignore a MinIO configuration's persisted region and sign for us-east-1, while the production settings UI removes both the region field and access to the documented custom-provider alternative.

**Files Needing Attention:** src/settings/settings.ts, src/settings/tab.ts, styles.css

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/settings/settings.ts | Forces all MinIO requests to sign for us-east-1, breaking production configurations whose server uses another region. |
| src/settings/tab.ts | Removes the MinIO region field while production still hides the only proposed alternative, the custom provider. |
| src/storage/storage.ts | Keeps validation aligned with the new derived MinIO region, but propagates that forced region into connection testing. |
| src/log/log.ts | Adds tested local timestamp formatting and stable three-letter level labels. |
| src/log/view.ts | Uses the new timestamp and level-label helpers when rendering persisted entries. |
| styles.css | Tightens log-row spacing but makes message alignment depend on the configured monospace font having equal glyph advances. |
| docs/technical_settings.md | Documents custom provider as the route for non-default MinIO regions without noting that production users cannot select it. |

<sub>Reviews (1): Last reviewed commit: ["Update log message"](https://github.com/8thpark/geode/commit/680f57b1fd844261b291e63784178f2fdfb785b5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54274101)</sub>

> Greptile also left **2 inline comments** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Settings module](https://app.greptile.com/8thpark/-/custom-context/knowledge-base/8thpark/geode/-/docs/settings-module.md)
- Knowledge Base — [Storage module](https://app.greptile.com/8thpark/-/custom-context/knowledge-base/8thpark/geode/-/docs/storage-module.md)
- Knowledge Base — [Log module](https://app.greptile.com/8thpark/-/custom-context/knowledge-base/8thpark/geode/-/docs/log-module.md)
- Knowledge Base — [Sync flow](https://app.greptile.com/8thpark/-/custom-context/knowledge-base/8thpark/geode/-/docs/sync-flow.md)
</details>

<!-- /greptile_comment -->